### PR TITLE
Remove local scripts, harden server security, and improve UI

### DIFF
--- a/.codekin/reports/security/2026-03-08_security-audit.md
+++ b/.codekin/reports/security/2026-03-08_security-audit.md
@@ -1,0 +1,20 @@
+# Security Audit: codekin
+
+**Date**: 2026-03-08T15:51:34.064Z
+**Repository**: /home/dev/repos/codekin
+**Branch**: fix/remove-local-scripts
+**Workflow Run**: d167dc3c-d4b0-4d94-b187-4147fac71c51
+**Session**: 83a8d056-b820-42fb-a6e4-c875b414b504
+
+---
+
+Let me check a few more areas before compiling the report.Now I have all the data needed to compile the report. Let me write it.Security audit complete. Report written to `.codekin/outputs/security-audits/2026-03-08_security-audit.md`.
+
+**Key findings:**
+
+- **2 Critical**: Unauthenticated `/api/hook-notify` endpoint (session-routes.ts:249) and SSRF via Stepflow callback URL (stepflow-handler.ts:427)
+- **5 High**: Permissive CORS default `*`, auth bypass when no token configured, auth token in URL query strings, unvalidated git clone URLs, localStorage token storage
+- **5 Medium**: Missing security headers, path traversal in workflow loader, file upload auth race, unvalidated cron expressions, unvalidated webhook branch names
+- **0 Secrets found**: No hardcoded credentials or committed secret files
+
+The highest-priority fix is adding auth to `/api/hook-notify` — a one-line change that closes the only unprotected mutation endpoint.

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ dist-ssr
 
 # Generated workflow outputs
 .codekin/outputs/
-.codekin/reports/
 review logs/
 dependency-reports/
 coverage-reports/

--- a/server/config.ts
+++ b/server/config.ts
@@ -17,8 +17,8 @@ import { readFileSync, existsSync } from 'fs'
 /** Main server port (WebSocket + REST + uploads). */
 export const PORT = parseInt(process.env.PORT || '32352', 10)
 
-/** CORS allowed origin. */
-export const CORS_ORIGIN = process.env.CORS_ORIGIN || '*'
+/** CORS allowed origin. Defaults to localhost dev server; set explicitly for production. */
+export const CORS_ORIGIN = process.env.CORS_ORIGIN || 'http://localhost:5173'
 
 // ---------------------------------------------------------------------------
 // Authentication

--- a/server/stepflow-handler.ts
+++ b/server/stepflow-handler.ts
@@ -424,6 +424,22 @@ export class StepflowHandler {
       headers['X-Stepflow-Signature'] = sig
     }
 
+    // SSRF protection: validate callback URL against allowlist
+    const parsedUrl = new URL(callbackUrl)
+    if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
+      throw new Error(`Callback URL protocol ${parsedUrl.protocol} not allowed`)
+    }
+    if (this.config.allowedCallbackHosts.length > 0 &&
+        !this.config.allowedCallbackHosts.includes(parsedUrl.hostname)) {
+      throw new Error(`Callback host ${parsedUrl.hostname} not in allowlist`)
+    }
+    // Block private/link-local IP ranges
+    const ip = parsedUrl.hostname
+    if (/^(127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|0\.)/.test(ip) ||
+        ip === 'localhost' || ip === '[::1]') {
+      throw new Error(`Callback to private/link-local address ${ip} is blocked`)
+    }
+
     const response = await fetch(callbackUrl, {
       method: 'POST',
       headers,
@@ -525,5 +541,8 @@ export function loadStepflowConfig(): StepflowConfig {
     if (!isNaN(n) && n > 0) maxConcurrentSessions = n
   }
 
-  return { enabled, secret, maxConcurrentSessions }
+  const allowedCallbackHosts = (process.env.STEPFLOW_CALLBACK_HOSTS || '')
+    .split(',').map(s => s.trim()).filter(Boolean)
+
+  return { enabled, secret, maxConcurrentSessions, allowedCallbackHosts }
 }

--- a/server/stepflow-types.ts
+++ b/server/stepflow-types.ts
@@ -303,4 +303,6 @@ export interface StepflowConfig {
   secret: string
   /** Maximum number of simultaneous Stepflow-sourced Claude sessions. */
   maxConcurrentSessions: number
+  /** Allowlist of hostnames permitted for callback URLs. Empty = allow all (unsafe). */
+  allowedCallbackHosts: string[]
 }

--- a/server/upload-routes.ts
+++ b/server/upload-routes.ts
@@ -157,12 +157,14 @@ export function createUploadRouter(
   const upload = multer({ storage, limits: { fileSize: 10 * 1024 * 1024 } })
 
   // --- File upload ---
-  router.post('/api/upload', upload.single('file'), (req, res) => {
+  router.post('/api/upload', (req, res, next) => {
     const token = extractToken(req)
     if (!verifyToken(token)) {
       res.status(401).json({ error: 'Invalid token' })
       return
     }
+    next()
+  }, upload.single('file'), (req, res) => {
     if (!req.file) {
       res.status(400).json({ error: 'No file uploaded' })
       return

--- a/server/webhook-workspace.ts
+++ b/server/webhook-workspace.ts
@@ -89,6 +89,16 @@ export async function createWorkspace(
     timeout: GIT_TIMEOUT_MS,
   })
 
+  // Validate cloneUrl — only allow HTTPS GitHub URLs
+  if (!/^https:\/\/github\.com\/[\w.-]+\/[\w.-]+(?:\.git)?$/.test(cloneUrl)) {
+    throw new Error(`Invalid clone URL: ${cloneUrl}`)
+  }
+
+  // Validate branch name — only safe characters
+  if (!/^[a-zA-Z0-9/_.-]+$/.test(branch)) {
+    throw new Error(`Invalid branch name: ${branch}`)
+  }
+
   // Set up remote to point to the real repo for pushes
   await execFileAsync('git', ['remote', 'set-url', 'origin', cloneUrl], {
     cwd: workspacePath,

--- a/server/workflow-loader.test.ts
+++ b/server/workflow-loader.test.ts
@@ -27,6 +27,11 @@ vi.mock('fs', async (importOriginal) => {
   }
 })
 
+// Mock config to set REPOS_ROOT to /tmp so test paths pass validation
+vi.mock('./config.js', () => ({
+  REPOS_ROOT: '/tmp',
+}))
+
 // Mock better-sqlite3 (needed by workflow-engine import)
 vi.mock('better-sqlite3', () => {
   class MockDatabase {
@@ -208,12 +213,12 @@ Some prompt.
 
       it('throws when repoPath does not exist', async () => {
         mockExistsSync.mockImplementation((p: string) => {
-          if (String(p) === '/nonexistent') return false
+          if (String(p) === '/tmp/nonexistent') return false
           return true
         })
 
         const handler = registeredDef.steps[0].handler
-        await expect(handler({ repoPath: '/nonexistent' }, { runId: 'r1', run: {}, abortSignal: new AbortController().signal }))
+        await expect(handler({ repoPath: '/tmp/nonexistent' }, { runId: 'r1', run: {}, abortSignal: new AbortController().signal }))
           .rejects.toThrow('does not exist')
       })
 

--- a/server/workflow-loader.ts
+++ b/server/workflow-loader.ts
@@ -30,7 +30,8 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'fs'
 import { execSync, execFileSync } from 'child_process'
-import { dirname, join } from 'path'
+import { dirname, join, resolve } from 'path'
+import { REPOS_ROOT } from './config.js'
 import { fileURLToPath } from 'url'
 import type { WorkflowEngine, WorkflowRun } from './workflow-engine.js'
 import type { SessionManager } from './session-manager.js'
@@ -197,7 +198,11 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
         handler: async (input) => {
           const repoPath = input.repoPath as string
           if (!repoPath) throw new Error('Missing repoPath in workflow input')
-          if (!existsSync(repoPath)) throw new Error(`Repository path does not exist: ${repoPath}`)
+          const resolvedPath = resolve(repoPath)
+          if (!resolvedPath.startsWith(REPOS_ROOT)) {
+            throw new Error(`Repository path ${resolvedPath} is outside REPOS_ROOT`)
+          }
+          if (!existsSync(resolvedPath)) throw new Error(`Repository path does not exist: ${resolvedPath}`)
 
           try {
             const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: repoPath, timeout: 5000 }).toString().trim()

--- a/server/workflow-routes.ts
+++ b/server/workflow-routes.ts
@@ -21,6 +21,33 @@ import type { SessionManager } from './session-manager.js'
 type VerifyFn = (token: string | undefined) => boolean
 type ExtractFn = (req: Request) => string | undefined
 
+/** Validate a 5-field cron expression. Returns true if the format is valid. */
+function isValidCron(expr: string): boolean {
+  const parts = expr.trim().split(/\s+/)
+  if (parts.length !== 5) return false
+  const ranges = [
+    [0, 59],  // minute
+    [0, 23],  // hour
+    [1, 31],  // day of month
+    [1, 12],  // month
+    [0, 6],   // day of week
+  ]
+  return parts.every((part, i) => {
+    const [min, max] = ranges[i]
+    return part.split(',').every(segment => {
+      const stepMatch = segment.match(/^(.+)\/(\d+)$/)
+      const range = stepMatch ? stepMatch[1] : segment
+      if (range === '*') return true
+      if (range.includes('-')) {
+        const [a, b] = range.split('-').map(Number)
+        return !isNaN(a) && !isNaN(b) && a >= min && b <= max && a <= b
+      }
+      const n = parseInt(range, 10)
+      return !isNaN(n) && n >= min && n <= max
+    })
+  })
+}
+
 /**
  * Sync cron schedules with the current workflow config.
  * When `sessions` is provided, also registers any standalone repo workflows.
@@ -159,6 +186,9 @@ export function createWorkflowRouter(verifyToken: VerifyFn, extractToken: Extrac
     const { id, kind, cronExpression, input, enabled } = req.body
     if (!id || !kind || !cronExpression) {
       return res.status(400).json({ error: 'Missing id, kind, or cronExpression' })
+    }
+    if (!isValidCron(cronExpression)) {
+      return res.status(400).json({ error: 'Invalid cron expression' })
     }
 
     const schedule = engine.upsertSchedule({

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -57,6 +57,9 @@ for (let i = 0; i < args.length; i++) {
 
 if (authToken) {
   console.log('Auth token configured')
+} else {
+  console.warn('⚠️  WARNING: No auth token configured. All endpoints are unauthenticated!')
+  console.warn('   Set AUTH_TOKEN or AUTH_TOKEN_FILE to secure the server.')
 }
 
 /** Check if a token matches the configured auth token (passes if no auth configured). */
@@ -206,7 +209,16 @@ app.post(
 // JSON body parser for all other routes
 app.use(express.json())
 
-// CORS — restrict to configured origin (default: allow all for local dev)
+// Security headers
+app.use((_req, res, next) => {
+  res.header('X-Content-Type-Options', 'nosniff')
+  res.header('X-Frame-Options', 'SAMEORIGIN')
+  res.header('X-XSS-Protection', '1; mode=block')
+  res.header('Referrer-Policy', 'strict-origin-when-cross-origin')
+  next()
+})
+
+// CORS — restrict to configured origin (default: localhost dev server)
 app.use((_req, res, next) => {
   res.header('Access-Control-Allow-Origin', CORS_ORIGIN)
   res.header('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS')


### PR DESCRIPTION
## Summary
- Remove local deploy/ops scripts (`deploy.sh`, `scan-repos.mjs`, `setup-global-hooks.sh`) from the repo
- Add security hardening based on automated audit:
  - Add auth to unauthenticated `/api/hook-notify` endpoint (Critical)
  - Add SSRF protection to Stepflow callback URLs with host allowlist and private IP blocking (Critical)
  - Change default CORS from `*` to `http://localhost:5173` (High)
  - Add startup warning when no auth token is configured (High)
  - Validate `cloneUrl` (HTTPS GitHub only) and `branch` names in webhook workspace (High)
  - Move file upload auth check before multer processing (Medium)
  - Add security headers middleware (X-Content-Type-Options, X-Frame-Options, etc.) (Medium)
  - Validate `repoPath` stays within `REPOS_ROOT` in workflow loader (Medium)
  - Validate cron expressions in workflow schedule routes (Medium)
- Extract shared `RepoList` component with search filtering
- Wire up dynamic workflow kinds with API endpoint and frontend fetching
- Add comprehensive test coverage for workflow engine, loader, and config

## Test plan
- [x] All 795 tests passing
- [x] Build succeeds (`tsc -b && vite build`)
- [x] Lint passes (0 errors)
- [ ] Verify CORS works correctly in dev (Vite on localhost:5173)
- [ ] Verify Stepflow callbacks work with `STEPFLOW_CALLBACK_HOSTS` set
- [ ] Test file upload auth rejection before disk write

🤖 Generated with [Claude Code](https://claude.com/claude-code)