### PR TITLE
Redesign workflow view with unified cards and wizard

### DIFF
--- a/src/components/AddWorkflowModal.tsx
+++ b/src/components/AddWorkflowModal.tsx
@@ -1,18 +1,25 @@
 /**
- * Modal dialog for registering a new scheduled workflow.
+ * Multi-step wizard for creating a new scheduled workflow.
+ *
+ * Steps:
+ *   1. Select repository
+ *   2. Select workflow type
+ *   3. Configure schedule and optional focus areas
  */
 
 import { useState, useEffect } from 'react'
-import { IconX, IconLoader2 } from '@tabler/icons-react'
+import { IconX, IconLoader2, IconArrowLeft, IconArrowRight, IconCheck } from '@tabler/icons-react'
 import { useRepos } from '../hooks/useRepos'
 import { listKinds } from '../lib/workflowApi'
 import type { ReviewRepoConfig, WorkflowKindInfo } from '../lib/workflowApi'
 import {
   WORKFLOW_KINDS, DAY_PATTERNS,
-  buildCron, formatHour, describeCron, slugify,
+  buildCron, formatHour, describeCron, slugify, kindCategory,
 } from '../lib/workflowHelpers'
 import { CategoryBadge } from './WorkflowBadges'
 import { RepoList } from './RepoList'
+
+type Step = 1 | 2 | 3
 
 interface FormState {
   kind: string
@@ -29,11 +36,263 @@ interface Props {
   onAdd: (repo: ReviewRepoConfig) => Promise<void>
 }
 
-export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
-  const { groups, loading: reposLoading, error: reposError } = useRepos(token)
+// ---------------------------------------------------------------------------
+// Step indicator
+// ---------------------------------------------------------------------------
+
+function StepIndicator({ current }: { current: Step }) {
+  const steps = [
+    { num: 1 as const, label: 'Repository' },
+    { num: 2 as const, label: 'Workflow' },
+    { num: 3 as const, label: 'Schedule' },
+  ]
+
+  return (
+    <div className="flex items-center gap-1 mb-5">
+      {steps.map((s, i) => (
+        <div key={s.num} className="flex items-center gap-1 flex-1">
+          <div className="flex items-center gap-2 flex-1">
+            <span className={`w-6 h-6 rounded-full flex items-center justify-center text-[12px] font-semibold shrink-0 ${
+              s.num < current
+                ? 'bg-success-7 text-white'
+                : s.num === current
+                  ? 'bg-accent-7 text-white'
+                  : 'bg-neutral-9 text-neutral-5'
+            }`}>
+              {s.num < current ? <IconCheck size={12} stroke={3} /> : s.num}
+            </span>
+            <span className={`text-[13px] font-medium ${
+              s.num === current ? 'text-neutral-1' : 'text-neutral-5'
+            }`}>
+              {s.label}
+            </span>
+          </div>
+          {i < steps.length - 1 && (
+            <div className={`h-px flex-1 mx-1 ${s.num < current ? 'bg-success-7' : 'bg-neutral-8'}`} />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 1: Repository selection
+// ---------------------------------------------------------------------------
+
+function StepRepo({
+  token,
+  selectedRepoId,
+  onSelect,
+}: {
+  token: string
+  selectedRepoId: string
+  onSelect: (repoId: string, repoPath: string, repoName: string) => void
+}) {
+  const { groups, loading, error } = useRepos(token)
   const allRepos = groups.flatMap(g => g.repos)
 
-  const [selectedRepoId, setSelectedRepoId] = useState<string>('')
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-8 justify-center text-[13px] text-neutral-5">
+        <IconLoader2 size={16} stroke={2} className="animate-spin" />
+        Loading repositories…
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-md bg-error-10/50 px-3 py-2 text-[13px] text-error-4">
+        Failed to load repos: {error}
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <p className="text-[13px] text-neutral-4 mb-3">
+        Choose which repository this workflow will run against.
+      </p>
+      <RepoList
+        groups={groups}
+        selectedId={selectedRepoId}
+        onSelect={repo => {
+          const r = allRepos.find(x => x.id === repo.id)
+          if (r) onSelect(r.id, r.path, r.name)
+        }}
+        maxHeight="320px"
+      />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 2: Workflow type selection
+// ---------------------------------------------------------------------------
+
+function StepKind({
+  token,
+  repoPath,
+  selectedKind,
+  onSelect,
+}: {
+  token: string
+  repoPath: string
+  selectedKind: string
+  onSelect: (kind: string) => void
+}) {
+  const [kinds, setKinds] = useState<WorkflowKindInfo[]>(
+    WORKFLOW_KINDS.map(k => ({ kind: k.value, name: k.label, source: 'builtin' as const }))
+  )
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    listKinds(token, repoPath || undefined)
+      .then(fetched => {
+        if (cancelled) return
+        if (fetched.length > 0) setKinds(fetched)
+      })
+      .catch(() => {})
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [token, repoPath])
+
+  // Group by category
+  const grouped = new Map<string, WorkflowKindInfo[]>()
+  for (const k of kinds) {
+    const cat = kindCategory(k.kind)
+    if (!grouped.has(cat)) grouped.set(cat, [])
+    grouped.get(cat)!.push(k)
+  }
+
+  return (
+    <div>
+      <p className="text-[13px] text-neutral-4 mb-3">
+        Select the type of automated workflow to run.
+      </p>
+
+      {loading && (
+        <div className="flex items-center gap-2 py-2 text-[13px] text-neutral-5 mb-2">
+          <IconLoader2 size={14} stroke={2} className="animate-spin" />
+          Checking for repo-specific workflows…
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {Array.from(grouped.entries()).map(([category, items]) => (
+          <div key={category}>
+            <div className="flex items-center gap-2 mb-2">
+              <CategoryBadge kind={items[0].kind} />
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              {items.map(k => (
+                <button
+                  key={k.kind}
+                  type="button"
+                  onClick={() => onSelect(k.kind)}
+                  className={`rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                    selectedKind === k.kind
+                      ? 'border-accent-6 bg-accent-9/30 ring-1 ring-accent-6/30'
+                      : 'border-neutral-7 bg-neutral-10 hover:border-neutral-6'
+                  }`}
+                >
+                  <span className={`block text-[14px] font-medium ${
+                    selectedKind === k.kind ? 'text-accent-2' : 'text-neutral-2'
+                  }`}>
+                    {k.name}
+                  </span>
+                  {k.source === 'repo' && (
+                    <span className="block text-[11px] text-neutral-5 mt-0.5">repo-specific</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 3: Schedule + custom prompt
+// ---------------------------------------------------------------------------
+
+function StepSchedule({
+  form,
+  onChange,
+}: {
+  form: FormState
+  onChange: (patch: Partial<FormState>) => void
+}) {
+  return (
+    <div className="space-y-5">
+      <div>
+        <p className="text-[13px] text-neutral-4 mb-3">
+          Choose when this workflow should run automatically.
+        </p>
+
+        {/* Time picker */}
+        <label className="block text-[13px] font-medium text-neutral-3 mb-2">Time</label>
+        <select
+          value={form.cronHour}
+          onChange={e => onChange({ cronHour: parseInt(e.target.value) })}
+          className="rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[15px] text-neutral-1 focus:border-accent-6 focus:outline-none w-full"
+        >
+          {Array.from({ length: 24 }, (_, h) => (
+            <option key={h} value={h}>{formatHour(h)}</option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <label className="block text-[13px] font-medium text-neutral-3 mb-2">Frequency</label>
+        <div className="flex flex-wrap gap-1.5">
+          {DAY_PATTERNS.map(p => (
+            <button
+              key={p.dow}
+              type="button"
+              onClick={() => onChange({ cronDow: p.dow })}
+              className={`rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors ${
+                form.cronDow === p.dow
+                  ? 'border-accent-6 bg-accent-9/40 text-accent-2'
+                  : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
+              }`}
+            >
+              {p.label}
+            </button>
+          ))}
+        </div>
+        <div className="mt-2 text-[13px] text-neutral-5">
+          {describeCron(buildCron(form.cronHour, form.cronDow))}
+        </div>
+      </div>
+
+      <div>
+        <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">
+          Focus areas <span className="text-neutral-5 font-normal">(optional)</span>
+        </label>
+        <textarea
+          value={form.customPrompt}
+          onChange={e => onChange({ customPrompt: e.target.value })}
+          rows={3}
+          placeholder="e.g. Focus on the auth module and payment flows"
+          className="w-full rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[15px] text-neutral-1 placeholder-neutral-5 focus:border-accent-6 focus:outline-none resize-none"
+        />
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// AddWorkflowModal (wizard)
+// ---------------------------------------------------------------------------
+
+export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
+  const [step, setStep] = useState<Step>(1)
+  const [selectedRepoId, setSelectedRepoId] = useState('')
   const [form, setForm] = useState<FormState>({
     kind: '',
     repoPath: '',
@@ -45,45 +304,33 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
 
-  // Dynamic kinds: built-in fallback + fetched from server (repo-aware)
-  const [kinds, setKinds] = useState<WorkflowKindInfo[]>(
-    WORKFLOW_KINDS.map(k => ({ kind: k.value, name: k.label, source: 'builtin' as const }))
-  )
-  const [kindsLoading, setKindsLoading] = useState(false)
+  const updateForm = (patch: Partial<FormState>) => setForm(f => ({ ...f, ...patch }))
 
-  // Fetch kinds when repo selection changes (includes repo-specific workflows)
-  useEffect(() => {
-    let cancelled = false
-    setKindsLoading(true)
-    listKinds(token, form.repoPath || undefined)
-      .then(fetched => {
-        if (cancelled) return
-        if (fetched.length > 0) {
-          setKinds(fetched)
-          // Auto-select first kind if current selection is not in the new list
-          if (!fetched.some(k => k.kind === form.kind)) {
-            setForm(f => ({ ...f, kind: fetched[0].kind }))
-          }
-        }
-      })
-      .catch(() => { /* keep fallback */ })
-      .finally(() => { if (!cancelled) setKindsLoading(false) })
-    return () => { cancelled = true }
-  }, [token, form.repoPath])
-
-  const handleRepoSelect = (repoId: string) => {
-    setSelectedRepoId(repoId)
-    const repo = allRepos.find(r => r.id === repoId)
-    if (repo) {
-      setForm(f => ({ ...f, repoPath: repo.path, repoName: repo.name }))
-    }
+  const canNext = (): boolean => {
+    if (step === 1) return !!form.repoPath
+    if (step === 2) return !!form.kind
+    return true
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!form.repoPath.trim()) { setFormError('Please select a repository'); return }
-    if (!form.kind) { setFormError('Please select a workflow'); return }
+  const handleNext = () => {
+    setFormError(null)
+    if (step === 1 && !form.repoPath) {
+      setFormError('Please select a repository')
+      return
+    }
+    if (step === 2 && !form.kind) {
+      setFormError('Please select a workflow')
+      return
+    }
+    if (step < 3) setStep((step + 1) as Step)
+  }
 
+  const handleBack = () => {
+    setFormError(null)
+    if (step > 1) setStep((step - 1) as Step)
+  }
+
+  const handleSubmit = async () => {
     setSaving(true)
     setFormError(null)
     try {
@@ -108,139 +355,109 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
       <div
-        className="w-[480px] max-h-[90vh] overflow-y-auto rounded-xl border border-neutral-7 bg-neutral-11 p-6 shadow-2xl"
+        className="w-[520px] max-h-[90vh] overflow-y-auto rounded-xl border border-neutral-7 bg-neutral-11 p-6 shadow-2xl"
         onClick={e => e.stopPropagation()}
       >
-        <div className="flex items-center justify-between mb-5">
-          <h2 className="text-[17px] font-semibold text-neutral-1">Add Workflow</h2>
+        {/* Header */}
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-[17px] font-semibold text-neutral-1">New Workflow</h2>
           <button onClick={onClose} className="rounded p-1 text-neutral-4 hover:text-neutral-1 hover:bg-neutral-9">
             <IconX size={16} stroke={2} />
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Repo selector */}
-          <div>
-            <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">Repository</label>
-            {reposLoading ? (
-              <div className="flex items-center gap-2 py-2 text-[13px] text-neutral-5">
-                <IconLoader2 size={14} stroke={2} className="animate-spin" />
-                Loading repos…
-              </div>
-            ) : reposError ? (
-              <div className="rounded-md bg-error-10/50 px-3 py-2 text-[13px] text-error-4">
-                Failed to load repos: {reposError}
-              </div>
-            ) : (
-              <RepoList
-                groups={groups}
-                selectedId={selectedRepoId}
-                onSelect={repo => handleRepoSelect(repo.id)}
-                maxHeight="180px"
-              />
-            )}
-          </div>
+        {/* Step indicator */}
+        <StepIndicator current={step} />
 
-          {/* Workflow kind */}
-          <div>
-            <div className="flex items-center justify-between mb-1.5">
-              <label className="block text-[13px] font-medium text-neutral-3">Workflow</label>
-              <div className="flex items-center gap-2">
-                {kindsLoading && <IconLoader2 size={12} stroke={2} className="animate-spin text-neutral-5" />}
-                {form.kind && <CategoryBadge kind={form.kind} />}
-              </div>
-            </div>
-            <div className="grid grid-cols-3 gap-2">
-              {kinds.map(k => (
-                <button
-                  key={k.kind}
-                  type="button"
-                  onClick={() => setForm(f => ({ ...f, kind: k.kind }))}
-                  className={`rounded-md border py-2 text-[13px] font-medium transition-colors
-                    ${form.kind === k.kind
-                      ? 'border-accent-6 bg-accent-9/40 text-accent-2'
-                      : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
-                    }`}
-                >
-                  {k.name}
-                  {k.source === 'repo' && (
-                    <span className="block text-[10px] text-neutral-5 font-normal mt-0.5">repo</span>
-                  )}
-                </button>
-              ))}
-            </div>
-          </div>
-
-          {/* Schedule */}
-          <div>
-            <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">Schedule</label>
-            <div className="flex gap-2 mb-2">
-              <select
-                value={form.cronHour}
-                onChange={e => setForm(f => ({ ...f, cronHour: parseInt(e.target.value) }))}
-                className="rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[15px] text-neutral-1 focus:border-accent-6 focus:outline-none"
-              >
-                {Array.from({ length: 24 }, (_, h) => (
-                  <option key={h} value={h}>{formatHour(h)}</option>
-                ))}
-              </select>
-              <div className="flex flex-wrap gap-1.5 flex-1">
-                {DAY_PATTERNS.map(p => (
-                  <button
-                    key={p.dow}
-                    type="button"
-                    onClick={() => setForm(f => ({ ...f, cronDow: p.dow }))}
-                    className={`rounded-md border px-2.5 py-1.5 text-[13px] transition-colors
-                      ${form.cronDow === p.dow
-                        ? 'border-accent-6 bg-accent-9/40 text-accent-2'
-                        : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
-                      }`}
-                  >
-                    {p.label}
-                  </button>
-                ))}
-              </div>
-            </div>
-            <div className="text-[13px] text-neutral-5">
-              {describeCron(buildCron(form.cronHour, form.cronDow))}
-            </div>
-          </div>
-
-          {/* Custom prompt (optional) */}
-          <div>
-            <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">
-              Additional focus areas <span className="text-neutral-5 font-normal">(optional)</span>
-            </label>
-            <textarea
-              value={form.customPrompt}
-              onChange={e => setForm(f => ({ ...f, customPrompt: e.target.value }))}
-              rows={3}
-              placeholder="e.g. Focus on the auth module and payment flows"
-              className="w-full rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[15px] text-neutral-1 placeholder-neutral-5 focus:border-accent-6 focus:outline-none resize-none"
+        {/* Step content */}
+        <div className="min-h-[200px]">
+          {step === 1 && (
+            <StepRepo
+              token={token}
+              selectedRepoId={selectedRepoId}
+              onSelect={(id, path, name) => {
+                setSelectedRepoId(id)
+                updateForm({ repoPath: path, repoName: name })
+              }}
             />
-          </div>
-
-          {formError && (
-            <div className="rounded-md bg-error-10/50 px-3 py-2 text-[13px] text-error-4">{formError}</div>
           )}
 
-          <div className="flex gap-2 pt-1">
+          {step === 2 && (
+            <StepKind
+              token={token}
+              repoPath={form.repoPath}
+              selectedKind={form.kind}
+              onSelect={kind => updateForm({ kind })}
+            />
+          )}
+
+          {step === 3 && (
+            <StepSchedule
+              form={form}
+              onChange={updateForm}
+            />
+          )}
+        </div>
+
+        {/* Error */}
+        {formError && (
+          <div className="rounded-md bg-error-10/50 px-3 py-2 text-[13px] text-error-4 mt-3">{formError}</div>
+        )}
+
+        {/* Navigation */}
+        <div className="flex gap-2 mt-5 pt-4 border-t border-neutral-8/50">
+          {step > 1 ? (
+            <button
+              type="button"
+              onClick={handleBack}
+              className="flex items-center gap-1.5 rounded-md border border-neutral-7 bg-neutral-10 px-4 py-2 text-[14px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
+            >
+              <IconArrowLeft size={14} stroke={2} />
+              Back
+            </button>
+          ) : (
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 rounded-md border border-neutral-7 bg-neutral-10 py-2 text-[15px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
+              className="rounded-md border border-neutral-7 bg-neutral-10 px-4 py-2 text-[14px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
             >
               Cancel
             </button>
+          )}
+
+          <div className="flex-1" />
+
+          {step < 3 ? (
             <button
-              type="submit"
-              disabled={saving}
-              className="flex-1 rounded-md bg-accent-7 py-2 text-[15px] font-medium text-white hover:bg-accent-6 disabled:opacity-50 transition-colors"
+              type="button"
+              onClick={handleNext}
+              disabled={!canNext()}
+              className="flex items-center gap-1.5 rounded-md bg-accent-7 px-4 py-2 text-[14px] font-medium text-white hover:bg-accent-6 disabled:opacity-40 transition-colors"
             >
-              {saving ? 'Adding…' : 'Add Workflow'}
+              Next
+              <IconArrowRight size={14} stroke={2} />
             </button>
-          </div>
-        </form>
+          ) : (
+            <button
+              type="button"
+              onClick={handleSubmit}
+              disabled={saving}
+              className="flex items-center gap-1.5 rounded-md bg-accent-7 px-4 py-2 text-[14px] font-medium text-white hover:bg-accent-6 disabled:opacity-50 transition-colors"
+            >
+              {saving ? (
+                <>
+                  <IconLoader2 size={14} stroke={2} className="animate-spin" />
+                  Creating…
+                </>
+              ) : (
+                <>
+                  <IconCheck size={14} stroke={2} />
+                  Create Workflow
+                </>
+              )}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -1,25 +1,26 @@
 /**
  * Modal dialog for editing an existing scheduled workflow.
+ * Focused on editable fields only — schedule, workflow kind, and custom prompt.
  */
 
 import { useState } from 'react'
-import { IconX, IconClock } from '@tabler/icons-react'
-import type { CronSchedule, ReviewRepoConfig, WorkflowRun } from '../lib/workflowApi'
+import { IconX, IconLoader2 } from '@tabler/icons-react'
+import type { ReviewRepoConfig } from '../lib/workflowApi'
 import {
   WORKFLOW_KINDS, DAY_PATTERNS,
-  buildCron, parseCron, formatHour, describeCron, formatTime, formatDuration, kindLabel,
+  buildCron, parseCron, formatHour, describeCron, kindLabel,
 } from '../lib/workflowHelpers'
-import { CategoryBadge, StatusBadge } from './WorkflowBadges'
+import { CategoryBadge } from './WorkflowBadges'
 
 interface Props {
   repo: ReviewRepoConfig
-  schedules: CronSchedule[]
-  recentRuns: WorkflowRun[]
+  schedules?: unknown[]
+  recentRuns?: unknown[]
   onClose: () => void
   onSave: (id: string, patch: Partial<ReviewRepoConfig>) => Promise<void>
 }
 
-export function EditWorkflowModal({ repo, schedules, recentRuns, onClose, onSave }: Props) {
+export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
   const parsed = parseCron(repo.cronExpression)
   const [form, setForm] = useState({
     kind: repo.kind ?? 'coverage.daily',
@@ -48,42 +49,53 @@ export function EditWorkflowModal({ repo, schedules, recentRuns, onClose, onSave
     }
   }
 
+  const repoShortName = repo.repoPath.split('/').pop() || repo.name
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
       <div
         className="w-[480px] max-h-[90vh] overflow-y-auto rounded-xl border border-neutral-7 bg-neutral-11 p-6 shadow-2xl"
         onClick={e => e.stopPropagation()}
       >
+        {/* Header */}
         <div className="flex items-center justify-between mb-5">
           <div>
             <h2 className="text-[17px] font-semibold text-neutral-1">Edit Workflow</h2>
-            <p className="text-[13px] text-neutral-4 mt-0.5">{repo.repoPath.split('/').pop() || repo.name}</p>
+            <div className="flex items-center gap-2 mt-1">
+              <span className="text-[13px] text-neutral-4">{repoShortName}</span>
+              <span className="text-neutral-7">·</span>
+              <span className="text-[13px] text-neutral-4">{kindLabel(repo.kind ?? '')}</span>
+            </div>
           </div>
           <button onClick={onClose} className="rounded p-1 text-neutral-4 hover:text-neutral-1 hover:bg-neutral-9">
             <IconX size={16} stroke={2} />
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
+        <form onSubmit={handleSubmit} className="space-y-5">
           {/* Workflow kind */}
           <div>
-            <div className="flex items-center justify-between mb-1.5">
-              <label className="block text-[13px] font-medium text-neutral-3">Workflow</label>
+            <div className="flex items-center justify-between mb-2">
+              <label className="text-[13px] font-medium text-neutral-3">Workflow type</label>
               <CategoryBadge kind={form.kind} />
             </div>
-            <div className="grid grid-cols-3 gap-2">
+            <div className="grid grid-cols-2 gap-2">
               {WORKFLOW_KINDS.map(k => (
                 <button
                   key={k.value}
                   type="button"
                   onClick={() => setForm(f => ({ ...f, kind: k.value }))}
-                  className={`rounded-md border py-2 text-[13px] font-medium transition-colors
-                    ${form.kind === k.value
-                      ? 'border-accent-6 bg-accent-9/40 text-accent-2'
-                      : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
-                    }`}
+                  className={`rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                    form.kind === k.value
+                      ? 'border-accent-6 bg-accent-9/30 ring-1 ring-accent-6/30'
+                      : 'border-neutral-7 bg-neutral-10 hover:border-neutral-6'
+                  }`}
                 >
-                  {k.label}
+                  <span className={`block text-[14px] font-medium ${
+                    form.kind === k.value ? 'text-accent-2' : 'text-neutral-2'
+                  }`}>
+                    {k.label}
+                  </span>
                 </button>
               ))}
             </div>
@@ -91,35 +103,33 @@ export function EditWorkflowModal({ repo, schedules, recentRuns, onClose, onSave
 
           {/* Schedule */}
           <div>
-            <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">Schedule</label>
-            <div className="flex gap-2 mb-2">
-              <select
-                value={form.cronHour}
-                onChange={e => setForm(f => ({ ...f, cronHour: parseInt(e.target.value) }))}
-                className="rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[15px] text-neutral-1 focus:border-accent-6 focus:outline-none"
-              >
-                {Array.from({ length: 24 }, (_, h) => (
-                  <option key={h} value={h}>{formatHour(h)}</option>
-                ))}
-              </select>
-              <div className="flex flex-wrap gap-1.5 flex-1">
-                {DAY_PATTERNS.map(p => (
-                  <button
-                    key={p.dow}
-                    type="button"
-                    onClick={() => setForm(f => ({ ...f, cronDow: p.dow }))}
-                    className={`rounded-md border px-2.5 py-1.5 text-[13px] transition-colors
-                      ${form.cronDow === p.dow
-                        ? 'border-accent-6 bg-accent-9/40 text-accent-2'
-                        : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
-                      }`}
-                  >
-                    {p.label}
-                  </button>
-                ))}
-              </div>
+            <label className="block text-[13px] font-medium text-neutral-3 mb-2">Schedule</label>
+            <select
+              value={form.cronHour}
+              onChange={e => setForm(f => ({ ...f, cronHour: parseInt(e.target.value) }))}
+              className="rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[15px] text-neutral-1 focus:border-accent-6 focus:outline-none w-full mb-3"
+            >
+              {Array.from({ length: 24 }, (_, h) => (
+                <option key={h} value={h}>{formatHour(h)}</option>
+              ))}
+            </select>
+            <div className="flex flex-wrap gap-1.5">
+              {DAY_PATTERNS.map(p => (
+                <button
+                  key={p.dow}
+                  type="button"
+                  onClick={() => setForm(f => ({ ...f, cronDow: p.dow }))}
+                  className={`rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors ${
+                    form.cronDow === p.dow
+                      ? 'border-accent-6 bg-accent-9/40 text-accent-2'
+                      : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
+                  }`}
+                >
+                  {p.label}
+                </button>
+              ))}
             </div>
-            <div className="text-[13px] text-neutral-5">
+            <div className="mt-2 text-[13px] text-neutral-5">
               {describeCron(buildCron(form.cronHour, form.cronDow))}
             </div>
           </div>
@@ -127,7 +137,7 @@ export function EditWorkflowModal({ repo, schedules, recentRuns, onClose, onSave
           {/* Custom prompt */}
           <div>
             <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">
-              Additional focus areas <span className="text-neutral-5 font-normal">(optional)</span>
+              Focus areas <span className="text-neutral-5 font-normal">(optional)</span>
             </label>
             <textarea
               value={form.customPrompt}
@@ -138,64 +148,31 @@ export function EditWorkflowModal({ repo, schedules, recentRuns, onClose, onSave
             />
           </div>
 
-          {/* Scheduled entries (read-only info) */}
-          {schedules.length > 0 && (
-            <div>
-              <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">Scheduled entries</label>
-              <div className="space-y-1">
-                {schedules.map(s => (
-                  <div key={s.id} className="flex items-center justify-between rounded-md border border-neutral-8/50 bg-neutral-10/60 px-2.5 py-1.5">
-                    <span className="text-[13px] text-neutral-3 font-mono">{describeCron(s.cronExpression)}</span>
-                    {!s.enabled && (
-                      <span className="text-[12px] text-warning-5 bg-warning-10/40 border border-warning-8/40 rounded-full px-2 py-0.5">paused</span>
-                    )}
-                    {s.nextRunAt && s.enabled && (
-                      <span className="text-[13px] text-neutral-5 flex items-center gap-1">
-                        <IconClock size={12} stroke={2} />
-                        {formatTime(s.nextRunAt)}
-                      </span>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-          {/* Recent runs (read-only info) */}
-          {recentRuns.length > 0 && (
-            <div>
-              <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">Recent runs</label>
-              <div className="space-y-1">
-                {recentRuns.slice(0, 5).map(run => (
-                  <div key={run.id} className="flex items-center gap-2 rounded-md border border-neutral-8/50 bg-neutral-10/60 px-2.5 py-1.5">
-                    <span className="text-[13px] text-neutral-4 font-mono tabular-nums">{formatTime(run.createdAt)}</span>
-                    <span className="text-[13px] text-neutral-5">{kindLabel(run.kind)}</span>
-                    <span className="ml-auto"><StatusBadge status={run.status} /></span>
-                    <span className="text-[13px] text-neutral-5 tabular-nums">{formatDuration(run.startedAt, run.completedAt)}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
           {formError && (
             <div className="rounded-md bg-error-10/50 px-3 py-2 text-[13px] text-error-4">{formError}</div>
           )}
 
-          <div className="flex gap-2 pt-1">
+          <div className="flex gap-2 pt-2 border-t border-neutral-8/50">
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 rounded-md border border-neutral-7 bg-neutral-10 py-2 text-[15px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
+              className="flex-1 rounded-md border border-neutral-7 bg-neutral-10 py-2 text-[14px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={saving}
-              className="flex-1 rounded-md bg-accent-7 py-2 text-[15px] font-medium text-white hover:bg-accent-6 disabled:opacity-50 transition-colors"
+              className="flex-1 rounded-md bg-accent-7 py-2 text-[14px] font-medium text-white hover:bg-accent-6 disabled:opacity-50 transition-colors flex items-center justify-center gap-1.5"
             >
-              {saving ? 'Saving…' : 'Save Changes'}
+              {saving ? (
+                <>
+                  <IconLoader2 size={14} stroke={2} className="animate-spin" />
+                  Saving…
+                </>
+              ) : (
+                'Save Changes'
+              )}
             </button>
           </div>
         </form>

--- a/src/components/WorkflowsView.tsx
+++ b/src/components/WorkflowsView.tsx
@@ -1,10 +1,9 @@
 /**
- * Workflows page — setup, scheduling, and run monitoring with debug detail.
+ * Workflows page — unified card-based layout with inline run history.
  *
- * Sections:
- *   - Scheduled Workflows: configured repos with cron, Run Now, and delete
- *   - Add Workflow modal: form to register a new repo/workflow
- *   - Run History: timeline of runs; click to expand step-by-step debug detail
+ * Each configured workflow gets a card showing identity, schedule, health,
+ * and expandable recent runs. A "Recent Activity" feed at the bottom shows
+ * the latest runs across all workflows.
  */
 
 import { useState, useEffect, useCallback } from 'react'
@@ -12,13 +11,14 @@ import {
   IconRefresh, IconPlus, IconPlayerPlay, IconPlayerStop, IconPlayerPause,
   IconExternalLink, IconTrash, IconChevronDown, IconChevronRight,
   IconCheck, IconX, IconLoader2, IconMinus, IconCircle, IconClock, IconPencil,
+  IconCalendarEvent, IconArrowRight,
 } from '@tabler/icons-react'
 import { useWorkflows } from '../hooks/useWorkflows'
 import { getRun } from '../lib/workflowApi'
 import type { WorkflowRun, WorkflowRunWithSteps, WorkflowStep, CronSchedule, ReviewRepoConfig } from '../lib/workflowApi'
 import { AddWorkflowModal } from './AddWorkflowModal'
 import { EditWorkflowModal } from './EditWorkflowModal'
-import { StatusBadge } from './WorkflowBadges'
+import { StatusBadge, CategoryBadge } from './WorkflowBadges'
 import { kindLabel, statusBadge, describeCron, formatDuration, formatTime, repoNameFromRun } from '../lib/workflowHelpers'
 
 // ---------------------------------------------------------------------------
@@ -47,7 +47,6 @@ function JsonBlock({ label, data, defaultOpen = false }: {
 }) {
   if (!data || Object.keys(data).length === 0) return null
   const json = JSON.stringify(data, null, 2)
-  // Truncate very long values (e.g. full review text)
   const display = json.length > 4000 ? json.slice(0, 4000) + '\n… (truncated)' : json
 
   return (
@@ -111,7 +110,6 @@ function RunDetail({ run }: { run: WorkflowRunWithSteps }) {
         run.steps.map(step => <StepCard key={step.id} step={step} />)
       )}
 
-      {/* Run-level output (e.g. filePath, sessionId) */}
       {run.output && Object.keys(run.output).length > 0 && (
         <div className="pt-1">
           <JsonBlock label="run output" data={run.output} defaultOpen />
@@ -128,10 +126,10 @@ function RunDetail({ run }: { run: WorkflowRunWithSteps }) {
 }
 
 // ---------------------------------------------------------------------------
-// RunTableRow
+// MiniRunRow — compact run entry for the card's recent runs
 // ---------------------------------------------------------------------------
 
-function RunTableRow({
+function MiniRunRow({
   run,
   selected,
   detail,
@@ -151,168 +149,300 @@ function RunTableRow({
   const sessionId = (run.output?.sessionId || run.input?.sessionId) as string | undefined
 
   return (
-    <>
-      <tr
+    <div>
+      <div
         onClick={onToggle}
-        className={`cursor-pointer transition-colors ${
+        className={`flex items-center gap-3 px-3 py-2 cursor-pointer transition-colors rounded-md ${
           selected ? 'bg-neutral-10' : 'hover:bg-neutral-10/50'
         }`}
       >
-        <td className="py-2.5 pl-3 pr-1 text-neutral-5 w-8">
+        <span className="text-neutral-5 w-4 shrink-0">
           {selected
-            ? <IconChevronDown size={14} stroke={2} />
-            : <IconChevronRight size={14} stroke={2} />
+            ? <IconChevronDown size={13} stroke={2} />
+            : <IconChevronRight size={13} stroke={2} />
           }
-        </td>
-        <td className="py-2.5 px-3 text-[15px] font-medium text-neutral-1 max-w-[180px] truncate">
-          {repoNameFromRun(run)}
-        </td>
-        <td className="py-2.5 px-3 text-[13px] text-neutral-4 whitespace-nowrap">
-          {kindLabel(run.kind)}
-        </td>
-        <td className="py-2.5 px-3 text-[13px] text-neutral-4 tabular-nums whitespace-nowrap">
+        </span>
+        <span className="text-[13px] text-neutral-4 tabular-nums whitespace-nowrap">
           {formatTime(run.createdAt)}
-        </td>
-        <td className="py-2.5 px-3 text-[13px] text-neutral-4 tabular-nums whitespace-nowrap">
+        </span>
+        <span className="text-[13px] text-neutral-4 tabular-nums whitespace-nowrap">
           {formatDuration(run.startedAt, run.completedAt)}
-        </td>
-        <td className="py-2.5 px-3">
+        </span>
+        <span className="ml-auto">
           <StatusBadge status={run.status} />
-        </td>
-        <td className="py-2.5 pl-1 pr-3 w-14" onClick={e => e.stopPropagation()}>
-          <div className="flex items-center gap-1 justify-end">
-            {run.status === 'running' && (
-              <button
-                onClick={() => onCancel(run.id)}
-                className="rounded p-1 text-neutral-4 hover:text-error-4 hover:bg-neutral-9 transition-colors"
-                title="Cancel"
-              >
-                <IconPlayerStop size={14} stroke={2} />
-              </button>
-            )}
-            {sessionId && onNavigateToSession && (
-              <button
-                onClick={() => onNavigateToSession(sessionId)}
-                className="rounded p-1 text-neutral-4 hover:text-accent-3 hover:bg-neutral-9 transition-colors"
-                title="View Session"
-              >
-                <IconExternalLink size={14} stroke={2} />
-              </button>
-            )}
-          </div>
-        </td>
-      </tr>
+        </span>
+        <div className="flex items-center gap-0.5 shrink-0" onClick={e => e.stopPropagation()}>
+          {run.status === 'running' && (
+            <button
+              onClick={() => onCancel(run.id)}
+              className="rounded p-1 text-neutral-4 hover:text-error-4 hover:bg-neutral-9 transition-colors"
+              title="Cancel"
+            >
+              <IconPlayerStop size={13} stroke={2} />
+            </button>
+          )}
+          {sessionId && onNavigateToSession && (
+            <button
+              onClick={() => onNavigateToSession(sessionId)}
+              className="rounded p-1 text-neutral-4 hover:text-accent-3 hover:bg-neutral-9 transition-colors"
+              title="View session"
+            >
+              <IconExternalLink size={13} stroke={2} />
+            </button>
+          )}
+        </div>
+      </div>
       {selected && (
-        <tr className="bg-neutral-10/30">
-          <td colSpan={7} className="px-4 pb-3 pt-1">
-            {detailLoading ? (
-              <div className="flex items-center gap-2 py-3 text-[13px] text-neutral-5">
-                <IconLoader2 size={16} stroke={2} className="animate-spin" />
-                Loading steps…
-              </div>
-            ) : detail ? (
-              <RunDetail run={detail} />
-            ) : null}
-          </td>
-        </tr>
+        <div className="px-3 pb-2">
+          {detailLoading ? (
+            <div className="flex items-center gap-2 py-3 text-[13px] text-neutral-5">
+              <IconLoader2 size={16} stroke={2} className="animate-spin" />
+              Loading steps…
+            </div>
+          ) : detail ? (
+            <RunDetail run={detail} />
+          ) : null}
+        </div>
       )}
-    </>
+    </div>
   )
 }
 
 // ---------------------------------------------------------------------------
-// ScheduleRow — a single workflow entry within a repo group
+// HealthIndicator — dot showing last run status
 // ---------------------------------------------------------------------------
 
-function ScheduleRow({
-  schedule,
+function HealthDot({ status }: { status: string | undefined }) {
+  if (!status) return <span className="w-2.5 h-2.5 rounded-full bg-neutral-7 shrink-0" title="No runs yet" />
+  const colors: Record<string, string> = {
+    succeeded: 'bg-success-5',
+    failed: 'bg-error-5',
+    running: 'bg-accent-5 animate-pulse',
+    queued: 'bg-neutral-5 animate-pulse',
+    canceled: 'bg-warning-5',
+    skipped: 'bg-neutral-6',
+  }
+  return <span className={`w-2.5 h-2.5 rounded-full shrink-0 ${colors[status] || 'bg-neutral-7'}`} title={status} />
+}
+
+// ---------------------------------------------------------------------------
+// WorkflowCard — one card per configured workflow
+// ---------------------------------------------------------------------------
+
+function WorkflowCard({
   repo,
+  schedule,
+  recentRuns,
+  selectedRunId,
+  runDetail,
+  detailLoading,
   onTrigger,
   onToggleEnabled,
   onEdit,
   onDelete,
+  onToggleRun,
+  onCancel,
+  onNavigateToSession,
 }: {
-  schedule: CronSchedule
-  repo?: ReviewRepoConfig
+  repo: ReviewRepoConfig
+  schedule?: CronSchedule
+  recentRuns: WorkflowRun[]
+  selectedRunId: string | null
+  runDetail: WorkflowRunWithSteps | null
+  detailLoading: boolean
   onTrigger: (id: string) => void
   onToggleEnabled: (id: string, enabled: boolean) => void
   onEdit: (repo: ReviewRepoConfig) => void
   onDelete: (id: string) => void
+  onToggleRun: (runId: string) => void
+  onCancel: (runId: string) => void
+  onNavigateToSession?: (sessionId: string) => void
 }) {
-  const paused = !schedule.enabled
+  const [showRuns, setShowRuns] = useState(false)
+  const paused = schedule ? !schedule.enabled : false
+  const lastRun = recentRuns[0]
+  const repoShortName = repo.repoPath.split('/').pop() || repo.name
+
   return (
-    <div className={`flex items-center gap-3 rounded-md border px-3 py-2.5 transition-colors ${
+    <div className={`rounded-xl border transition-colors ${
       paused
-        ? 'border-neutral-8/40 bg-neutral-11/20 opacity-60'
+        ? 'border-neutral-8/40 bg-neutral-11/20'
         : 'border-neutral-8/60 bg-neutral-11/40'
     }`}>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className={`shrink-0 text-[13px] font-medium rounded px-2 py-0.5 ${
-            paused
-              ? 'text-neutral-5 bg-neutral-9/60'
-              : 'text-neutral-3 bg-neutral-9'
-          }`}>
-            {kindLabel(repo?.kind ?? schedule.kind)}
-          </span>
-          <span className={`text-[13px] font-mono ${paused ? 'text-neutral-5' : 'text-neutral-3'}`}>
-            {describeCron(schedule.cronExpression)}
-          </span>
-          {paused && (
-            <span className="inline-flex items-center gap-1 text-[12px] font-medium text-warning-5 bg-warning-10/40 border border-warning-8/40 rounded-full px-2 py-0.5">
-              <IconPlayerPause size={12} stroke={2} />
-              paused
-            </span>
-          )}
+      {/* Card header */}
+      <div className="px-4 pt-3.5 pb-3">
+        <div className="flex items-start gap-3">
+          {/* Health dot + repo info */}
+          <div className="pt-1.5">
+            <HealthDot status={lastRun?.status} />
+          </div>
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className={`text-[15px] font-semibold ${paused ? 'text-neutral-4' : 'text-neutral-1'}`}>
+                {repoShortName}
+              </span>
+              <CategoryBadge kind={repo.kind ?? ''} />
+              {paused && (
+                <span className="inline-flex items-center gap-1 text-[12px] font-medium text-warning-5 bg-warning-10/40 border border-warning-8/40 rounded-full px-2 py-0.5">
+                  <IconPlayerPause size={11} stroke={2} />
+                  paused
+                </span>
+              )}
+            </div>
+            <div className={`text-[14px] font-medium mt-0.5 ${paused ? 'text-neutral-5' : 'text-neutral-3'}`}>
+              {kindLabel(repo.kind ?? '')}
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="flex items-center gap-1 shrink-0">
+            <button
+              onClick={() => onToggleEnabled(repo.id, !schedule?.enabled)}
+              className={`rounded-md p-1.5 transition-colors ${
+                paused
+                  ? 'text-success-5 hover:text-success-3 hover:bg-neutral-9'
+                  : 'text-neutral-5 hover:text-warning-4 hover:bg-neutral-9'
+              }`}
+              title={paused ? 'Resume' : 'Pause'}
+            >
+              {paused
+                ? <IconPlayerPlay size={15} stroke={2} />
+                : <IconPlayerPause size={15} stroke={2} />
+              }
+            </button>
+            <button
+              onClick={() => onEdit(repo)}
+              className="rounded-md p-1.5 text-neutral-5 hover:text-neutral-2 hover:bg-neutral-9 transition-colors"
+              title="Edit"
+            >
+              <IconPencil size={15} stroke={2} />
+            </button>
+            <button
+              onClick={() => onDelete(repo.id)}
+              className="rounded-md p-1.5 text-neutral-6 hover:text-error-4 hover:bg-neutral-9 transition-colors"
+              title="Delete"
+            >
+              <IconTrash size={15} stroke={2} />
+            </button>
+          </div>
         </div>
-        {schedule.nextRunAt && !paused && (
-          <div className="mt-1 flex items-center gap-1 text-[13px] text-neutral-5">
-            <IconClock size={12} stroke={2} />
-            Next: {formatTime(schedule.nextRunAt)}
+
+        {/* Schedule + next run + Run Now */}
+        <div className="mt-3 flex items-center gap-3 flex-wrap">
+          <div className="flex items-center gap-1.5 text-[13px] text-neutral-4">
+            <IconCalendarEvent size={14} stroke={2} className="text-neutral-5" />
+            {schedule ? describeCron(schedule.cronExpression) : describeCron(repo.cronExpression)}
+          </div>
+          {schedule?.nextRunAt && !paused && (
+            <div className="flex items-center gap-1 text-[13px] text-neutral-5">
+              <IconClock size={12} stroke={2} />
+              Next: {formatTime(schedule.nextRunAt)}
+            </div>
+          )}
+          <div className="ml-auto">
+            <button
+              onClick={() => onTrigger(repo.id)}
+              className="rounded-md border border-neutral-7 bg-neutral-9 px-3 py-1 text-[13px] text-neutral-2 hover:bg-neutral-8 hover:text-neutral-1 transition-colors flex items-center gap-1.5"
+            >
+              <IconPlayerPlay size={12} stroke={2} />
+              Run Now
+            </button>
+          </div>
+        </div>
+
+        {/* Last run summary */}
+        {lastRun && (
+          <div className="mt-2.5 flex items-center gap-2 text-[13px] text-neutral-5">
+            <span>Last run:</span>
+            <StatusBadge status={lastRun.status} />
+            <span className="tabular-nums">{formatTime(lastRun.createdAt)}</span>
+            <span className="tabular-nums">{formatDuration(lastRun.startedAt, lastRun.completedAt)}</span>
           </div>
         )}
       </div>
 
-      <div className="flex items-center gap-1 shrink-0">
-        <button
-          onClick={() => onToggleEnabled(schedule.id, !schedule.enabled)}
-          className={`rounded p-1.5 transition-colors ${
-            paused
-              ? 'text-success-5 hover:text-success-3 hover:bg-neutral-9'
-              : 'text-neutral-5 hover:text-warning-4 hover:bg-neutral-9'
-          }`}
-          title={paused ? 'Resume schedule' : 'Pause schedule'}
-        >
-          {paused
-            ? <IconPlayerPlay size={14} stroke={2} />
-            : <IconPlayerPause size={14} stroke={2} />
-          }
-        </button>
-        <button
-          onClick={() => onTrigger(schedule.id)}
-          className="rounded-md border border-neutral-7 bg-neutral-9 px-2.5 py-1 text-[13px] text-neutral-2 hover:bg-neutral-8 hover:text-neutral-1 transition-colors flex items-center gap-1.5"
-          title="Run now"
-        >
-          <IconPlayerPlay size={12} stroke={2} />
-          Run Now
-        </button>
-        {repo && (
+      {/* Recent runs toggle */}
+      {recentRuns.length > 0 && (
+        <div className="border-t border-neutral-8/40">
           <button
-            onClick={() => onEdit(repo)}
-            className="rounded p-1.5 text-neutral-5 hover:text-neutral-2 hover:bg-neutral-9 transition-colors"
-            title="Edit workflow"
+            onClick={() => setShowRuns(!showRuns)}
+            className="w-full flex items-center gap-2 px-4 py-2 text-[13px] text-neutral-4 hover:text-neutral-2 transition-colors"
           >
-            <IconPencil size={14} stroke={2} />
+            {showRuns
+              ? <IconChevronDown size={13} stroke={2} />
+              : <IconChevronRight size={13} stroke={2} />
+            }
+            <span>Recent runs ({recentRuns.length})</span>
+            {/* Mini status dots for last few runs */}
+            {!showRuns && (
+              <div className="flex items-center gap-1 ml-1">
+                {recentRuns.slice(0, 5).map(r => (
+                  <HealthDot key={r.id} status={r.status} />
+                ))}
+              </div>
+            )}
           </button>
-        )}
+
+          {showRuns && (
+            <div className="pb-2 px-1">
+              {recentRuns.map(run => (
+                <MiniRunRow
+                  key={run.id}
+                  run={run}
+                  selected={selectedRunId === run.id}
+                  detail={selectedRunId === run.id ? runDetail : null}
+                  detailLoading={selectedRunId === run.id ? detailLoading : false}
+                  onToggle={() => onToggleRun(run.id)}
+                  onCancel={onCancel}
+                  onNavigateToSession={onNavigateToSession}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ActivityRow — compact run for the activity feed
+// ---------------------------------------------------------------------------
+
+function ActivityRow({
+  run,
+  onNavigateToSession,
+}: {
+  run: WorkflowRun
+  onNavigateToSession?: (sessionId: string) => void
+}) {
+  const sessionId = (run.output?.sessionId || run.input?.sessionId) as string | undefined
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-2 hover:bg-neutral-10/30 transition-colors rounded-md">
+      <HealthDot status={run.status} />
+      <span className="text-[14px] font-medium text-neutral-2 min-w-0 truncate max-w-[140px]">
+        {repoNameFromRun(run)}
+      </span>
+      <span className="text-[13px] text-neutral-4">
+        {kindLabel(run.kind)}
+      </span>
+      <span className="text-[13px] text-neutral-5 tabular-nums ml-auto whitespace-nowrap">
+        {formatTime(run.createdAt)}
+      </span>
+      <span className="text-[13px] text-neutral-5 tabular-nums whitespace-nowrap">
+        {formatDuration(run.startedAt, run.completedAt)}
+      </span>
+      <StatusBadge status={run.status} />
+      {sessionId && onNavigateToSession && (
         <button
-          onClick={() => onDelete(schedule.id)}
-          className="rounded p-1.5 text-neutral-6 hover:text-error-4 hover:bg-neutral-9 transition-colors"
-          title="Delete"
+          onClick={() => onNavigateToSession(sessionId)}
+          className="rounded p-1 text-neutral-5 hover:text-accent-3 hover:bg-neutral-9 transition-colors shrink-0"
+          title="View session"
         >
-          <IconTrash size={14} stroke={2} />
+          <IconExternalLink size={13} stroke={2} />
         </button>
-      </div>
+      )}
     </div>
   )
 }
@@ -329,32 +459,42 @@ interface Props {
 export function WorkflowsView({ token, onNavigateToSession }: Props) {
   const { runs, schedules, config, loading, error, refresh, cancelRun, triggerSchedule, addRepo, removeRepo, updateRepo, toggleScheduleEnabled } = useWorkflows(token)
 
-  const [activeTab, setActiveTab] = useState<'schedules' | 'runs'>('schedules')
   const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
   const [runDetail, setRunDetail] = useState<WorkflowRunWithSteps | null>(null)
   const [showAddForm, setShowAddForm] = useState(false)
   const [editingRepo, setEditingRepo] = useState<ReviewRepoConfig | null>(null)
+  const [showActivity, setShowActivity] = useState(false)
 
-  // Derived: loading when selected run doesn't match the fetched detail yet
   const detailLoading = selectedRunId !== null && (runDetail === null || runDetail.id !== selectedRunId)
 
-  // Build repo map for schedule cards
+  // Build repo map
   const repoMap = new Map<string, ReviewRepoConfig>()
   if (config) {
     for (const repo of config.reviewRepos) repoMap.set(repo.id, repo)
   }
 
-  // Group schedules by repoPath
-  const scheduleGroups: { repoPath: string; repoName: string; items: CronSchedule[] }[] = []
-  const groupIndex = new Map<string, number>()
-  for (const schedule of schedules) {
-    const repo = repoMap.get(schedule.id)
-    const key = repo?.repoPath ?? schedule.id
-    if (!groupIndex.has(key)) {
-      groupIndex.set(key, scheduleGroups.length)
-      scheduleGroups.push({ repoPath: key, repoName: repo?.name ?? schedule.id, items: [] })
+  // Build schedule map
+  const scheduleMap = new Map<string, CronSchedule>()
+  for (const s of schedules) scheduleMap.set(s.id, s)
+
+  // Build runs-per-repo map
+  const runsPerRepo = new Map<string, WorkflowRun[]>()
+  for (const run of runs) {
+    const repoPath = run.input.repoPath as string | undefined
+    if (!repoPath) continue
+    // Find matching repo config
+    const matchingRepo = config?.reviewRepos.find(r => r.repoPath === repoPath && r.kind === run.kind)
+    if (matchingRepo) {
+      const key = matchingRepo.id
+      if (!runsPerRepo.has(key)) runsPerRepo.set(key, [])
+      runsPerRepo.get(key)!.push(run)
     }
-    scheduleGroups[groupIndex.get(key)!].items.push(schedule)
+  }
+
+  // Orphan runs (not matching any config)
+  const assignedRunIds = new Set<string>()
+  for (const arr of runsPerRepo.values()) {
+    for (const r of arr) assignedRunIds.add(r.id)
   }
 
   // Fetch run detail when selection changes
@@ -395,11 +535,13 @@ export function WorkflowsView({ token, onNavigateToSession }: Props) {
     }
   }, [toggleScheduleEnabled])
 
+  const repos = config?.reviewRepos ?? []
+
   return (
     <div className="flex h-full flex-col overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between border-b border-neutral-8/50 px-5 py-3">
-        <h1 className="text-[17px] font-medium text-neutral-1">AI Workflows</h1>
+        <h1 className="text-[17px] font-medium text-neutral-1">Workflows</h1>
         <div className="flex items-center gap-1.5">
           <button
             onClick={() => refresh()}
@@ -410,29 +552,12 @@ export function WorkflowsView({ token, onNavigateToSession }: Props) {
           </button>
           <button
             onClick={() => setShowAddForm(true)}
-            className="flex items-center gap-1.5 rounded-md border border-neutral-7 bg-neutral-9 px-2.5 py-1.5 text-[13px] text-neutral-2 hover:bg-neutral-8 hover:text-neutral-1 transition-colors"
+            className="flex items-center gap-1.5 rounded-md bg-accent-7 px-3 py-1.5 text-[13px] font-medium text-white hover:bg-accent-6 transition-colors"
           >
             <IconPlus size={14} stroke={2} />
-            Add
+            New Workflow
           </button>
         </div>
-      </div>
-
-      {/* Tabs */}
-      <div className="flex border-b border-neutral-8/50 px-5">
-        {(['schedules', 'runs'] as const).map(tab => (
-          <button
-            key={tab}
-            onClick={() => setActiveTab(tab)}
-            className={`mr-4 pb-2.5 pt-2 text-[15px] font-medium border-b-2 transition-colors ${
-              activeTab === tab
-                ? 'border-accent-5 text-accent-3'
-                : 'border-transparent text-neutral-4 hover:text-neutral-2'
-            }`}
-          >
-            {tab === 'schedules' ? 'Scheduled' : 'Run History'}
-          </button>
-        ))}
       </div>
 
       <div className="flex-1 overflow-y-auto p-5">
@@ -443,87 +568,74 @@ export function WorkflowsView({ token, onNavigateToSession }: Props) {
           </div>
         )}
 
-        {/* Scheduled Workflows — grouped by repo */}
-        {activeTab === 'schedules' && (
-          <section>
-            {scheduleGroups.length === 0 ? (
-              <div className="rounded-lg border border-dashed border-neutral-8 px-4 py-6 text-center">
-                <div className="text-[15px] text-neutral-4 mb-1">No workflows configured</div>
-                <button
-                  onClick={() => setShowAddForm(true)}
-                  className="text-[13px] text-accent-4 hover:text-accent-3 underline underline-offset-2"
-                >
-                  Add your first workflow
-                </button>
+        {/* Workflow cards */}
+        {repos.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-neutral-8 px-6 py-10 text-center">
+            <div className="text-neutral-5 mb-1">
+              <IconCalendarEvent size={32} stroke={1.5} className="mx-auto mb-3 text-neutral-6" />
+              <div className="text-[15px] text-neutral-3 font-medium mb-1">No workflows configured</div>
+              <div className="text-[13px] text-neutral-5">
+                Set up automated code reviews, security audits, and more.
               </div>
-            ) : (
-              <div className="space-y-3">
-                {scheduleGroups.map(group => (
-                  <div key={group.repoPath} className="rounded-lg border border-neutral-8 bg-neutral-10/50">
-                    {/* Repo header */}
-                    <div className="flex items-center gap-2 px-3 pt-2.5 pb-2 border-b border-neutral-8/60">
-                      <span className="text-[15px] font-bold text-neutral-1">{group.repoPath.split('/').pop() || group.repoName}</span>
-                    </div>
-                    {/* Schedule rows */}
-                    <div className="p-2 space-y-1.5">
-                      {group.items.map(schedule => (
-                        <ScheduleRow
-                          key={schedule.id}
-                          schedule={schedule}
-                          repo={repoMap.get(schedule.id)}
-                          onTrigger={triggerSchedule}
-                          onToggleEnabled={handleToggleEnabled}
-                          onEdit={setEditingRepo}
-                          onDelete={handleDeleteSchedule}
-                        />
-                      ))}
-                    </div>
-                  </div>
+            </div>
+            <button
+              onClick={() => setShowAddForm(true)}
+              className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-accent-7 px-4 py-2 text-[13px] font-medium text-white hover:bg-accent-6 transition-colors"
+            >
+              <IconPlus size={14} stroke={2} />
+              Create your first workflow
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {repos.map(repo => (
+              <WorkflowCard
+                key={repo.id}
+                repo={repo}
+                schedule={scheduleMap.get(repo.id)}
+                recentRuns={runsPerRepo.get(repo.id) ?? []}
+                selectedRunId={selectedRunId}
+                runDetail={runDetail}
+                detailLoading={detailLoading}
+                onTrigger={triggerSchedule}
+                onToggleEnabled={handleToggleEnabled}
+                onEdit={setEditingRepo}
+                onDelete={handleDeleteSchedule}
+                onToggleRun={handleToggleRun}
+                onCancel={cancelRun}
+                onNavigateToSession={onNavigateToSession}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Recent Activity */}
+        {runs.length > 0 && (
+          <div className="mt-6">
+            <button
+              onClick={() => setShowActivity(!showActivity)}
+              className="flex items-center gap-2 text-[14px] font-medium text-neutral-3 hover:text-neutral-1 transition-colors mb-2"
+            >
+              {showActivity
+                ? <IconChevronDown size={14} stroke={2} />
+                : <IconArrowRight size={14} stroke={2} />
+              }
+              Recent Activity
+              <span className="text-[12px] text-neutral-5 font-normal">({runs.length} runs)</span>
+            </button>
+
+            {showActivity && (
+              <div className="rounded-xl border border-neutral-8/50 bg-neutral-11/30 py-1 divide-y divide-neutral-8/30">
+                {runs.slice(0, 20).map(run => (
+                  <ActivityRow
+                    key={run.id}
+                    run={run}
+                    onNavigateToSession={onNavigateToSession}
+                  />
                 ))}
               </div>
             )}
-          </section>
-        )}
-
-        {/* Run History */}
-        {activeTab === 'runs' && (
-          <section>
-            {runs.length === 0 ? (
-              <div className="text-[15px] text-neutral-5 py-2">
-                {loading ? 'Loading…' : 'No workflow runs yet.'}
-              </div>
-            ) : (
-              <div className="rounded-lg border border-neutral-8 overflow-hidden">
-                <table className="w-full border-collapse">
-                  <thead>
-                    <tr className="border-b border-neutral-8/60 bg-neutral-11/80">
-                      <th className="w-8 py-2.5 pl-3 pr-1" />
-                      <th className="py-2.5 px-3 text-left text-[13px] font-medium text-neutral-4 uppercase tracking-wider">Repo</th>
-                      <th className="py-2.5 px-3 text-left text-[13px] font-medium text-neutral-4 uppercase tracking-wider">Kind</th>
-                      <th className="py-2.5 px-3 text-left text-[13px] font-medium text-neutral-4 uppercase tracking-wider">Started</th>
-                      <th className="py-2.5 px-3 text-left text-[13px] font-medium text-neutral-4 uppercase tracking-wider">Duration</th>
-                      <th className="py-2.5 px-3 text-left text-[13px] font-medium text-neutral-4 uppercase tracking-wider">Status</th>
-                      <th className="w-14 py-2.5 pl-1 pr-3" />
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y divide-neutral-8/40">
-                    {runs.map(run => (
-                      <RunTableRow
-                        key={run.id}
-                        run={run}
-                        selected={selectedRunId === run.id}
-                        detail={selectedRunId === run.id ? runDetail : null}
-                        detailLoading={selectedRunId === run.id ? detailLoading : false}
-                        onToggle={() => handleToggleRun(run.id)}
-                        onCancel={cancelRun}
-                        onNavigateToSession={onNavigateToSession}
-                      />
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </section>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- **Unified card layout** — replaces the tab-split (Scheduled / Run History) with per-workflow cards showing config, schedule, health status, and expandable recent runs all in one place
- **Multi-step add wizard** — converts the single-form modal into a focused 3-step flow: select repo → select workflow type → configure schedule
- **Simplified edit modal** — removes read-only info sections (now visible on the card itself), focuses on editable fields only
- **Better visual hierarchy** — health dots, category badges, collapsible recent activity feed, improved empty state

## Test plan
- [ ] Verify workflow cards display correctly with schedule, health dot, and last run info
- [ ] Test "New Workflow" wizard: navigate through all 3 steps, verify back/next, create a workflow
- [ ] Test edit modal: change kind, schedule, and focus areas
- [ ] Test Run Now, Pause/Resume, Delete actions on workflow cards
- [ ] Test expanding recent runs and drilling into step details
- [ ] Verify recent activity feed shows all runs across workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)