### PR TITLE
Replace native time picker with custom styled component

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Codekin</title>
-    <script type="module" crossorigin src="/assets/index-C0uevU2N.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-Cj7k_spD.css">
+    <script type="module" crossorigin src="/assets/index-TfzCnhC7.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-dNFIrKVU.css">
   </head>
   <body class="bg-neutral-12 text-neutral-2">
     <div id="root"></div>

--- a/src/components/AddWorkflowModal.tsx
+++ b/src/components/AddWorkflowModal.tsx
@@ -15,9 +15,10 @@ import type { ReviewRepoConfig, WorkflowKindInfo } from '../lib/workflowApi'
 import {
   WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL,
   buildCron, describeCron, slugify, kindCategory,
-  toTimeValue, fromTimeValue, isBiweeklyDow,
+  isBiweeklyDow,
 } from '../lib/workflowHelpers'
 import { CategoryBadge } from './WorkflowBadges'
+import TimePicker from './TimePicker'
 import { RepoList } from './RepoList'
 
 type Step = 1 | 2 | 3
@@ -256,11 +257,6 @@ function StepSchedule({
   form: FormState
   onChange: (patch: Partial<FormState>) => void
 }) {
-  const handleTimeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { hour, minute } = fromTimeValue(e.target.value)
-    onChange({ cronHour: hour, cronMinute: minute })
-  }
-
   return (
     <div className="space-y-5">
       <div>
@@ -270,12 +266,10 @@ function StepSchedule({
 
         {/* Time picker */}
         <label className="block text-[13px] font-medium text-neutral-3 mb-2">Time</label>
-        <input
-          type="time"
-          step={900}
-          value={toTimeValue(form.cronHour, form.cronMinute)}
-          onChange={handleTimeChange}
-          className="rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[15px] text-neutral-1 focus:border-accent-6 focus:outline-none w-40 themed-time-input"
+        <TimePicker
+          hour={form.cronHour}
+          minute={form.cronMinute}
+          onChange={(h, m) => onChange({ cronHour: h, cronMinute: m })}
         />
       </div>
 

--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -9,9 +9,9 @@ import type { ReviewRepoConfig } from '../lib/workflowApi'
 import {
   WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL, isBiweeklyDow,
   buildCron, parseCron, describeCron, kindLabel,
-  toTimeValue, fromTimeValue,
 } from '../lib/workflowHelpers'
 import { CategoryBadge } from './WorkflowBadges'
+import TimePicker from './TimePicker'
 
 const btnClass = (selected: boolean) =>
   `rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors ${
@@ -116,15 +116,11 @@ export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
           {/* Schedule */}
           <div>
             <label className="block text-[13px] font-medium text-neutral-3 mb-2">Time</label>
-            <input
-              type="time"
-              step={900}
-              value={toTimeValue(form.cronHour, form.cronMinute)}
-              onChange={e => {
-                const { hour, minute } = fromTimeValue(e.target.value)
-                setForm(f => ({ ...f, cronHour: hour, cronMinute: minute }))
-              }}
-              className="rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[15px] text-neutral-1 focus:border-accent-6 focus:outline-none w-40 mb-3 themed-time-input"
+            <TimePicker
+              hour={form.cronHour}
+              minute={form.cronMinute}
+              onChange={(h, m) => setForm(f => ({ ...f, cronHour: h, cronMinute: m }))}
+              className="mb-3"
             />
             <label className="block text-[13px] font-medium text-neutral-3 mb-2">Frequency</label>
             <div className="flex flex-wrap gap-1.5 mb-2">

--- a/src/components/TimePicker.tsx
+++ b/src/components/TimePicker.tsx
@@ -1,0 +1,109 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+
+interface TimePickerProps {
+  hour: number
+  minute: number
+  onChange: (hour: number, minute: number) => void
+  step?: number // minute step, default 15
+  className?: string
+}
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i)
+
+export default function TimePicker({ hour, minute, onChange, step = 15, className = '' }: TimePickerProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const hourListRef = useRef<HTMLDivElement>(null)
+  const minListRef = useRef<HTMLDivElement>(null)
+
+  const minutes = Array.from({ length: 60 / step }, (_, i) => i * step)
+
+  const pad = (n: number) => String(n).padStart(2, '0')
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  // Scroll selected items into view when opening
+  useEffect(() => {
+    if (!open) return
+    requestAnimationFrame(() => {
+      hourListRef.current?.querySelector('[data-selected="true"]')?.scrollIntoView({ block: 'nearest' })
+      minListRef.current?.querySelector('[data-selected="true"]')?.scrollIntoView({ block: 'nearest' })
+    })
+  }, [open])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') setOpen(false)
+  }, [])
+
+  return (
+    <div ref={ref} className={`relative inline-block ${className}`} onKeyDown={handleKeyDown}>
+      {/* Display button */}
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className="flex items-center gap-2 rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[15px] font-mono text-neutral-1 focus:border-accent-6 focus:outline-none w-40 cursor-pointer hover:border-neutral-5 transition-colors"
+      >
+        <span className="flex-1 text-left">{pad(hour)}:{pad(minute)}</span>
+        {/* Clock icon */}
+        <svg className="w-4 h-4 text-neutral-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="10" />
+          <polyline points="12 6 12 12 16 14" />
+        </svg>
+      </button>
+
+      {/* Dropdown */}
+      {open && (
+        <div className="absolute top-full left-0 z-50 mt-1 flex rounded-md border border-neutral-7 bg-neutral-10 shadow-lg overflow-hidden">
+          {/* Hours column */}
+          <div ref={hourListRef} className="h-52 overflow-y-auto scrollbar-thin">
+            {HOURS.map(h => (
+              <button
+                key={h}
+                type="button"
+                data-selected={h === hour}
+                onClick={() => { onChange(h, minute); }}
+                className={`block w-full px-4 py-1.5 text-center font-mono text-[14px] transition-colors cursor-pointer
+                  ${h === hour
+                    ? 'bg-accent-8 text-accent-2'
+                    : 'text-neutral-2 hover:bg-neutral-8'
+                  }`}
+              >
+                {pad(h)}
+              </button>
+            ))}
+          </div>
+
+          {/* Divider */}
+          <div className="w-px bg-neutral-7" />
+
+          {/* Minutes column */}
+          <div ref={minListRef} className="h-52 overflow-y-auto scrollbar-thin">
+            {minutes.map(m => (
+              <button
+                key={m}
+                type="button"
+                data-selected={m === minute}
+                onClick={() => { onChange(hour, m); }}
+                className={`block w-full px-4 py-1.5 text-center font-mono text-[14px] transition-colors cursor-pointer
+                  ${m === minute
+                    ? 'bg-accent-8 text-accent-2'
+                    : 'text-neutral-2 hover:bg-neutral-8'
+                  }`}
+              >
+                {pad(m)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -654,20 +654,3 @@ html, body, #root {
   border: 1px solid var(--color-neutral-9);
 }
 
-/* Themed time input — dark/light color-scheme + icon contrast */
-[data-theme="dark"] .themed-time-input {
-  color-scheme: dark;
-}
-
-[data-theme="light"] .themed-time-input {
-  color-scheme: light;
-}
-
-.themed-time-input::-webkit-calendar-picker-indicator {
-  filter: var(--time-icon-filter, none);
-  cursor: pointer;
-}
-
-[data-theme="dark"] .themed-time-input::-webkit-calendar-picker-indicator {
-  filter: invert(0.8) sepia(0.1) saturate(0.5) hue-rotate(160deg);
-}


### PR DESCRIPTION
## Summary
- Replace native `<input type="time">` with a custom `TimePicker` component that uses app fonts (Inconsolata) and color scheme (accent/neutral palette)
- SVG clock icon with proper contrast in dark mode (uses `text-neutral-3` instead of CSS filter hack)
- Remove unused `themed-time-input` CSS rules from `index.css`

## Test plan
- [ ] Open Add Workflow modal → verify time picker dropdown uses monospace font and app colors
- [ ] Open Edit Workflow modal → same verification
- [ ] Click outside dropdown → verify it closes
- [ ] Press Escape → verify it closes
- [ ] Verify selected hour/minute scroll into view on open
- [ ] Check clock icon contrast in dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)