### PR TITLE
Fix sidebar repo ordering to sort alphabetically

### DIFF
--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -51,7 +51,11 @@ function buildRepoNodes(
     list.push(s)
     map.set(key, list)
   }
-  return Array.from(map.entries()).map(([key, repoSessions]) => ({
+  return Array.from(map.entries()).sort((a, b) => {
+    const nameA = a[0].replace(/\/+$/, '').split('/').pop() ?? a[0]
+    const nameB = b[0].replace(/\/+$/, '').split('/').pop() ?? b[0]
+    return nameA.localeCompare(nameB)
+  }).map(([key, repoSessions]) => ({
     workingDir: key,
     displayName: repoDisplayName(key),
     sessions: repoSessions,


### PR DESCRIPTION
## Summary
- The previous fix (fb8cbbb) only sorted repos in the new-session repo picker dropdown
- The sidebar's `buildRepoNodes` used `Map` insertion order, so repos appeared in session creation order
- Added `.sort()` by display name so the sidebar repo tree is always alphabetical

## Test plan
- [ ] Open Codekin with multiple repos having active sessions
- [ ] Verify sidebar repos are listed in alphabetical order
- [ ] Create a new session in a repo that would sort first — confirm it appears at the top

🤖 Generated with [Claude Code](https://claude.com/claude-code)