### PR TITLE
Add model selection to workflow definitions

### DIFF
--- a/server/workflow-config.ts
+++ b/server/workflow-config.ts
@@ -22,6 +22,8 @@ export interface ReviewRepoConfig {
   /** Workflow kind to run. Defaults to 'code-review.daily'. */
   kind?: string
   customPrompt?: string
+  /** Claude model to use for this workflow (e.g. 'claude-sonnet-4-6'). Omit for system default. */
+  model?: string
 }
 
 export interface WorkflowConfig {

--- a/server/workflow-loader.ts
+++ b/server/workflow-loader.ts
@@ -236,10 +236,11 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
           const repoPath = input.repoPath as string
           const repoName = (input.repoName as string) || repoPath.split('/').pop() || 'unknown'
 
+          const model = (input.model as string | undefined) || def.model
           const session = sessions.create(`${def.sessionPrefix}:${repoName}`, repoPath, {
             source: 'workflow',
             groupDir: repoPath,
-            model: def.model,
+            model,
           })
 
           console.log(`[workflow:${def.kind}] Created session ${session.id} for ${repoName} (run ${ctx.runId})`)

--- a/server/workflow-routes.ts
+++ b/server/workflow-routes.ts
@@ -69,7 +69,7 @@ export function syncSchedules(sessions?: SessionManager) {
       id: repo.id,
       kind: repo.kind ?? 'code-review.daily',
       cronExpression: repo.cronExpression,
-      input: { repoPath: repo.repoPath, repoName: repo.name, customPrompt: repo.customPrompt },
+      input: { repoPath: repo.repoPath, repoName: repo.name, customPrompt: repo.customPrompt, model: repo.model },
       enabled: repo.enabled,
     })
   }
@@ -248,7 +248,7 @@ export function createWorkflowRouter(verifyToken: VerifyFn, extractToken: Extrac
   })
 
   router.post('/config/repos', (req, res) => {
-    const { id, name, repoPath, cronExpression, enabled, customPrompt, kind } = req.body as Partial<ReviewRepoConfig>
+    const { id, name, repoPath, cronExpression, enabled, customPrompt, kind, model } = req.body as Partial<ReviewRepoConfig>
     if (!id || !name || !repoPath || !cronExpression) {
       return res.status(400).json({ error: 'Missing required fields: id, name, repoPath, cronExpression' })
     }
@@ -268,6 +268,7 @@ export function createWorkflowRouter(verifyToken: VerifyFn, extractToken: Extrac
       enabled: enabled !== false,
       kind,
       customPrompt,
+      model,
     })
 
     // Re-sync schedules with updated config

--- a/src/components/AddWorkflowModal.tsx
+++ b/src/components/AddWorkflowModal.tsx
@@ -13,7 +13,7 @@ import { useRepos } from '../hooks/useRepos'
 import { listKinds } from '../lib/workflowApi'
 import type { ReviewRepoConfig, WorkflowKindInfo } from '../lib/workflowApi'
 import {
-  WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL,
+  WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL, MODEL_OPTIONS,
   buildCron, describeCron, slugify, kindCategory,
   isBiweeklyDow,
 } from '../lib/workflowHelpers'
@@ -31,6 +31,7 @@ interface FormState {
   cronMinute: number
   cronDow: string
   customPrompt: string
+  model: string
 }
 
 interface Props {
@@ -337,6 +338,27 @@ function StepSchedule({
         </div>
       </div>
 
+      {/* Model selection */}
+      <div>
+        <label className="block text-[13px] font-medium text-neutral-3 mb-2">Model</label>
+        <div className="flex gap-1.5">
+          {MODEL_OPTIONS.map(m => (
+            <button
+              key={m.value}
+              type="button"
+              onClick={() => onChange({ model: m.value })}
+              className={`rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors ${
+                form.model === m.value
+                  ? 'border-accent-6 bg-accent-9/40 text-accent-2'
+                  : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
+              }`}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
       <div>
         <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">
           Focus areas <span className="text-neutral-5 font-normal">(optional)</span>
@@ -369,6 +391,7 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
     cronMinute: 0,
     cronDow: '*',
     customPrompt: '',
+    model: '',
   })
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
@@ -412,6 +435,7 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
         kind: form.kind,
         enabled: true,
         customPrompt: form.customPrompt.trim() || undefined,
+        model: form.model || undefined,
       })
       onClose()
     } catch (err) {

--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -7,7 +7,7 @@ import { useState } from 'react'
 import { IconX, IconLoader2 } from '@tabler/icons-react'
 import type { ReviewRepoConfig } from '../lib/workflowApi'
 import {
-  WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL, isBiweeklyDow,
+  WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL, MODEL_OPTIONS, isBiweeklyDow,
   buildCron, parseCron, describeCron, kindLabel,
 } from '../lib/workflowHelpers'
 import { CategoryBadge } from './WorkflowBadges'
@@ -36,6 +36,7 @@ export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
     cronMinute: parsed.minute,
     cronDow: parsed.dow,
     customPrompt: repo.customPrompt ?? '',
+    model: repo.model ?? '',
   })
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
@@ -49,6 +50,7 @@ export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
         kind: form.kind,
         cronExpression: buildCron(form.cronHour, form.cronDow, form.cronMinute),
         customPrompt: form.customPrompt.trim() || undefined,
+        model: form.model || undefined,
       })
       onClose()
     } catch (err) {
@@ -159,6 +161,23 @@ export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
             )}
             <div className="mt-2 text-[13px] text-neutral-5">
               {describeCron(buildCron(form.cronHour, form.cronDow, form.cronMinute))}
+            </div>
+          </div>
+
+          {/* Model selection */}
+          <div>
+            <label className="block text-[13px] font-medium text-neutral-3 mb-2">Model</label>
+            <div className="flex gap-1.5">
+              {MODEL_OPTIONS.map(m => (
+                <button
+                  key={m.value}
+                  type="button"
+                  onClick={() => setForm(f => ({ ...f, model: m.value }))}
+                  className={btnClass(form.model === m.value)}
+                >
+                  {m.label}
+                </button>
+              ))}
             </div>
           </div>
 

--- a/src/lib/workflowApi.ts
+++ b/src/lib/workflowApi.ts
@@ -66,6 +66,7 @@ export interface ReviewRepoConfig {
   enabled: boolean
   kind?: string
   customPrompt?: string
+  model?: string
 }
 
 export interface WorkflowConfig {

--- a/src/lib/workflowHelpers.ts
+++ b/src/lib/workflowHelpers.ts
@@ -15,6 +15,12 @@ export const WORKFLOW_KINDS = [
   { value: 'complexity.weekly', label: 'Complexity Report', category: 'assessment' as WorkflowCategory },
 ]
 
+export const MODEL_OPTIONS = [
+  { value: '', label: 'Default (Opus)' },
+  { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+  { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
+]
+
 export const DAY_PRESETS = [
   { label: 'Daily', dow: '*' },
   { label: 'Weekdays', dow: '1-5' },


### PR DESCRIPTION
## Summary
- Adds optional `model` field to workflow MD frontmatter (e.g. `model: claude-sonnet-4-6`)
- Exposes model selection (Opus/Sonnet/Haiku) as button group in both Add Workflow and Edit Workflow modals
- Model flows through config → schedule input → session creation → Claude CLI `--model` flag
- Per-config model (UI) takes priority over per-definition model (frontmatter), with system default as final fallback

## Test plan
- [ ] Open Add Workflow modal → verify Model button group appears on Step 3 (Schedule)
- [ ] Select Sonnet, create workflow → verify config persists `model: claude-sonnet-4-6`
- [ ] Open Edit Workflow modal for existing workflow → verify model field reflects saved value
- [ ] Change model in edit modal → save → verify updated in config
- [ ] Trigger workflow manually → verify Claude spawns with correct `--model` flag
- [ ] Leave model as "Default (Opus)" → verify no `--model` flag is passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)