### PR TITLE
Add model label badge to workflow list rows

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Codekin</title>
-    <script type="module" crossorigin src="/assets/index-DPudnR8n.js"></script>
+    <script type="module" crossorigin src="/assets/index-DpGwZSiY.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-dNFIrKVU.css">
   </head>
   <body class="bg-neutral-12 text-neutral-2">

--- a/src/components/workflows/WorkflowRow.tsx
+++ b/src/components/workflows/WorkflowRow.tsx
@@ -8,7 +8,7 @@ import {
   IconPencil, IconTrash,
 } from '@tabler/icons-react'
 import type { WorkflowRun, WorkflowRunWithSteps, CronSchedule, ReviewRepoConfig } from '../../lib/workflowApi'
-import { kindLabel, describeCron } from '../../lib/workflowHelpers'
+import { kindLabel, describeCron, modelLabel } from '../../lib/workflowHelpers'
 import { StatusBadge } from '../WorkflowBadges'
 import { HealthDot } from './HealthDot'
 import { MiniRunRow } from './MiniRunRow'
@@ -64,6 +64,11 @@ export function WorkflowRow({
         <span className="text-[14px] text-neutral-5 whitespace-nowrap shrink-0">
           {schedule ? describeCron(schedule.cronExpression) : describeCron(repo.cronExpression)}
         </span>
+        {modelLabel(repo.model) && (
+          <span className="text-[12px] text-neutral-5 bg-neutral-9 rounded px-1.5 py-0.5 shrink-0">
+            {modelLabel(repo.model)}
+          </span>
+        )}
         {lastRun && (
           <>
             <StatusBadge status={lastRun.status} />

--- a/src/lib/workflowHelpers.ts
+++ b/src/lib/workflowHelpers.ts
@@ -109,6 +109,12 @@ export function describeCron(expr: string): string {
   return `Weekly ${dayName} at ${time}`
 }
 
+/** Look up the display label for a model value, e.g. `"claude-sonnet-4-6"` → `"Sonnet 4.6"`. Returns `null` for empty/default. */
+export function modelLabel(model: string | undefined): string | null {
+  if (!model) return null
+  return MODEL_OPTIONS.find(m => m.value === model)?.label ?? model
+}
+
 /** Look up the display label for a workflow kind, e.g. `"coverage.daily"` → `"Coverage Assessment"`. */
 export function kindLabel(kind: string): string {
   return WORKFLOW_KINDS.find(k => k.value === kind)?.label ?? kind


### PR DESCRIPTION
## Summary
- Display the selected model name (e.g. "Sonnet 4.6") as a compact pill badge in each workflow row
- Badge only appears for non-default models; default (Opus) shows no badge
- Added `modelLabel()` helper to map model IDs to friendly display names

## Test plan
- [ ] Verify workflows with a non-default model show the model badge
- [ ] Verify workflows using the default model show no badge
- [ ] Confirm badge styling fits within the row layout without overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)