### PR TITLE
Fix docs file picker not appearing on sidebar icon click

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,6 @@ import { deriveActivityLabel } from './lib/deriveActivityLabel'
 import { Settings } from './components/Settings'
 import { ChatView } from './components/ChatView'
 import { DocsBrowser } from './components/DocsBrowser'
-import { DocsFilePicker } from './components/DocsFilePicker'
 import { TodoPanel } from './components/TodoPanel'
 import { LeftSidebar } from './components/LeftSidebar'
 import { TentativeBanner } from './components/TentativeBanner'
@@ -418,17 +417,13 @@ export default function App() {
         onSendModule={handleSendModule}
         onNavigateToWorkflows={() => navigate('/workflows')}
         onBrowseDocs={handleBrowseDocs}
+        docsPickerOpen={docsBrowser.pickerOpen}
+        docsPickerRepoDir={docsBrowser.pickerRepoDir}
+        docsPickerFiles={docsBrowser.pickerFiles}
+        docsPickerLoading={docsBrowser.pickerLoading}
+        onDocsPickerSelect={handleSelectDocFile}
+        onDocsPickerClose={docsBrowser.closePicker}
       />
-
-      {/* Docs file picker (floating, anchored to sidebar) */}
-      {docsBrowser.pickerOpen && (
-        <DocsFilePicker
-          files={docsBrowser.pickerFiles}
-          loading={docsBrowser.pickerLoading}
-          onSelect={handleSelectDocFile}
-          onClose={docsBrowser.closePicker}
-        />
-      )}
 
       {/* Main area */}
       <div className="terminal-area flex flex-1 flex-col overflow-hidden bg-neutral-12">

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -97,6 +97,12 @@ interface Props {
   onSendModule: (mod: Module) => void
   onNavigateToWorkflows: () => void
   onBrowseDocs?: (workingDir: string) => void
+  docsPickerOpen?: boolean
+  docsPickerRepoDir?: string | null
+  docsPickerFiles?: { path: string; pinned: boolean }[]
+  docsPickerLoading?: boolean
+  onDocsPickerSelect?: (filePath: string) => void
+  onDocsPickerClose?: () => void
 }
 
 // --------------------------------------------------------------------------
@@ -132,6 +138,12 @@ export function LeftSidebar({
   onSendModule,
   onNavigateToWorkflows,
   onBrowseDocs,
+  docsPickerOpen,
+  docsPickerRepoDir,
+  docsPickerFiles,
+  docsPickerLoading,
+  onDocsPickerSelect,
+  onDocsPickerClose,
 }: Props) {
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem('codekin-left-sidebar-collapsed') === 'true')
   const [width, setWidth] = useState(() => {
@@ -329,6 +341,12 @@ export function LeftSidebar({
             onDeleteRepo={onDeleteRepo}
             onViewArchivedSession={setArchiveViewSessionId}
             onBrowseDocs={onBrowseDocs}
+            docsPickerOpen={docsPickerOpen}
+            docsPickerRepoDir={docsPickerRepoDir}
+            docsPickerFiles={docsPickerFiles}
+            docsPickerLoading={docsPickerLoading}
+            onDocsPickerSelect={onDocsPickerSelect}
+            onDocsPickerClose={onDocsPickerClose}
           />
         ))}
 

--- a/src/components/RepoSection.tsx
+++ b/src/components/RepoSection.tsx
@@ -13,6 +13,7 @@ import {
 import type { Session } from '../types'
 import { listArchivedSessions, type ArchivedSessionInfo } from '../lib/ccApi'
 import { ApprovalsPanel } from './ApprovalsPanel'
+import { DocsFilePicker } from './DocsFilePicker'
 
 const ARCHIVED_PREVIEW_LIMIT = 5
 
@@ -88,6 +89,12 @@ export interface RepoSectionProps {
   onDeleteRepo: (workingDir: string) => void
   onViewArchivedSession: (id: string) => void
   onBrowseDocs?: (workingDir: string) => void
+  docsPickerOpen?: boolean
+  docsPickerRepoDir?: string | null
+  docsPickerFiles?: { path: string; pinned: boolean }[]
+  docsPickerLoading?: boolean
+  onDocsPickerSelect?: (filePath: string) => void
+  onDocsPickerClose?: () => void
 }
 
 // --------------------------------------------------------------------------
@@ -110,6 +117,12 @@ export function RepoSection({
   onDeleteRepo,
   onViewArchivedSession,
   onBrowseDocs,
+  docsPickerOpen,
+  docsPickerRepoDir,
+  docsPickerFiles,
+  docsPickerLoading,
+  onDocsPickerSelect,
+  onDocsPickerClose,
 }: RepoSectionProps) {
   const [expanded, setExpanded] = useState(isActive)
   const [approvalsOpen, setApprovalsOpen] = useState(false)
@@ -172,13 +185,23 @@ export function RepoSection({
           )}
         </button>
         {onBrowseDocs && (
-          <button
-            onClick={(e) => { e.stopPropagation(); onBrowseDocs(node.workingDir) }}
-            className="flex-shrink-0 rounded p-0.5 transition-colors opacity-0 group-hover:opacity-100 text-neutral-5 hover:text-neutral-2"
-            title="Browse docs"
-          >
-            <IconFileText size={14} stroke={2} />
-          </button>
+          <div className="relative flex-shrink-0">
+            <button
+              onClick={(e) => { e.stopPropagation(); onBrowseDocs(node.workingDir) }}
+              className="rounded p-0.5 transition-colors opacity-0 group-hover:opacity-100 text-neutral-5 hover:text-neutral-2"
+              title="Browse docs"
+            >
+              <IconFileText size={14} stroke={2} />
+            </button>
+            {docsPickerOpen && docsPickerRepoDir === node.workingDir && onDocsPickerSelect && onDocsPickerClose && (
+              <DocsFilePicker
+                files={docsPickerFiles ?? []}
+                loading={docsPickerLoading ?? false}
+                onSelect={onDocsPickerSelect}
+                onClose={onDocsPickerClose}
+              />
+            )}
+          </div>
         )}
         <button
           onClick={() => setApprovalsOpen(!approvalsOpen)}


### PR DESCRIPTION
## Summary
- The `DocsFilePicker` was rendered at the App level with `position: absolute` but no positioned ancestor, causing it to render off-screen (click did nothing)
- Moved picker rendering into `RepoSection` next to the doc icon button, wrapped in a `relative` container so it anchors correctly
- Picker state props are now passed through `LeftSidebar` → `RepoSection`

## Test plan
- [ ] Click the doc icon on a repo row in the sidebar — file picker should appear anchored to the icon
- [ ] Select a file from the picker — doc viewer should open
- [ ] Click outside the picker — it should close
- [ ] Verify picker appears for the correct repo when multiple repos are listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)