### PR TITLE
Fix Settings panel contrast in light mode

### DIFF
--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -45,7 +45,7 @@ interface Props {
 // ---------------------------------------------------------------------------
 function SectionCard({ icon, title, children }: { icon: React.ReactNode; title: string; children: React.ReactNode }) {
   return (
-    <section className="rounded-lg border border-neutral-9/60 bg-neutral-10/30">
+    <section className="settings-section-card rounded-lg border border-neutral-9/60 bg-neutral-10/30">
       <div className="flex items-center gap-2 px-4 py-3 border-b border-neutral-9/40">
         <span className="text-neutral-5">{icon}</span>
         <h3 className="text-[13px] font-semibold uppercase tracking-wide text-neutral-5">{title}</h3>

--- a/src/index.css
+++ b/src/index.css
@@ -394,6 +394,16 @@
   background-color: color-mix(in srgb, var(--color-neutral-7) 90%, transparent);
 }
 
+/* Settings section cards — stronger contrast in light mode */
+[data-theme="light"] .settings-section-card {
+  background-color: var(--color-neutral-12);
+  border-color: var(--color-neutral-7);
+}
+
+[data-theme="light"] .settings-section-card > div:first-child {
+  border-color: var(--color-neutral-7);
+}
+
 /* User message bubble — darker background in light mode */
 [data-theme="light"] .terminal-area .user-bubble {
   background-color: color-mix(in srgb, var(--color-neutral-8) 80%, transparent);


### PR DESCRIPTION
## Summary
- Section cards in the Settings modal were nearly invisible in light mode because `neutral-9`, `neutral-10`, and `neutral-11` are too close in the light palette
- Added light-mode CSS overrides for `.settings-section-card` using `neutral-12` (background) and `neutral-7` (borders) for clear visual separation

## Test plan
- [ ] Open Settings in light mode and verify section cards are clearly visible
- [ ] Confirm dark mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)