### PR TITLE
Convert DocsFilePicker from popup to inline scrollable list

### DIFF
--- a/src/components/DocsFilePicker.tsx
+++ b/src/components/DocsFilePicker.tsx
@@ -1,12 +1,13 @@
 /**
- * DocsFilePicker — dropdown showing available .md files for a repo.
+ * DocsFilePicker — inline scrollable list of .md files for a repo.
  *
- * Anchored to the doc icon on the repo row. Pinned files (CLAUDE.md, README.md)
- * appear first, separated by a divider from the rest.
+ * Rendered inside the sidebar (like archived sessions), with a search filter
+ * and scrollable list capped at ~10 visible items. Pinned files (CLAUDE.md,
+ * README.md) appear first, separated by a divider from the rest.
  */
 
-import { useEffect, useRef } from 'react'
-import { IconLoader2 } from '@tabler/icons-react'
+import { useState, useEffect, useRef } from 'react'
+import { IconLoader2, IconFileText } from '@tabler/icons-react'
 
 interface DocFile {
   path: string
@@ -21,62 +22,77 @@ interface Props {
 }
 
 export function DocsFilePicker({ files, loading, onSelect, onClose }: Props) {
+  const [search, setSearch] = useState('')
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
-    function handleClick(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        onClose()
-      }
-    }
     function handleKey(e: KeyboardEvent) {
       if (e.key === 'Escape') onClose()
     }
-    document.addEventListener('mousedown', handleClick)
     document.addEventListener('keydown', handleKey)
-    return () => {
-      document.removeEventListener('mousedown', handleClick)
-      document.removeEventListener('keydown', handleKey)
-    }
+    return () => document.removeEventListener('keydown', handleKey)
   }, [onClose])
 
-  const pinned = files.filter(f => f.pinned)
-  const rest = files.filter(f => !f.pinned)
+  const filtered = search.trim()
+    ? files.filter(f => f.path.toLowerCase().includes(search.toLowerCase()))
+    : files
+
+  const pinned = filtered.filter(f => f.pinned)
+  const rest = filtered.filter(f => !f.pinned)
 
   return (
-    <div
-      ref={ref}
-      className="absolute left-full top-0 ml-1 w-64 z-50 rounded-md border border-neutral-10 bg-neutral-12 py-1 shadow-lg"
-    >
+    <div ref={ref} className="mt-1 border-t border-neutral-8/30 pt-1">
       {loading ? (
         <div className="flex items-center justify-center py-3">
           <IconLoader2 size={14} className="animate-spin text-neutral-5" />
         </div>
       ) : files.length === 0 ? (
-        <div className="text-[13px] text-neutral-5 px-3 py-2">No markdown files found</div>
+        <div className="pl-10 pr-2 py-1 text-[13px] text-neutral-5">No markdown files found</div>
       ) : (
         <>
-          {pinned.map(f => (
-            <button
-              key={f.path}
-              onClick={() => onSelect(f.path)}
-              className="w-full text-left px-3 py-1.5 text-[15px] text-neutral-2 font-medium hover:bg-neutral-10/50 transition-colors cursor-pointer"
-            >
-              {f.path}
-            </button>
-          ))}
-          {pinned.length > 0 && rest.length > 0 && (
-            <div className="border-t border-neutral-10 my-1" />
+          {files.length > 5 && (
+            <div className="px-2 pb-1">
+              <input
+                type="text"
+                value={search}
+                onChange={e => setSearch(e.target.value)}
+                placeholder="Filter docs..."
+                autoFocus
+                className="w-full rounded border border-neutral-7 bg-neutral-10/50 px-2 py-1 text-[13px] text-neutral-2 placeholder-neutral-5 focus:border-accent-6 focus:outline-none"
+              />
+            </div>
           )}
-          {rest.map(f => (
-            <button
-              key={f.path}
-              onClick={() => onSelect(f.path)}
-              className="w-full text-left px-3 py-1.5 text-[15px] text-neutral-4 hover:bg-neutral-10/50 transition-colors cursor-pointer"
-            >
-              {f.path}
-            </button>
-          ))}
+          <div className="overflow-y-auto" style={{ maxHeight: '320px' }}>
+            {filtered.length === 0 ? (
+              <div className="pl-10 pr-2 py-1 text-[13px] text-neutral-5">No matching files</div>
+            ) : (
+              <>
+                {pinned.map(f => (
+                  <button
+                    key={f.path}
+                    onClick={() => onSelect(f.path)}
+                    className="group w-full flex items-center gap-2 pl-10 pr-2 py-1 text-left text-[15px] text-neutral-2 font-medium hover:bg-neutral-6/50 hover:text-neutral-1 transition-colors cursor-pointer rounded-md"
+                  >
+                    <IconFileText size={13} className="flex-shrink-0 text-neutral-5" />
+                    <span className="flex-1 truncate">{f.path}</span>
+                  </button>
+                ))}
+                {pinned.length > 0 && rest.length > 0 && (
+                  <div className="border-t border-neutral-8/30 my-0.5 mx-10" />
+                )}
+                {rest.map(f => (
+                  <button
+                    key={f.path}
+                    onClick={() => onSelect(f.path)}
+                    className="group w-full flex items-center gap-2 pl-10 pr-2 py-1 text-left text-[15px] text-neutral-4 hover:bg-neutral-6/50 hover:text-neutral-2 transition-colors cursor-pointer rounded-md"
+                  >
+                    <IconFileText size={13} className="flex-shrink-0 text-neutral-6" />
+                    <span className="flex-1 truncate">{f.path}</span>
+                  </button>
+                ))}
+              </>
+            )}
+          </div>
         </>
       )}
     </div>

--- a/src/components/RepoSection.tsx
+++ b/src/components/RepoSection.tsx
@@ -185,23 +185,15 @@ export function RepoSection({
           )}
         </button>
         {onBrowseDocs && (
-          <div className="relative flex-shrink-0">
-            <button
-              onClick={(e) => { e.stopPropagation(); onBrowseDocs(node.workingDir) }}
-              className="rounded p-0.5 transition-colors opacity-0 group-hover:opacity-100 text-neutral-5 hover:text-neutral-2"
-              title="Browse docs"
-            >
-              <IconFileText size={14} stroke={2} />
-            </button>
-            {docsPickerOpen && docsPickerRepoDir === node.workingDir && onDocsPickerSelect && onDocsPickerClose && (
-              <DocsFilePicker
-                files={docsPickerFiles ?? []}
-                loading={docsPickerLoading ?? false}
-                onSelect={onDocsPickerSelect}
-                onClose={onDocsPickerClose}
-              />
-            )}
-          </div>
+          <button
+            onClick={(e) => { e.stopPropagation(); onBrowseDocs(node.workingDir) }}
+            className={`flex-shrink-0 rounded p-0.5 transition-colors opacity-0 group-hover:opacity-100 ${
+              docsPickerOpen && docsPickerRepoDir === node.workingDir ? 'text-primary-5 opacity-100!' : 'text-neutral-5 hover:text-neutral-2'
+            }`}
+            title="Browse docs"
+          >
+            <IconFileText size={14} stroke={2} />
+          </button>
         )}
         <button
           onClick={() => setApprovalsOpen(!approvalsOpen)}
@@ -307,6 +299,16 @@ export function RepoSection({
                 <span>New session</span>
               </button>
             </div>
+          )}
+
+          {/* Inline docs picker */}
+          {docsPickerOpen && docsPickerRepoDir === node.workingDir && onDocsPickerSelect && onDocsPickerClose && (
+            <DocsFilePicker
+              files={docsPickerFiles ?? []}
+              loading={docsPickerLoading ?? false}
+              onSelect={onDocsPickerSelect}
+              onClose={onDocsPickerClose}
+            />
           )}
 
           {/* Inline approvals */}


### PR DESCRIPTION
## Summary
- Replaced the absolutely-positioned popup (hidden behind terminal view) with an inline scrollable list rendered in the sidebar
- Capped at ~10 visible items (320px max-height) with overflow scroll for repos with many markdown files
- Search filter auto-appears when there are more than 5 files
- Docs icon now highlights when picker is open, matching approvals/archive button style

## Test plan
- [ ] Open docs picker on a repo — verify it renders inline in the sidebar below sessions
- [ ] Confirm scrolling works when there are many .md files
- [ ] Verify search filter appears for repos with 6+ markdown files
- [ ] Check Escape key closes the picker
- [ ] Verify pinned files (CLAUDE.md, README.md) still appear first with divider

🤖 Generated with [Claude Code](https://claude.com/claude-code)