### PR TITLE
Invert docs browser header for clear terminal distinction

### DIFF
--- a/src/components/DocsBrowser.tsx
+++ b/src/components/DocsBrowser.tsx
@@ -31,24 +31,22 @@ export function DocsBrowser({
 }: Props) {
   return (
     <div className="relative flex flex-1 min-h-0 w-full flex-col">
-      {/* Nav bar */}
-      <div className="flex items-center gap-2 px-4 py-2 border-b border-neutral-10 bg-neutral-11/50 flex-shrink-0">
+      {/* Nav bar — inverted colors so it's clearly distinct from terminal */}
+      <div className="docs-header flex items-center gap-2 px-4 py-2 border-b flex-shrink-0">
         <button
           onClick={onClose}
-          className="flex items-center gap-1 text-[13px] text-neutral-4 hover:text-neutral-1 transition-colors cursor-pointer"
+          className="docs-header-back flex items-center gap-1 text-[13px] transition-colors cursor-pointer"
         >
           <IconChevronLeft size={14} stroke={2.5} />
           Back
         </button>
-        <span className="flex-1 text-[13px] text-neutral-5 text-center truncate">
-          {repoName} <span className="text-neutral-7">/</span> {filePath}
+        <span className="docs-header-path flex-1 text-[13px] text-center truncate">
+          {repoName} <span className="docs-header-slash">/</span> {filePath}
         </span>
         <button
           onClick={onToggleRaw}
-          className={`rounded px-2 py-0.5 text-[13px] transition-colors cursor-pointer ${
-            rawMode
-              ? 'bg-neutral-9 text-neutral-2'
-              : 'text-neutral-5 hover:text-neutral-2 hover:bg-neutral-9'
+          className={`docs-header-toggle rounded px-2 py-0.5 text-[13px] transition-colors cursor-pointer ${
+            rawMode ? 'is-active' : ''
           }`}
         >
           {rawMode ? 'Rendered' : 'Raw'}

--- a/src/index.css
+++ b/src/index.css
@@ -664,6 +664,37 @@ html, body, #root {
   border: 1px solid var(--color-neutral-9);
 }
 
+/* ── Docs browser header (inverted) ────────────────────────────────────── */
+/* Inverted neutral colors so the header clearly signals "not terminal". */
+
+.docs-header {
+  background: var(--color-neutral-2);
+  border-color: var(--color-neutral-3);
+}
+.docs-header-back {
+  color: var(--color-neutral-8);
+}
+.docs-header-back:hover {
+  color: var(--color-neutral-11);
+}
+.docs-header-path {
+  color: var(--color-neutral-6);
+}
+.docs-header-slash {
+  color: var(--color-neutral-5);
+}
+.docs-header-toggle {
+  color: var(--color-neutral-7);
+}
+.docs-header-toggle:hover {
+  color: var(--color-neutral-10);
+  background: var(--color-neutral-4);
+}
+.docs-header-toggle.is-active {
+  background: var(--color-neutral-5);
+  color: var(--color-neutral-11);
+}
+
 /* ── Docs browser prose ────────────────────────────────────────────────── */
 /* Scoped styles for rendered markdown in the docs browser.
    Uses Lato for body text (distinct from monospace chat) and


### PR DESCRIPTION
## Summary
- Inverts the docs browser nav bar colors so it uses the opposite end of the neutral scale — dark header in light mode, light header in dark mode
- Replaces inline Tailwind classes with scoped CSS classes (`.docs-header`, `.docs-header-back`, etc.) using CSS custom properties for proper `data-theme` support
- Makes it immediately obvious to users that they're viewing a document, not a terminal session

## Test plan
- [ ] Open a markdown doc in dark mode — header should appear with a light/contrasted background
- [ ] Switch to light mode — header should appear with a dark background
- [ ] Verify Back button, file path, and Raw/Rendered toggle are all readable in both themes
- [ ] Verify hover states work on Back button and toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)