### PR TITLE
Add star/favourite toggle for MD docs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -423,6 +423,7 @@ export default function App() {
         docsPickerLoading={docsBrowser.pickerLoading}
         onDocsPickerSelect={handleSelectDocFile}
         onDocsPickerClose={docsBrowser.closePicker}
+        docsStarredDocs={docsBrowser.starredDocs}
       />
 
       {/* Main area */}
@@ -461,7 +462,9 @@ export default function App() {
               loading={docsBrowser.loading}
               error={docsBrowser.error}
               rawMode={docsBrowser.rawMode}
+              isStarred={docsBrowser.isCurrentFileStarred}
               onToggleRaw={docsBrowser.toggleRawMode}
+              onToggleStar={docsBrowser.toggleStarCurrentFile}
               onClose={docsBrowser.close}
             />
             {/* Input bar in docs mode */}

--- a/src/components/DocsBrowser.tsx
+++ b/src/components/DocsBrowser.tsx
@@ -1,11 +1,11 @@
 /**
  * DocsBrowser — full document view replacing the message feed.
  *
- * Shows a nav bar with back button, file path, and raw/rendered toggle,
+ * Shows a nav bar with back button, file path, star toggle, and raw/rendered toggle,
  * followed by the rendered markdown content or raw source.
  */
 
-import { IconChevronLeft, IconLoader2 } from '@tabler/icons-react'
+import { IconChevronLeft, IconLoader2, IconStar, IconStarFilled } from '@tabler/icons-react'
 import { MarkdownRenderer } from './MarkdownRenderer'
 
 interface Props {
@@ -15,7 +15,9 @@ interface Props {
   loading: boolean
   error: string | null
   rawMode: boolean
+  isStarred: boolean
   onToggleRaw: () => void
+  onToggleStar: () => void
   onClose: () => void
 }
 
@@ -26,7 +28,9 @@ export function DocsBrowser({
   loading,
   error,
   rawMode,
+  isStarred,
   onToggleRaw,
+  onToggleStar,
   onClose,
 }: Props) {
   return (
@@ -43,6 +47,13 @@ export function DocsBrowser({
         <span className="docs-header-path flex-1 text-[13px] text-center truncate">
           {repoName} <span className="docs-header-slash">/</span> {filePath}
         </span>
+        <button
+          onClick={onToggleStar}
+          className={`docs-header-star transition-colors cursor-pointer ${isStarred ? 'is-starred' : ''}`}
+          title={isStarred ? 'Remove from favourites' : 'Add to favourites'}
+        >
+          {isStarred ? <IconStarFilled size={15} /> : <IconStar size={15} />}
+        </button>
         <button
           onClick={onToggleRaw}
           className={`docs-header-toggle rounded px-2 py-0.5 text-[13px] transition-colors cursor-pointer ${

--- a/src/components/DocsFilePicker.tsx
+++ b/src/components/DocsFilePicker.tsx
@@ -2,12 +2,12 @@
  * DocsFilePicker — inline scrollable list of .md files for a repo.
  *
  * Rendered inside the sidebar (like archived sessions), with a search filter
- * and scrollable list capped at ~10 visible items. Pinned files (CLAUDE.md,
- * README.md) appear first, separated by a divider from the rest.
+ * and scrollable list capped at ~10 visible items. Starred files appear first,
+ * then pinned files (CLAUDE.md, README.md), separated by dividers from the rest.
  */
 
 import { useState, useEffect, useRef } from 'react'
-import { IconLoader2, IconFileText } from '@tabler/icons-react'
+import { IconLoader2, IconFileText, IconStarFilled } from '@tabler/icons-react'
 
 interface DocFile {
   path: string
@@ -17,11 +17,12 @@ interface DocFile {
 interface Props {
   files: DocFile[]
   loading: boolean
+  starredDocs: string[]
   onSelect: (filePath: string) => void
   onClose: () => void
 }
 
-export function DocsFilePicker({ files, loading, onSelect, onClose }: Props) {
+export function DocsFilePicker({ files, loading, starredDocs, onSelect, onClose }: Props) {
   const [search, setSearch] = useState('')
   const ref = useRef<HTMLDivElement>(null)
 
@@ -33,12 +34,16 @@ export function DocsFilePicker({ files, loading, onSelect, onClose }: Props) {
     return () => document.removeEventListener('keydown', handleKey)
   }, [onClose])
 
+  const starredSet = new Set(starredDocs)
+
   const filtered = search.trim()
     ? files.filter(f => f.path.toLowerCase().includes(search.toLowerCase()))
     : files
 
-  const pinned = filtered.filter(f => f.pinned)
-  const rest = filtered.filter(f => !f.pinned)
+  const starred = filtered.filter(f => starredSet.has(f.path))
+  const pinned = filtered.filter(f => f.pinned && !starredSet.has(f.path))
+  const rest = filtered.filter(f => !f.pinned && !starredSet.has(f.path))
+  const hasGroups = (starred.length > 0 ? 1 : 0) + (pinned.length > 0 ? 1 : 0) + (rest.length > 0 ? 1 : 0) > 1
 
   return (
     <div ref={ref} className="mt-1 border-t border-neutral-8/30 pt-1">
@@ -67,6 +72,19 @@ export function DocsFilePicker({ files, loading, onSelect, onClose }: Props) {
               <div className="pl-10 pr-2 py-1 text-[13px] text-neutral-5">No matching files</div>
             ) : (
               <>
+                {starred.map(f => (
+                  <button
+                    key={f.path}
+                    onClick={() => onSelect(f.path)}
+                    className="group w-full flex items-center gap-2 pl-10 pr-2 py-1 text-left text-[15px] text-neutral-2 font-medium hover:bg-neutral-6/50 hover:text-neutral-1 transition-colors cursor-pointer rounded-md"
+                  >
+                    <IconStarFilled size={13} className="flex-shrink-0 text-primary-5" />
+                    <span className="flex-1 truncate">{f.path}</span>
+                  </button>
+                ))}
+                {starred.length > 0 && hasGroups && (
+                  <div className="border-t border-neutral-8/30 my-0.5 mx-10" />
+                )}
                 {pinned.map(f => (
                   <button
                     key={f.path}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -103,6 +103,7 @@ interface Props {
   docsPickerLoading?: boolean
   onDocsPickerSelect?: (filePath: string) => void
   onDocsPickerClose?: () => void
+  docsStarredDocs?: string[]
 }
 
 // --------------------------------------------------------------------------
@@ -144,6 +145,7 @@ export function LeftSidebar({
   docsPickerLoading,
   onDocsPickerSelect,
   onDocsPickerClose,
+  docsStarredDocs,
 }: Props) {
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem('codekin-left-sidebar-collapsed') === 'true')
   const [width, setWidth] = useState(() => {
@@ -347,6 +349,7 @@ export function LeftSidebar({
             docsPickerLoading={docsPickerLoading}
             onDocsPickerSelect={onDocsPickerSelect}
             onDocsPickerClose={onDocsPickerClose}
+            docsStarredDocs={docsStarredDocs}
           />
         ))}
 

--- a/src/components/RepoSection.tsx
+++ b/src/components/RepoSection.tsx
@@ -95,6 +95,7 @@ export interface RepoSectionProps {
   docsPickerLoading?: boolean
   onDocsPickerSelect?: (filePath: string) => void
   onDocsPickerClose?: () => void
+  docsStarredDocs?: string[]
 }
 
 // --------------------------------------------------------------------------
@@ -123,6 +124,7 @@ export function RepoSection({
   docsPickerLoading,
   onDocsPickerSelect,
   onDocsPickerClose,
+  docsStarredDocs,
 }: RepoSectionProps) {
   const [expanded, setExpanded] = useState(isActive)
   const [approvalsOpen, setApprovalsOpen] = useState(false)
@@ -306,6 +308,7 @@ export function RepoSection({
             <DocsFilePicker
               files={docsPickerFiles ?? []}
               loading={docsPickerLoading ?? false}
+              starredDocs={docsStarredDocs ?? []}
               onSelect={onDocsPickerSelect}
               onClose={onDocsPickerClose}
             />

--- a/src/hooks/useDocsBrowser.ts
+++ b/src/hooks/useDocsBrowser.ts
@@ -2,16 +2,30 @@
  * Hook for the docs browser feature.
  *
  * Manages state for the file picker, selected file, content loading,
- * raw/rendered toggle, and open/close lifecycle.
+ * raw/rendered toggle, starred docs, and open/close lifecycle.
  */
 
 import { useState, useCallback } from 'react'
 
 const BASE = '/cc'
+const STARRED_KEY = 'codekin-starred-docs'
 
 interface DocFile {
   path: string
   pinned: boolean
+}
+
+/** Load starred doc paths from localStorage. Keyed by repo dir. */
+function loadStarred(): Record<string, string[]> {
+  try {
+    return JSON.parse(localStorage.getItem(STARRED_KEY) || '{}')
+  } catch {
+    return {}
+  }
+}
+
+function persistStarred(starred: Record<string, string[]>) {
+  localStorage.setItem(STARRED_KEY, JSON.stringify(starred))
 }
 
 interface UseDocsBrowserReturn {
@@ -46,6 +60,13 @@ interface UseDocsBrowserReturn {
   closePicker: () => void
   /** The repo working dir for the open picker. */
   pickerRepoDir: string | null
+
+  /** Starred docs — persisted per-repo in localStorage. */
+  starredDocs: string[]
+  /** Whether the currently viewed file is starred. */
+  isCurrentFileStarred: boolean
+  /** Toggle star on the currently viewed file. */
+  toggleStarCurrentFile: () => void
 }
 
 export function useDocsBrowser(): UseDocsBrowserReturn {
@@ -60,6 +81,8 @@ export function useDocsBrowser(): UseDocsBrowserReturn {
   const [pickerFiles, setPickerFiles] = useState<DocFile[]>([])
   const [pickerLoading, setPickerLoading] = useState(false)
   const [pickerRepoDir, setPickerRepoDir] = useState<string | null>(null)
+
+  const [starred, setStarred] = useState<Record<string, string[]>>(loadStarred)
 
   const openPicker = useCallback(async (repoDir: string, token: string) => {
     setPickerRepoDir(repoDir)
@@ -119,6 +142,25 @@ export function useDocsBrowser(): UseDocsBrowserReturn {
     setRawMode(prev => !prev)
   }, [])
 
+  const currentRepoStarred = repoWorkingDir ? (starred[repoWorkingDir] ?? []) : []
+  const isCurrentFileStarred = selectedFile !== null && currentRepoStarred.includes(selectedFile)
+
+  const toggleStarCurrentFile = useCallback(() => {
+    if (!repoWorkingDir || !selectedFile) return
+    setStarred(prev => {
+      const repoStarred = prev[repoWorkingDir] ?? []
+      const next = repoStarred.includes(selectedFile)
+        ? repoStarred.filter(f => f !== selectedFile)
+        : [...repoStarred, selectedFile]
+      const updated = { ...prev, [repoWorkingDir]: next }
+      persistStarred(updated)
+      return updated
+    })
+  }, [repoWorkingDir, selectedFile])
+
+  /** Starred docs for the picker's currently open repo. */
+  const pickerStarred = pickerRepoDir ? (starred[pickerRepoDir] ?? []) : []
+
   return {
     isOpen: selectedFile !== null,
     selectedFile,
@@ -136,5 +178,8 @@ export function useDocsBrowser(): UseDocsBrowserReturn {
     openPicker,
     closePicker,
     pickerRepoDir,
+    starredDocs: pickerStarred,
+    isCurrentFileStarred,
+    toggleStarCurrentFile,
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -690,6 +690,15 @@ html, body, #root {
   color: var(--color-neutral-10);
   background: var(--color-neutral-4);
 }
+.docs-header-star {
+  color: var(--color-neutral-6);
+}
+.docs-header-star:hover {
+  color: var(--color-primary-5);
+}
+.docs-header-star.is-starred {
+  color: var(--color-primary-5);
+}
 .docs-header-toggle.is-active {
   background: var(--color-neutral-5);
   color: var(--color-neutral-11);


### PR DESCRIPTION
## Summary
- Adds a star button to the docs browser header to mark files as favourites
- Starred state is persisted per-repo in localStorage (`codekin-starred-docs`)
- Starred docs appear first in the file picker list with a gold star icon, above pinned and regular files

## Test plan
- [ ] Open a markdown doc and click the star button — it should toggle between outline and filled star
- [ ] Close and reopen the doc — star state should persist
- [ ] Open the file picker — starred docs should appear at the top with a gold star icon
- [ ] Star docs in different repos — each repo maintains its own starred list

🤖 Generated with [Claude Code](https://claude.com/claude-code)