### PR TITLE
Fix sidebar session timestamp vertical alignment

### DIFF
--- a/src/components/RepoSection.tsx
+++ b/src/components/RepoSection.tsx
@@ -270,7 +270,7 @@ export function RepoSection({
                 )}
                 {!isEditing && (
                   <>
-                    <span className="text-[13px] text-neutral-6 tabular-nums flex-shrink-0">{compactAge(s.created)}</span>
+                    <span className="text-[13px] leading-[15px] text-neutral-6 tabular-nums flex-shrink-0">{compactAge(s.created)}</span>
                     <span
                       onClick={e => { e.stopPropagation(); startEditing(s) }}
                       className="cursor-pointer flex-shrink-0 text-transparent group-hover:text-neutral-5 hover:text-neutral-2! transition-colors"
@@ -340,7 +340,7 @@ export function RepoSection({
                     >
                       <IconArchive size={12} className="flex-shrink-0 opacity-40" />
                       <span className="flex-1 truncate">{archivedDisplayName(s)}</span>
-                      <span className="shrink-0 text-[13px] text-neutral-6 tabular-nums">{archivedCompactAge(s.archivedAt)}</span>
+                      <span className="shrink-0 text-[13px] leading-[15px] text-neutral-6 tabular-nums">{archivedCompactAge(s.archivedAt)}</span>
                     </button>
                   ))}
                   {hasMore && !archiveExpanded && (


### PR DESCRIPTION
## Summary
- Fixed timestamp text (13px) appearing slightly too high relative to session name text (15px) in sidebar session items
- Added explicit `leading-[15px]` to timestamp spans in both active and archived session rows to match the visual line height of adjacent text

## Test plan
- [ ] Verify timestamps in sidebar session list align vertically with session names
- [ ] Check archived session timestamps also align correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)