### PR TITLE
Fix workflow light mode contrast and sidebar timestamp alignment

### DIFF
--- a/src/components/RepoSection.tsx
+++ b/src/components/RepoSection.tsx
@@ -240,17 +240,17 @@ export function RepoSection({
               <div
                 key={s.id}
                 onClick={() => { if (!isEditing) onSelectSession(s.id) }}
-                className={`group w-full flex items-center gap-2 pl-10 pr-2 py-1 text-left text-[15px] transition-colors rounded-md cursor-pointer ${
+                className={`group w-full flex items-baseline gap-2 pl-10 pr-2 py-1 text-left text-[15px] transition-colors rounded-md cursor-pointer ${
                   isActiveSession
                     ? 'bg-accent-9/30 text-accent-2'
                     : 'text-neutral-3 hover:bg-neutral-6/50 hover:text-neutral-1'
                 }`}
               >
                 {s.source === 'workflow'
-                  ? <IconSparkles size={12} className={`flex-shrink-0 ${dotColor.replace(/bg-/g, 'text-')}`} />
+                  ? <IconSparkles size={12} className={`flex-shrink-0 self-center ${dotColor.replace(/bg-/g, 'text-')}`} />
                   : s.source === 'webhook'
-                  ? <IconRobot size={12} className={`flex-shrink-0 ${dotColor.replace(/bg-/g, 'text-')}`} />
-                  : <span className="inline-flex items-center justify-center w-[12px] flex-shrink-0"><span className={`inline-block h-1.5 w-1.5 rounded-full ${dotColor}`} /></span>
+                  ? <IconRobot size={12} className={`flex-shrink-0 self-center ${dotColor.replace(/bg-/g, 'text-')}`} />
+                  : <span className="inline-flex items-center justify-center w-[12px] flex-shrink-0 self-center"><span className={`inline-block h-1.5 w-1.5 rounded-full ${dotColor}`} /></span>
                 }
                 {isEditing ? (
                   <input
@@ -270,7 +270,7 @@ export function RepoSection({
                 )}
                 {!isEditing && (
                   <>
-                    <span className="text-[13px] leading-[15px] text-neutral-6 tabular-nums flex-shrink-0">{compactAge(s.created)}</span>
+                    <span className="text-[13px] text-neutral-6 tabular-nums flex-shrink-0">{compactAge(s.created)}</span>
                     <span
                       onClick={e => { e.stopPropagation(); startEditing(s) }}
                       className="cursor-pointer flex-shrink-0 text-transparent group-hover:text-neutral-5 hover:text-neutral-2! transition-colors"
@@ -336,11 +336,11 @@ export function RepoSection({
                     <button
                       key={s.id}
                       onClick={() => onViewArchivedSession(s.id)}
-                      className="group w-full flex items-center gap-2 pl-12 pr-2 py-0.5 text-left text-[15px] text-neutral-4 hover:bg-neutral-6/50 hover:text-neutral-2 transition-colors"
+                      className="group w-full flex items-baseline gap-2 pl-12 pr-2 py-0.5 text-left text-[15px] text-neutral-4 hover:bg-neutral-6/50 hover:text-neutral-2 transition-colors"
                     >
-                      <IconArchive size={12} className="flex-shrink-0 opacity-40" />
+                      <IconArchive size={12} className="flex-shrink-0 self-center opacity-40" />
                       <span className="flex-1 truncate">{archivedDisplayName(s)}</span>
-                      <span className="shrink-0 text-[13px] leading-[15px] text-neutral-6 tabular-nums">{archivedCompactAge(s.archivedAt)}</span>
+                      <span className="shrink-0 text-[13px] text-neutral-6 tabular-nums">{archivedCompactAge(s.archivedAt)}</span>
                     </button>
                   ))}
                   {hasMore && !archiveExpanded && (

--- a/src/components/WorkflowsView.tsx
+++ b/src/components/WorkflowsView.tsx
@@ -200,7 +200,7 @@ export function WorkflowsView({ token, onNavigateToSession }: Props) {
             </button>
 
             {showActivity && (
-              <div className="rounded-lg border border-neutral-9/60 bg-neutral-10/30 py-1 divide-y divide-neutral-9/30">
+              <div className="workflow-card rounded-lg border border-neutral-9/60 bg-neutral-10/30 py-1 divide-y divide-neutral-9/30">
                 {runs.slice(0, 20).map(run => (
                   <ActivityRow
                     key={run.id}

--- a/src/components/workflows/CustomWorkflowGuide.tsx
+++ b/src/components/workflows/CustomWorkflowGuide.tsx
@@ -13,7 +13,7 @@ export function CustomWorkflowGuide() {
   const [open, setOpen] = useState(false)
 
   return (
-    <div className="mt-6 rounded-lg border border-neutral-9/60 bg-neutral-10/30">
+    <div className="workflow-card mt-6 rounded-lg border border-neutral-9/60 bg-neutral-10/30">
       <button
         onClick={() => setOpen(!open)}
         className="w-full flex items-center gap-2 px-4 py-3 text-left text-[15px] font-medium text-neutral-3 hover:text-neutral-1 transition-colors"

--- a/src/components/workflows/RepoGroup.tsx
+++ b/src/components/workflows/RepoGroup.tsx
@@ -43,7 +43,7 @@ export function RepoGroup({
   const repoName = repoPath.split('/').pop() || repoPath
 
   return (
-    <div className="rounded-lg border border-neutral-9/60 bg-neutral-10/30 overflow-hidden">
+    <div className="workflow-card rounded-lg border border-neutral-9/60 bg-neutral-10/30 overflow-hidden">
       {/* Repo header */}
       <div className="flex items-baseline gap-2 px-4 py-2.5 border-b border-neutral-9/40 bg-neutral-10/20">
         <span className="text-[15px] font-semibold text-neutral-2">{repoName}</span>

--- a/src/index.css
+++ b/src/index.css
@@ -404,6 +404,20 @@
   border-color: var(--color-neutral-7);
 }
 
+/* Workflow panel cards — match settings contrast in light mode */
+[data-theme="light"] .workflow-card {
+  background-color: var(--color-neutral-12);
+  border-color: var(--color-neutral-7);
+}
+
+[data-theme="light"] .workflow-card > div:first-child {
+  border-color: var(--color-neutral-7);
+}
+
+[data-theme="light"] .workflow-card .divide-neutral-9\/30 > :not(:first-child) {
+  border-color: var(--color-neutral-7);
+}
+
 /* User message bubble — darker background in light mode */
 [data-theme="light"] .terminal-area .user-bubble {
   background-color: color-mix(in srgb, var(--color-neutral-8) 80%, transparent);


### PR DESCRIPTION
## Summary
- **Workflow panels**: Previous PR #47 swapped near-identical Tailwind opacity shades (`neutral-8/50` → `neutral-9/60`) which produced no visible contrast change in light mode because those values are all near-white when inverted. This PR adds explicit `[data-theme="light"]` CSS overrides using the same approach as settings section cards (`bg-neutral-12` + `border-neutral-7`), matching the settings view contrast.
- **Sidebar timestamps**: Previous PR #46 added `leading-[15px]` which had no effect because the parent flex container used `items-center` (centers by box, not baseline). This PR switches to `items-baseline` so the 13px timestamp text aligns on the text baseline with the 15px session name. Icons get `self-center` to stay vertically centered.

## Test plan
- [ ] Verify workflow list panels have clear borders/backgrounds in light mode
- [ ] Verify sidebar session timestamps align with session names (no vertical offset)
- [ ] Verify archived session timestamps also align correctly
- [ ] Verify dark mode is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)