### PR TITLE
Fix repo health audit findings

### DIFF
--- a/.codekin/reports/repo-health/2026-03-09_repo-health.md
+++ b/.codekin/reports/repo-health/2026-03-09_repo-health.md
@@ -1,8 +1,14 @@
-# Repository Health Assessment — Codekin
+# Repository Health: codekin
 
-**Date**: 2026-03-09
-**Branch assessed**: `release/v0.3.0`
-**Assessed by**: Automated workflow (Claude claude-sonnet-4-6)
+**Date**: 2026-03-09T12:29:39.025Z
+**Repository**: /srv/repos/codekin
+**Branch**: release/v0.3.0
+**Workflow Run**: 089fa9be-3490-45f1-9eca-6817323bf3d4
+**Session**: 7bb09539-06ea-42c9-b47a-9da4e1fdc929
+
+---
+
+Yes, just finished gathering all the data. Now compiling the final report — one moment.Now I have all the data needed to write the full report. Let me save it to the reports directory.Here is the full report:
 
 ---
 
@@ -10,317 +16,162 @@
 
 **Overall Health: Good**
 
-Codekin is in a strong state following a burst of productive activity on 2026-03-08–09 that delivered 100+ commits across security hardening, feature additions, refactoring, and bug fixes. The codebase has zero TODO/FIXME debt, strict TypeScript enforcement in both frontend and server, and no open PRs. The primary maintenance concerns are cosmetic: a large backlog of merged-but-not-deleted remote branches, a significantly out-of-date CHANGELOG, and minor config inconsistencies.
+Codekin is in strong shape after a burst of 100+ commits on 2026-03-08–09. Zero TODO/FIXME debt, strict TypeScript enforced everywhere, no open PRs, and all dependencies appear MIT/permissive. The main maintenance concerns are cosmetic and hygiene-related.
 
-| Area | Status | Count |
-|---|---|---|
-| Dead code items | Low risk | ~6 exports flagged for review |
-| Stale TODOs | None | 0 |
-| Config issues | Minor | 2 |
-| License concerns | None | 0 |
-| Doc drift items | Minor | 2 |
-| Merged undeleted branches | 29 | cleanup recommended |
-| Active unmerged branches | 3 | (`release/v0.3.0`, `codekin/reports`, `feat/enforce-branching-policy`) |
-| Open PRs | None | 0 |
-| Stuck PRs | None | 0 |
+| Area | Status |
+|---|---|
+| Dead code | Low risk — ~6 exported symbols to review |
+| TODO/FIXME debt | **Clean** — 0 found |
+| Config issues | 2 minor (no Prettier, ESLint not on `strictTypeChecked`) |
+| License concerns | None |
+| Doc drift | 2 minor items (missing `model` field in WORKFLOWS.md, missing `auth` variant in protocol doc) |
+| CHANGELOG | **Significantly stale** — missing v0.1.8 through v0.3.0 |
+| Merged undeleted branches | **29** — all safe to delete |
+| Open / stuck PRs | 0 |
 
 ---
 
 ## Dead Code
 
-TypeScript's `noUnusedLocals: true` and `noUnusedParameters: true` are active in all tsconfigs, which means purely local dead code is caught at build time. The following items are **exported symbols** that escape that check and should be manually verified.
+TypeScript's `noUnusedLocals: true` catches local dead code at build time. Only *exported* symbols escape that check:
 
-| File | Export / Function | Type | Recommendation |
-|---|---|---|---|
-| `src/hooks/useChatSocket.ts` | `processMessage`, `trimMessages`, `rebuildFromHistory` | Potentially test-only exports | Confirm usage; if only used in tests, move to a non-exported internal or re-export from a test helper |
-| `src/components/workflows/StepCard.tsx` | `StepIcon`, `JsonBlock` | Internal helpers as public exports | Make private (unexported) if not used outside this file |
-| `src/lib/workflowHelpers.ts` | `slugify`, `repoNameFromRun`, `statusBadge` (and ~15 others) | Large utility surface | Audit imports; remove any functions not referenced in `src/` |
-| `server/webhook-github.ts` | `_setGhRunner()`, `_resetGhRunner()` | Test injection points | Intentional; acceptable pattern. Consider a `/** @internal */` JSDoc annotation |
-| `src/hooks/useSessionOrchestration.ts` | `groupKey()` | Utility export | Verify imported by consumers; unexport if internal-only |
-
-**Orphan file candidates**: None found. All hook and component files follow naming conventions matching their consumers. `noUnusedLocals` in tsconfig would surface any truly unreferenced local symbols at build time.
+| File | Export | Recommendation |
+|---|---|---|
+| `src/hooks/useChatSocket.ts` | `processMessage`, `trimMessages`, `rebuildFromHistory` | Likely test-only exports — verify or move to test helper |
+| `src/components/workflows/StepCard.tsx` | `StepIcon`, `JsonBlock` | Unexport if not used outside this file |
+| `src/lib/workflowHelpers.ts` | `slugify`, `repoNameFromRun`, `statusBadge` + ~15 others | Audit imports; remove any unreferenced functions |
+| `server/webhook-github.ts` | `_setGhRunner()`, `_resetGhRunner()` | Intentional test injection — add `@internal` JSDoc |
+| `src/hooks/useSessionOrchestration.ts` | `groupKey()` | Unexport if internal-only |
 
 ---
 
 ## TODO/FIXME Tracker
 
-A full grep across `src/`, `server/`, `docs/`, and config files found **zero** actionable `TODO`, `FIXME`, `HACK`, `XXX`, or `WORKAROUND` comments in source code.
+**Zero** actionable annotations found in any source file. The only grep matches were test fixture strings in `server/claude-process.test.ts`.
 
-The only matches were inside `server/claude-process.test.ts` (lines 60–61, 818) where `'TODO'` appears as a test fixture *value* passed to `summarizeToolInput('Grep', { pattern: 'TODO' })`. These are intentional test data strings, not debt markers.
-
-| Type | Count |
-|---|---|
-| TODO | 0 |
-| FIXME | 0 |
-| HACK | 0 |
-| XXX | 0 |
-| WORKAROUND | 0 |
-| **Total** | **0** |
-| Stale (>30 days) | 0 |
+| Type | Count | Stale |
+|---|---|---|
+| TODO / FIXME / HACK / XXX / WORKAROUND | 0 | 0 |
 
 ---
 
 ## Config Drift
 
-### tsconfig.app.json
-
-| Setting | Current Value | Recommendation | Status |
-|---|---|---|---|
-| `strict` | `true` | `true` | ✅ Good |
-| `noUnusedLocals` | `true` | `true` | ✅ Good |
-| `noUnusedParameters` | `true` | `true` | ✅ Good |
-| `target` | `ES2022` | ES2022+ | ✅ Good |
-| `noEmit` | `true` (frontend only) | Expected for Vite | ✅ Good |
-
-### tsconfig.node.json
-
-| Setting | Current Value | Recommendation | Status |
-|---|---|---|---|
-| `strict` | `true` | `true` | ✅ Good |
-| `target` | `ES2023` | ES2022+ | ✅ Good |
-| Scope | `vite.config.ts` only | — | ⚠️ `server/` has its own `tsconfig.json`; coverage verified separately |
-
-### Server tsconfig (`server/tsconfig.json`)
-
-Not present under the root composite — the server is compiled independently. Confirm `strict: true` is set in its own tsconfig; if missing, server code does not benefit from null-safety and strict checks.
-
-### eslint.config.js
-
-| Setting | Current Value | Recommendation | Status |
-|---|---|---|---|
-| Config format | Flat config (ESLint 9+) | Flat config | ✅ Modern |
-| React Hooks rules | `reactHooks.configs.flat.recommended` | Enabled | ✅ Good |
-| React Refresh rules | `reactRefresh.configs.vite` | Enabled | ✅ Good |
-| `@typescript-eslint` | `tseslint.configs.recommended` | Use `strict` variant for stronger guarantees | ⚠️ Consider upgrading to `tseslint.configs.strictTypeChecked` |
-| `no-explicit-any` disabled in tests | `@typescript-eslint/no-explicit-any: off` for `*.test.*` | Acceptable test exception | ✅ Acceptable |
-
-### Prettier
-
-No `.prettierrc` or `prettier.config.*` file exists in the repo root. Code formatting is not enforced by CI. This is a minor gap — if contributors have different editor settings, formatting drift can accumulate.
-
-**Findings summary**:
-1. **`tseslint.configs.recommended` (eslint.config.js)** — Consider upgrading to `strictTypeChecked` for stronger type-aware linting.
-2. **No Prettier config** — Formatting is unenforced; consider adding `.prettierrc` and a `lint:format` script.
-
-### package-lock.json version field
-
-The lock file header still reads `"version": "0.2.2"` even though `package.json` was bumped to `0.3.0`. This is cosmetic (the version field in lockfiles is informational, not functional), but it indicates `npm install` was not re-run after the version bump. Running `npm install` will update it.
+1. **`eslint.config.js`** — Using `tseslint.configs.recommended`; consider upgrading to `strictTypeChecked` for stronger guarantees (unsafe type assertions, unhandled promises, `any` leakage).
+2. **No Prettier config** — Formatting is unenforced; formatting drift can accumulate across contributors.
+3. **`package-lock.json` version field** — Still reads `0.2.2` after the `0.3.0` bump; run `npm install` to sync.
 
 ---
 
 ## License Compliance
 
-**Project license**: MIT
-
-All direct and dev dependencies were identified from `package.json`. Based on well-known package registries:
-
-| License | Count | Packages |
-|---|---|---|
-| MIT | ~22 | `react`, `react-dom`, `vite`, `tailwindcss`, `eslint`, `typescript`, `typescript-eslint`, `marked`, `marked-highlight`, `cmdk`, `remark-gfm`, `react-markdown`, `vitest`, `jsdom`, `@vitejs/plugin-react`, `@tabler/icons-react`, `globals`, `@types/*` (most) |
-| BSD-2-Clause | ~1 | `highlight.js` |
-| Apache-2.0 | ~1 | `dompurify` (also dual-licensed MIT/Apache) |
-| Unknown / unverified | — | License data not computed at runtime; verify with `npx license-checker --summary` |
-
-**Flagged dependencies**: None. No GPL, LGPL, AGPL, or copyleft licenses identified among known dependencies. All dependencies appear compatible with the project's MIT license.
-
-**Recommendation**: Run `npx license-checker --summary --excludePrivatePackages` to produce a definitive license audit with transitive dependencies included.
+**Project**: MIT. All identified dependencies (react, vite, tailwindcss, eslint, typescript, marked, dompurify, highlight.js, etc.) use MIT, Apache-2.0, or BSD licenses. No GPL/LGPL/AGPL detected. Run `npx license-checker --summary` for a full transitive audit.
 
 ---
 
 ## Documentation Freshness
 
-### README.md
+**README**: No drift detected. All scripts, paths, and feature descriptions match reality.
 
-The README is well-maintained and reflects the current install, usage, and configuration. Verified items:
-
-| README Item | Matches Reality? | Notes |
-|---|---|---|
-| `npm install -g codekin` install command | ✅ | npm package exists |
-| `npm run dev` / `npm run build` / `npm test` | ✅ | All present in `package.json` |
-| WebSocket server port 32352 | ✅ | Matches `CLAUDE.md` and server config |
-| Feature list (workflows, docs browser, webhooks) | ✅ | All features shipped in v0.3.0 |
-| Configuration table (`ANTHROPIC_API_KEY`, `REPOS_ROOT`, etc.) | ✅ | Matches server env var usage |
-
-**No README drift detected.**
-
-### API Docs Freshness
-
-| Doc File | Last Known Update | Recent Code Changes | Stale? |
-|---|---|---|---|
-| `docs/stream-json-protocol.md` | Pre-v0.3.0 (stable) | `server/types.ts` had an auth variant added (d2938f2) | ⚠️ Minor — WsClientMessage auth variant added; doc may not reflect it |
-| `docs/WORKFLOWS.md` | Pre-v0.3.0 | Workflow model field added (v0.3.0) | ⚠️ Minor — `model` frontmatter field added to workflow definitions; not documented |
-| `docs/GITHUB-WEBHOOKS-SPEC.md` | 2026-02-23 | Security hardening applied (94b498e) | ✅ Spec predates impl; security changes are impl details |
-| `docs/DOCS-BROWSER-SPEC.md` | 2026-03-09 | Feature fully implemented | ✅ Fresh |
-| `docs/CLAUDE-HOOKS-SPEC.md` | 2026-02-25 | No changes to hooks | ✅ Current |
-| `docs/FEATURES.md` | Pre-v0.3.0 | Docs browser, webhooks settings UI added | ⚠️ Minor — new features may not be listed |
-
-**Stale doc items** (2):
-1. `docs/stream-json-protocol.md` — The new `auth` variant of `WsClientMessage` (added in commit `d2938f2`) is not documented.
-2. `docs/WORKFLOWS.md` — The optional `model` frontmatter field (added in v0.3.0 via commits `3e24e83`, `a33e712`) is not documented in the workflow file format reference.
-
-### CHANGELOG
-
-**Significantly stale.** `CHANGELOG.md` only documents `v0.1.7`. Versions `v0.1.8`, `v0.2.0`, `v0.2.1`, `v0.2.2`, and `v0.3.0` are all missing entries. See Draft Changelog below.
+**Stale items**:
+1. `docs/WORKFLOWS.md` — The optional `model` frontmatter field added in v0.3.0 is not documented.
+2. `docs/stream-json-protocol.md` — The `auth` variant of `WsClientMessage` (commit `d2938f2`) is not in the client→server message table.
+3. `CHANGELOG.md` — Missing entries for v0.1.8, v0.2.0, v0.2.1, v0.2.2, and v0.3.0.
 
 ---
 
 ## Draft Changelog
 
-> Period: `v0.2.2` → `v0.3.0` (2026-03-08 – 2026-03-09)
-> Note: v0.1.8, v0.2.0, v0.2.1, v0.2.2 entries are also missing from CHANGELOG.md and should be reconstructed from git log for those ranges separately.
-
 ```markdown
 ## [0.3.0] - 2026-03-09
 
 ### Features
-- **Docs browser**: New in-app markdown docs browser accessible from the sidebar,
-  with inline file picker, keyboard navigation, inverted header, and star/favourite
-  persistence (#35, #33, #44, #43, #45, #48)
-- **Workflow model selection**: Workflows can now specify a Claude model via an
-  optional `model` frontmatter field; model badge shown in workflow list (#30, #31)
-- **GitHub Webhooks settings**: Settings panel now includes a GitHub Webhooks
-  configuration section (#40)
-- **Repository Health workflow**: New built-in `repo-health` assessment workflow type (#34)
-- **Custom TimePicker**: Native browser time input replaced with a custom themed
-  TimePicker component; bi-weekly frequency toggle added to schedule UI (#26, #27)
+- Docs browser: in-app markdown docs viewer with inline file picker,
+  keyboard navigation, inverted header, and star/favourite persistence
+- Workflow model selection: optional `model` frontmatter field; model badge in workflow list
+- GitHub Webhooks section in Settings panel
+- Repository Health built-in workflow type
+- Custom TimePicker component replacing native browser time input; bi-weekly frequency toggle
 
 ### Fixes
-- Fix workflow panel contrast in light mode (#47, #49)
-- Fix docs icon toggle: clicking again now closes the picker (#48)
-- Fix sidebar timestamp vertical alignment (#46)
-- Fix docs file picker not appearing when clicking sidebar doc icon (#39)
-- Fix docs API: switch from path params to query params (#37)
-- Fix sidebar session name bold and workflow list alignment (#38)
-- Fix sidebar repo ordering to sort alphabetically (#29)
-- Fix workflow `validate_repo` failing when `REPOS_ROOT` is a symlink (#25)
-- Fix Settings font sizes to match app conventions (#41)
-- Fix settings panel contrast in light mode (#42)
-- Remove tracked `dist/` files that caused stale asset references (#36)
-- Fix CI: restore `better-sqlite3` as root devDependency for tests
-- Add missing `auth` variant to server `WsClientMessage` type
+- Fix workflow panel contrast in light mode
+- Fix docs icon toggle (clicking again closes the picker)
+- Fix sidebar timestamp vertical alignment
+- Fix docs file picker not appearing on sidebar icon click
+- Fix docs API: switch from path params to query params
+- Fix sidebar session name bold and workflow list alignment
+- Fix sidebar repo ordering (alphabetical)
+- Fix workflow validate_repo failing when REPOS_ROOT is a symlink
+- Fix Settings font sizes and light mode contrast
+- Remove tracked dist/ files causing stale asset references
+- Fix CI: restore better-sqlite3 as root devDependency
+- Add missing auth variant to server WsClientMessage type
 
 ### Security
-- Implement critical findings from code review audit (H1–H3, M1–M6, L1–L4) (#32)
-- Implement critical findings from dependency audit
+- Implement critical code review audit findings (H1–H3, M1–M6, L1–L4)
+- Implement critical dependency audit findings
 
 ### Refactoring
-- Reduce code complexity across 7 modules per complexity audit (#28)
-- Refine `SessionManager` split: complete delegation to extracted modules
-- Improve Settings modal layout with section cards and wider form factor (#41)
-- Unify button styles and text sizing across workflow views
-- Improve workflow schedule UI: narrower time input, themed picker (#26)
+- Reduce complexity across 7 modules per complexity audit
+- Refine SessionManager split; complete delegation to extracted modules
+- Improve Settings modal layout with section cards
 
 ### Documentation
-- Add JSDoc and inline comments per comment audit recommendations (#22)
-- Add docs browser feature spec (`docs/DOCS-BROWSER-SPEC.md`) (#33)
+- Add JSDoc and inline comments per comment audit
+- Add docs/DOCS-BROWSER-SPEC.md
 
 ### Chores
+- Add 50 new tests from coverage audit
 - Bump version to 0.3.0
-- Add top-priority tests from coverage audit (50 new tests)
-- Add complexity, security, code-review, and dependency audit reports
 ```
 
 ---
 
 ## Stale Branches
 
-> "Stale" threshold: no commit activity in the last 30 days.
-> Given all repo activity is within the last 2 days, no branches are stale by the 30-day definition.
-> The relevant hygiene issue is **merged branches not yet deleted from the remote** (29 branches).
+No branches meet the 30-day staleness threshold (all activity is within 2 days). The primary hygiene issue is **29 merged branches not yet deleted from the remote**.
 
-### Merged branches still on remote (safe to delete)
+**All 29 merged branches** (docs/comment-audit-recommendations, feat/docs-browser, feat/docs-browser-spec, feat/docs-star-favourites, feat/redesign-workflow-view, feat/repo-health-workflow, feat/settings-webhook-section, feat/workflow-list-larger-fonts, feat/workflow-model-selection, fix/code-review-security-fixes, fix/custom-time-picker-styling, fix/dist-tracking-deploy, fix/docs-api-query-params, fix/docs-header-contrast, fix/docs-icon-toggle, fix/docs-picker-inline, fix/docs-picker-positioning, fix/remove-local-scripts, fix/security-audit-hardening, fix/settings-layout-cleanup, fix/settings-light-mode-contrast, fix/sidebar-alphabetical-sort, fix/sidebar-timestamp-alignment, fix/ui-sidebar-bold-workflow-alignment, fix/workflow-contrast-and-sidebar-timestamps, fix/workflow-model-display, fix/workflow-panel-contrast, fix/workflow-time-selector-and-biweekly-toggle, refactor/complexity-audit-2026-03, release/v0.2.0) → **Recommend deletion**.
 
-All 29 of the following branches are fully merged into `origin/main` and have no unique commits. They can be safely deleted.
+**Unmerged branches**:
 
-| Branch | Last Commit | Merged into main? | Recommendation |
-|---|---|---|---|
-| `origin/docs/comment-audit-recommendations` | 2026-03-08 | ✅ Yes | Delete |
-| `origin/feat/docs-browser` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/feat/docs-browser-spec` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/feat/docs-star-favourites` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/feat/redesign-workflow-view` | 2026-03-08 | ✅ Yes | Delete |
-| `origin/feat/repo-health-workflow` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/feat/settings-webhook-section` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/feat/workflow-list-larger-fonts` | 2026-03-08 | ✅ Yes | Delete |
-| `origin/feat/workflow-model-selection` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/code-review-security-fixes` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/custom-time-picker-styling` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/dist-tracking-deploy` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/docs-api-query-params` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/docs-header-contrast` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/docs-icon-toggle` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/docs-picker-inline` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/docs-picker-positioning` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/remove-local-scripts` | 2026-03-08 | ✅ Yes | Delete |
-| `origin/fix/security-audit-hardening` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/settings-layout-cleanup` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/settings-light-mode-contrast` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/sidebar-alphabetical-sort` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/sidebar-timestamp-alignment` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/ui-sidebar-bold-workflow-alignment` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/workflow-contrast-and-sidebar-timestamps` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/workflow-model-display` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/workflow-panel-contrast` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/fix/workflow-time-selector-and-biweekly-toggle` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/refactor/complexity-audit-2026-03` | 2026-03-09 | ✅ Yes | Delete |
-| `origin/release/v0.2.0` | 2026-03-08 | ✅ Yes | Delete |
-
-### Unmerged branches
-
-| Branch | Last Commit | Ahead/Behind main | Merged? | Recommendation |
-|---|---|---|---|---|
-| `origin/release/v0.3.0` | 2026-03-09 | +2 / 0 | ❌ No | Active release branch — merge to main and tag, then delete |
-| `origin/codekin/reports` | 2026-03-09 | +5 / 102 | ❌ No | Automated reports branch; 102 commits behind main. Consider rebasing or merging the report files directly into main via a PR |
-| `origin/feat/enforce-branching-policy` | 2026-03-08 | +8 / 124 | ❌ No | No merge base with main (diverged early). Review if any unique content needs to be cherry-picked; otherwise abandon and delete |
+| Branch | Ahead/Behind | Recommendation |
+|---|---|---|
+| `release/v0.3.0` | +2 / 0 | Merge to main, tag, delete |
+| `codekin/reports` | +5 / 102 | PR the report files into main; address divergence |
+| `feat/enforce-branching-policy` | +8 / 124 (no merge base) | Cherry-pick any useful content; delete |
 
 ---
 
 ## PR Hygiene
 
-`gh pr list` returned **no open pull requests**. The repository is in a clean state with respect to PRs.
-
-| Metric | Value |
-|---|---|
-| Open PRs | 0 |
-| Stuck PRs (>7 days, no review) | 0 |
-| PRs with merge conflicts | 0 |
+**0 open PRs.** Nothing stuck.
 
 ---
 
 ## Merge Conflict Forecast
 
-Only branches with commits in the last 14 days and diverged from `main` are assessed.
-
-| Branch | Commits Ahead | Commits Behind | Files Changed vs Main | Conflict Risk |
+| Branch | Ahead | Behind | Changed Files | Risk |
 |---|---|---|---|---|
-| `origin/release/v0.3.0` | 2 | 0 | `package.json`, `server/types.ts` | **Low** — 0 commits behind; clean fast-forward merge possible |
-| `origin/codekin/reports` | 5 | 102 | 5 report files in `.codekin/reports/` | **Low** — changes are in non-overlapping report files; content conflict unlikely but rebase would require touching 102 commits |
-| `origin/feat/enforce-branching-policy` | 8 | 124 | No shared merge base (unrelated history) | **High** — no common ancestor with current `main`; cannot be rebased conventionally; treat as an isolated branch |
-
-**Overlapping file check** (`release/v0.3.0` vs `main`):
-- `package.json` — changed on `release/v0.3.0` (version bump); `main` is at the prior commit — no conflict, clean merge.
-- `server/types.ts` — auth variant added; no conflicting change on `main`.
+| `release/v0.3.0` | 2 | 0 | `package.json`, `server/types.ts` | **Low** — clean fast-forward |
+| `codekin/reports` | 5 | 102 | 5 report files (non-overlapping) | **Low content risk, High rebase effort** |
+| `feat/enforce-branching-policy` | 8 | 124 | No shared merge base | **High** — cannot rebase conventionally |
 
 ---
 
 ## Recommendations
 
-1. **Merge `release/v0.3.0` into `main` and tag** _(High impact)_ — The release branch is 2 commits ahead of `main` with no conflicts. Complete the release cycle: merge to `main`, tag `v0.3.0` on main, then delete the release branch.
+1. **Merge `release/v0.3.0` → `main` and tag `v0.3.0`** — Clean fast-forward, no conflicts.
+2. **Delete 29 merged remote branches** — `git push origin --delete <branch>` for each, or batch via `gh`.
+3. **Update `CHANGELOG.md`** — Add entries for v0.1.8 through v0.3.0 using the draft above.
+4. **Document `model` field in `docs/WORKFLOWS.md`** — One row in the frontmatter table.
+5. **Document `auth` WsClientMessage variant in `docs/stream-json-protocol.md`**.
+6. **Resolve `codekin/reports` branch drift** — Merge the 5 report files into main via a PR.
+7. **Evaluate and close `feat/enforce-branching-policy`** — No merge base; cherry-pick or delete.
+8. **Run `npm install`** to sync `package-lock.json` version field to `0.3.0`.
+9. **Add `.prettierrc`** to enforce consistent formatting across contributors.
+10. **Upgrade ESLint to `strictTypeChecked`** for stronger type-aware linting.
 
-2. **Delete 29 merged remote branches** _(Medium impact — hygiene)_ — Run `git push origin --delete <branch>` for all 29 merged branches listed above, or use `gh api` to batch-delete. This reduces noise in `git branch -r` and makes active branches immediately visible.
+---
 
-3. **Update `CHANGELOG.md`** _(Medium impact — documentation)_ — The changelog is missing entries for `v0.1.8`, `v0.2.0`, `v0.2.1`, `v0.2.2`, and `v0.3.0`. Use the draft changelog above as the basis for the `v0.3.0` entry, and reconstruct earlier versions from `git log`.
-
-4. **Document new workflow `model` field in `docs/WORKFLOWS.md`** _(Medium impact — documentation)_ — The optional `model` frontmatter key added in v0.3.0 is not mentioned in the workflow format reference. Add a row to the frontmatter field table.
-
-5. **Document `auth` WsClientMessage variant in `docs/stream-json-protocol.md`** _(Low-medium impact)_ — The `auth` variant added to `WsClientMessage` (`server/types.ts`, commit `d2938f2`) should be added to the client→server message table in the protocol doc.
-
-6. **Resolve `origin/codekin/reports` branch drift** _(Low-medium impact)_ — This branch is 102 commits behind main. Either (a) merge the report files into `main` directly via a PR, or (b) rebase the branch onto main so reports can be committed cleanly going forward.
-
-7. **Evaluate `origin/feat/enforce-branching-policy`** _(Low impact)_ — This branch has no merge base with current `main`. Review its 8 unique commits to see if any content is worth cherry-picking (branching policy docs, etc.), then delete the branch.
-
-8. **Run `npm install` to sync `package-lock.json` version** _(Low impact — cosmetic)_ — The lock file header still reads `"version": "0.2.2"`. Running `npm install` after the version bump will update it and keep lock file metadata consistent.
-
-9. **Add Prettier config** _(Low impact — developer experience)_ — No `.prettierrc` exists. Adding one with `"semi": false, "singleQuote": true` (or whatever the current convention is) and a `lint:format` / `format` script will prevent future formatting drift without relying on per-editor settings.
-
-10. **Upgrade ESLint to `strictTypeChecked`** _(Low impact — code quality)_ — `tseslint.configs.recommended` catches basic TypeScript issues. Upgrading to `tseslint.configs.strictTypeChecked` (requires adding `parserOptions.projectService: true`) would surface unsafe type assertions, unhandled promise rejections, and `any` leakage that the current config misses.
+Report saved to `.codekin/reports/repo-health/2026-03-09_repo-health.md`.Committed and pushed. The report is now at `.codekin/reports/repo-health/2026-03-09_repo-health.md` on `release/v0.3.0`.

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120,
+  "tabWidth": 2
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,97 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-03-09
+
+### Features
+- Docs browser: in-app markdown docs viewer with inline file picker,
+  keyboard navigation, inverted header, and star/favourite persistence
+- Workflow model selection: optional `model` frontmatter field; model badge in workflow list
+- GitHub Webhooks section in Settings panel
+- Repository Health built-in workflow type
+- Custom TimePicker component replacing native browser time input; bi-weekly frequency toggle
+
+### Fixes
+- Fix workflow panel contrast in light mode
+- Fix docs icon toggle (clicking again closes the picker)
+- Fix sidebar timestamp vertical alignment
+- Fix docs file picker not appearing on sidebar icon click
+- Fix docs API: switch from path params to query params
+- Fix sidebar session name bold and workflow list alignment
+- Fix sidebar repo ordering (alphabetical)
+- Fix workflow validate_repo failing when REPOS_ROOT is a symlink
+- Fix Settings font sizes and light mode contrast
+- Remove tracked dist/ files causing stale asset references
+- Fix CI: restore better-sqlite3 as root devDependency
+- Add missing auth variant to server WsClientMessage type
+
+### Security
+- Implement critical code review audit findings (H1–H3, M1–M6, L1–L4)
+- Implement critical dependency audit findings
+
+### Refactoring
+- Reduce complexity across 7 modules per complexity audit
+- Refine SessionManager split; complete delegation to extracted modules
+- Improve Settings modal layout with section cards
+
+### Documentation
+- Add JSDoc and inline comments per comment audit
+- Add docs/DOCS-BROWSER-SPEC.md
+
+### Chores
+- Add 50 new tests from coverage audit
+- Bump version to 0.3.0
+
+## [0.2.2] - 2026-03-08
+
+### Features
+- Redesign workflow view: unified cards, multi-step wizard, cleaner edit
+- Group workflow list by repo with compact rows and hover actions
+- Sidebar: add Active sessions label and session count on collapsed repos
+- Extract shared RepoList component with search filtering
+- Wire up dynamic workflow kinds: API endpoint, frontend fetching, and repo registration
+- Add repo workflow discovery and kind listing APIs
+- Commit workflow reports to dedicated branch and push to remote
+
+### Fixes
+- Fix empty repo list in AddWorkflowModal by passing auth token to useRepos
+- Show error message in AddWorkflowModal when repo fetch fails
+- Fix shell injection in workflow-loader and move better-sqlite3 to deps
+- Improve contrast of remote badge in RepoList
+- Increase contrast on repo group boxes in workflow list
+
+### Security
+- Harden server: SSRF protection, input validation, security headers
+- Add auth check to hook-notify endpoint
+
+### Documentation
+- Document custom repo workflow definitions in WORKFLOWS.md
+
+### Chores
+- Remove session name field from new-session dropdown
+- Remove manual refresh button from workflows view
+- Add workflow-loader tests covering MD parsing, step handlers, and cleanup
+
+## [0.2.1] - 2026-03-08
+
+### Fixes
+- Fix silent errors on workflow trigger/cancel actions
+- Fix workflow loader not finding MD definitions when running from dist/
+
+### Chores
+- Remove local deploy/ops scripts from repo
+
+## [0.2.0] - 2026-03-08
+
+### Chores
+- First open source release
+- Bump version to 0.2.0
+
+## [0.1.8] - 2026-03-08
+
+### Chores
+- Initial release
+
 ## [0.1.7] - 2026-03-08
 
 ### Added

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -46,6 +46,7 @@ You are performing an automated analysis. Please do the following:
 | `outputDir` | yes | Directory inside the repo where report files are written (e.g. `review logs`) |
 | `filenameSuffix` | yes | Filename suffix appended to the date (e.g. `_code-review-daily.md` → `2026-03-07_code-review-daily.md`) |
 | `commitMessage` | yes | Git commit message prefix used when the report is committed (date is appended automatically) |
+| `model` | no | Claude model to use for this workflow (e.g. `claude-sonnet-4-6`). If omitted, the server default (Opus) is used. Shown as a badge in the workflow list UI. |
 
 ### Prompt Body
 

--- a/docs/stream-json-protocol.md
+++ b/docs/stream-json-protocol.md
@@ -319,6 +319,7 @@ Response to a `control_request`. The `request_id` must match.
 
 | Type | Fields | Description |
 |------|--------|-------------|
+| `auth` | `token` | Authenticate the WebSocket connection (must be sent as first message) |
 | `create_session` | `name`, `workingDir` | Create a new session (auto-starts Claude) |
 | `join_session` | `sessionId` | Join an existing session (receives history via `outputBuffer`) |
 | `leave_session` | — | Leave current session |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,22 +6,55 @@ import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
 export default defineConfig([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'server/dist', 'server/vitest.config.ts']),
   {
     files: ['**/*.{ts,tsx}'],
+    ignores: ['**/*.test.{ts,tsx}'],
     extends: [
       js.configs.recommended,
-      tseslint.configs.recommended,
+      tseslint.configs.strictTypeChecked,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Demote pervasive pre-existing patterns to warnings for incremental adoption.
+      // These should be promoted to errors as the codebase is cleaned up.
+      '@typescript-eslint/restrict-template-expressions': ['warn', { allowNumber: true }],
+      '@typescript-eslint/no-confusing-void-expression': 'warn',
+      '@typescript-eslint/no-unnecessary-condition': 'warn',
+      '@typescript-eslint/no-base-to-string': 'warn',
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+      '@typescript-eslint/no-unsafe-assignment': 'warn',
+      '@typescript-eslint/no-unsafe-argument': 'warn',
+      '@typescript-eslint/no-unsafe-member-access': 'warn',
+      '@typescript-eslint/no-unsafe-return': 'warn',
+      '@typescript-eslint/no-misused-promises': 'warn',
+      '@typescript-eslint/no-floating-promises': 'warn',
+      '@typescript-eslint/use-unknown-in-catch-callback-variable': 'warn',
+      '@typescript-eslint/require-await': 'warn',
+      '@typescript-eslint/no-redundant-type-constituents': 'warn',
+      '@typescript-eslint/no-dynamic-delete': 'warn',
+      '@typescript-eslint/no-deprecated': 'warn',
     },
   },
   {
     files: ['**/*.test.{ts,tsx}'],
+    extends: [
+      js.configs.recommended,
+      tseslint.configs.recommended,
+    ],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+    },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codekin",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codekin",
-      "version": "0.2.2",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@tabler/icons-react": "^3.37.1",

--- a/src/components/workflows/StepCard.tsx
+++ b/src/components/workflows/StepCard.tsx
@@ -12,7 +12,7 @@ import { statusBadge, formatDuration } from '../../lib/workflowHelpers'
 // StepIcon
 // ---------------------------------------------------------------------------
 
-export function StepIcon({ status }: { status: string }) {
+function StepIcon({ status }: { status: string }) {
   const cls = 'shrink-0'
   switch (status) {
     case 'succeeded': return <IconCheck size={14} stroke={2.5} className={`${cls} text-success-4`} />


### PR DESCRIPTION
## Summary
- Add CHANGELOG entries for v0.1.8 through v0.3.0 (was significantly stale)
- Document `model` frontmatter field in `docs/WORKFLOWS.md`
- Document `auth` WsClientMessage variant in `docs/stream-json-protocol.md`
- Unexport unused `StepIcon` in `StepCard.tsx` (dead code cleanup)
- Sync `package-lock.json` version to 0.3.0 via `npm install`
- Add `.prettierrc` for consistent formatting across contributors
- Upgrade ESLint from `recommended` to `strictTypeChecked` with type-aware parsing; pre-existing violations demoted to warnings for incremental adoption

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` (errors only) passes — 0 errors
- [x] `npm test` — all 855 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)