### PR TITLE
Fix mobile header alignment

### DIFF
--- a/src/components/MobileTopBar.tsx
+++ b/src/components/MobileTopBar.tsx
@@ -20,16 +20,16 @@ interface Props {
 
 export function MobileTopBar({ repoName, sessionName, onMenuOpen, onNewSession, onSettingsOpen }: Props) {
   return (
-    <div className="app-left-sidebar mobile-top-bar-safe flex items-center gap-2 px-2 py-2 border-b border-neutral-8/30 bg-neutral-12 flex-shrink-0">
+    <div className="app-left-sidebar mobile-top-bar-safe flex items-center h-12 px-1.5 border-b border-neutral-8/30 bg-neutral-12 flex-shrink-0">
       <button
         onClick={onMenuOpen}
-        className="flex items-center justify-center rounded-lg p-2 text-neutral-3 hover:text-neutral-1 hover:bg-neutral-6 transition-colors"
+        className="flex items-center justify-center rounded-lg size-10 text-neutral-3 hover:text-neutral-1 hover:bg-neutral-6 transition-colors"
         aria-label="Open menu"
       >
         <IconMenu2 size={22} stroke={2} />
       </button>
 
-      <div className="flex items-center gap-2 flex-1 min-w-0">
+      <div className="flex items-center gap-2 flex-1 min-w-0 px-1.5">
         <AppIcon size={20} className="text-primary-7 flex-shrink-0" />
         <div className="flex-1 min-w-0 truncate text-[15px] text-neutral-2">
           {repoName ? (
@@ -45,21 +45,23 @@ export function MobileTopBar({ repoName, sessionName, onMenuOpen, onNewSession, 
         </div>
       </div>
 
-      <button
-        onClick={onSettingsOpen}
-        className="flex items-center justify-center rounded-lg p-2 text-neutral-4 hover:text-neutral-1 hover:bg-neutral-6 transition-colors"
-        aria-label="Settings"
-      >
-        <IconSettings size={20} stroke={2} />
-      </button>
+      <div className="flex items-center">
+        <button
+          onClick={onSettingsOpen}
+          className="flex items-center justify-center rounded-lg size-10 text-neutral-4 hover:text-neutral-1 hover:bg-neutral-6 transition-colors"
+          aria-label="Settings"
+        >
+          <IconSettings size={20} stroke={2} />
+        </button>
 
-      <button
-        onClick={onNewSession}
-        className="flex items-center justify-center rounded-lg p-2 text-neutral-4 hover:text-neutral-1 hover:bg-neutral-6 transition-colors"
-        aria-label="New session"
-      >
-        <IconPlus size={20} stroke={2} />
-      </button>
+        <button
+          onClick={onNewSession}
+          className="flex items-center justify-center rounded-lg size-10 text-neutral-4 hover:text-neutral-1 hover:bg-neutral-6 transition-colors"
+          aria-label="New session"
+        >
+          <IconPlus size={20} stroke={2} />
+        </button>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Use fixed `h-12` height for consistent header sizing instead of padding-based height
- Apply uniform `size-10` touch targets on all header buttons (hamburger, settings, new session)
- Group right-side action buttons in a flex container for tighter alignment

## Test plan
- [ ] Verify mobile header looks aligned on various screen widths
- [ ] Confirm buttons are easy to tap with uniform sizing
- [ ] Check safe area inset still works on notched devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)