### PR TITLE
Add image display support for tool results

### DIFF
--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -307,9 +307,28 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> {
     const blocks = Array.isArray(msg.content) ? msg.content : []
     for (const block of blocks as Array<{ type: string; tool_use_id?: string; content?: unknown; is_error?: boolean }>) {
       if (block.type === 'tool_result') {
-        const content = typeof block.content === 'string' ? block.content : JSON.stringify(block.content)
         const isError = block.is_error === true
-        console.log(`[tool-result] id=${block.tool_use_id} error=${isError} content=${content.slice(0, 300)}`)
+
+        // When content is an array of content blocks, extract images and stringify the rest
+        let content = ''
+        const contentBlocks = Array.isArray(block.content) ? block.content : null
+        if (contentBlocks) {
+          const textParts: string[] = []
+          for (const cb of contentBlocks as Array<{ type: string; text?: string; source?: { type: string; data: string; media_type: string } }>) {
+            if (cb.type === 'image' && cb.source?.type === 'base64') {
+              console.log(`[tool-result] id=${block.tool_use_id} image media_type=${cb.source.media_type} data_len=${cb.source.data.length}`)
+              this.emit('image', cb.source.data, cb.source.media_type)
+            } else {
+              textParts.push(typeof cb.text === 'string' ? cb.text : JSON.stringify(cb))
+            }
+          }
+          content = textParts.join('\n')
+        } else {
+          content = typeof block.content === 'string' ? block.content : ''
+        }
+        if (content) {
+          console.log(`[tool-result] id=${block.tool_use_id} error=${isError} content=${content.slice(0, 300)}`)
+        }
 
         // Deferred ExitPlanMode: emit planning_mode only after tool_result confirms success.
         // Match by tool_use_id, or use flag-based fallback when id wasn't available.
@@ -321,7 +340,7 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> {
           }
         }
 
-        // Emit non-empty tool results as dedicated tool_output events
+        // Emit non-empty text tool results as dedicated tool_output events
         if (content.trim()) {
           const truncated = content.length > 2000
             ? content.slice(0, 2000) + `\n… (truncated, ${content.length} chars total)`

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -439,6 +439,13 @@ export class SessionManager {
       this.broadcast(session, msg)
     })
 
+    cp.on('image', (base64Data: string, mediaType: string) => {
+      this.resetStallTimer(session)
+      const msg: WsServerMessage = { type: 'image', base64: base64Data, mediaType }
+      // Don't persist base64 images to history — they're too large and would bloat session storage
+      this.broadcast(session, msg)
+    })
+
     cp.on('tool_active', (toolName, toolInput) => {
       this.resetStallTimer(session)
       const msg: WsServerMessage = { type: 'tool_active', toolName, toolInput }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -195,6 +195,7 @@ function ToolOutputInline({ msg, fontSize }: { msg: ChatMessage & { type: 'tool_
 interface ToolRun {
   groups: (ChatMessage & { type: 'tool_group' })[]
   outputs: (ChatMessage & { type: 'tool_output' })[]
+  images: (ChatMessage & { type: 'image' })[]
 }
 
 function ToolActivity({ run, fontSize }: { run: ToolRun; fontSize: number }) {
@@ -238,8 +239,26 @@ function ToolActivity({ run, fontSize }: { run: ToolRun; fontSize: number }) {
           {run.outputs.map((o, oi) => (
             <ToolOutputInline key={`o-${oi}`} msg={o} fontSize={fontSize} />
           ))}
+          {run.images.map((img, ii) => (
+            <ImageInline key={`img-${ii}`} msg={img} />
+          ))}
         </div>
       )}
+    </div>
+  )
+}
+
+function ImageInline({ msg }: { msg: ChatMessage & { type: 'image' } }) {
+  const [expanded, setExpanded] = useState(false)
+  const src = `data:${msg.mediaType};base64,${msg.base64}`
+  return (
+    <div className="pl-4 py-1">
+      <img
+        src={src}
+        alt="Tool output"
+        className={`rounded-lg border border-neutral-8 cursor-pointer transition-all ${expanded ? 'max-w-full' : 'max-w-xs max-h-48 object-contain'}`}
+        onClick={() => setExpanded(!expanded)}
+      />
     </div>
   )
 }
@@ -374,14 +393,15 @@ export function ChatView({ messages, fontSize, theme = 'dark', disabled, plannin
                 nodes.push(<div key={`ts-${msg.key || i}`} className="px-4 pt-3 pb-0.5 text-[13px] text-neutral-6">{hh}:{mm}</div>)
               }
 
-              // Collect consecutive tool_group/tool_output into a single ToolActivity
-              if (msg.type === 'tool_group' || msg.type === 'tool_output') {
-                const run: ToolRun = { groups: [], outputs: [] }
+              // Collect consecutive tool_group/tool_output/image into a single ToolActivity
+              if (msg.type === 'tool_group' || msg.type === 'tool_output' || msg.type === 'image') {
+                const run: ToolRun = { groups: [], outputs: [], images: [] }
                 const startIdx = i
-                while (i < messages.length && (messages[i].type === 'tool_group' || messages[i].type === 'tool_output')) {
+                while (i < messages.length && (messages[i].type === 'tool_group' || messages[i].type === 'tool_output' || messages[i].type === 'image')) {
                   const m = messages[i]
                   if (m.type === 'tool_group') run.groups.push(m as ChatMessage & { type: 'tool_group' })
                   if (m.type === 'tool_output') run.outputs.push(m as ChatMessage & { type: 'tool_output' })
+                  if (m.type === 'image') run.images.push(m as ChatMessage & { type: 'image' })
                   i++
                 }
                 const taKey = run.groups[0]?.key || run.outputs[0]?.key || `ta-${startIdx}`

--- a/src/hooks/useChatSocket.ts
+++ b/src/hooks/useChatSocket.ts
@@ -94,6 +94,10 @@ function applyMessageMut(messages: ChatMessage[], msg: WsServerMessage): boolean
       messages.push({ type: 'tool_output', content: msg.content, isError: msg.isError, key: nextKey() })
       return true
 
+    case 'image':
+      messages.push({ type: 'image', base64: msg.base64, mediaType: msg.mediaType, key: nextKey() })
+      return true
+
     case 'planning_mode':
       messages.push({ type: 'planning_mode', active: msg.active, key: nextKey() })
       return true
@@ -334,6 +338,11 @@ export function useChatSocket({
           break
 
         case 'tool_output':
+          flushBeforeStructuralMessage()
+          setMessages(prev => trimMessages(processMessage(prev, msg)))
+          break
+
+        case 'image':
           flushBeforeStructuralMessage()
           setMessages(prev => trimMessages(processMessage(prev, msg)))
           break

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,7 @@ export type WsServerMessage =
   | { type: 'tool_active'; toolName: string; toolInput?: string }
   | { type: 'tool_done'; toolName: string; summary?: string }
   | { type: 'tool_output'; content: string; isError?: boolean }
+  | { type: 'image'; base64: string; mediaType: string }
   | { type: 'system_message'; subtype: 'init' | 'exit' | 'error' | 'restart' | 'stall' | 'notification'; text: string; model?: string }
   | { type: 'user_echo'; text: string }
   | { type: 'result' }
@@ -152,6 +153,7 @@ export type ChatMessage =
   | { type: 'system'; subtype: 'init' | 'exit' | 'error' | 'restart' | 'stall' | 'notification' | 'trim'; text: string; model?: string; ts?: number; key?: string }
   | { type: 'tool_group'; tools: Array<{ name: string; summary?: string; active: boolean }>; ts?: number; key?: string }
   | { type: 'tool_output'; content: string; isError?: boolean; ts?: number; key?: string }
+  | { type: 'image'; base64: string; mediaType: string; ts?: number; key?: string }
   | { type: 'planning_mode'; active: boolean; ts?: number; key?: string }
   | { type: 'todo_list'; tasks: TaskItem[]; ts?: number; key?: string }
   | { type: 'tentative'; text: string; index: number; ts?: number; key?: string }


### PR DESCRIPTION
## Summary
- Detect base64 image content blocks in Claude Code's `tool_result` stream-json output (previously JSON-stringified and truncated to 2000 chars, destroying the data)
- Emit dedicated `image` WebSocket events from server to frontend
- Render images inline within collapsible tool activity groups, with click-to-expand

## Test plan
- [x] All 855 existing tests pass
- [x] TypeScript build clean
- [ ] Start a session and ask Claude to read an image file — verify the image renders inline in the tool activity group
- [ ] Click the image thumbnail to verify it expands to full size
- [ ] Verify non-image tool results (text) still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)