### PR TITLE
Fix external images not rendering in chat content

### DIFF
--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -235,7 +235,7 @@ app.use((_req, res, next) => {
   res.header('X-XSS-Protection', '1; mode=block')
   res.header('Referrer-Policy', 'strict-origin-when-cross-origin')
   res.header('Permissions-Policy', 'camera=(), microphone=(), geolocation=()')
-  res.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss: ws:; img-src 'self' data:; font-src 'self'")
+  res.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' wss: ws:; img-src 'self' data: https:; font-src 'self'")
   if (process.env.NODE_ENV === 'production') {
     res.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
   }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -131,6 +131,17 @@ function AssistantMessage({ msg, fontSize, theme }: { msg: ChatMessage & { type:
                 </code>
               )
             },
+            img({ src, alt, ...props }) {
+              return (
+                <img
+                  src={src}
+                  alt={alt || 'Image'}
+                  className="max-w-full max-h-96 rounded-lg border border-neutral-8 my-2"
+                  loading="lazy"
+                  {...props}
+                />
+              )
+            },
           }}
         >
           {msg.text}


### PR DESCRIPTION
## Summary
- Add `https:` to CSP `img-src` directive to allow external image URLs (previously only `'self' data:` was permitted)
- Add custom `img` component to the markdown renderer with proper styling (max-width, rounded borders, lazy loading)

## Test plan
- [ ] Open a session and have Claude output markdown with an external image URL — verify it renders
- [ ] Verify base64 images from tool results still render correctly
- [ ] Verify same-origin images still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)