### PR TITLE
Fix: read auth token from URL query parameter

### DIFF
--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -19,14 +19,26 @@ const defaults: Settings = {
 function load(): Settings {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
-    if (!raw) return defaults
-    const saved = JSON.parse(raw)
-    // Only restore token and theme; fontSize always uses the current default
-    return {
+    const saved = raw ? JSON.parse(raw) : null
+    const base: Settings = {
       ...defaults,
-      token: saved.token ?? defaults.token,
-      theme: saved.theme === 'light' ? 'light' : 'dark',
+      token: saved?.token ?? defaults.token,
+      theme: saved?.theme === 'light' ? 'light' : 'dark',
     }
+
+    // Check URL for ?token= parameter (e.g. shared invite links)
+    const url = new URL(window.location.href)
+    const urlToken = url.searchParams.get('token')
+    if (urlToken) {
+      base.token = urlToken
+      // Persist immediately so subsequent loads pick it up
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(base))
+      // Strip the token from the URL for security
+      url.searchParams.delete('token')
+      window.history.replaceState({}, '', url.pathname + url.search + url.hash)
+    }
+
+    return base
   } catch {
     return defaults
   }


### PR DESCRIPTION
## Summary
- When opening a shared link with `?token=...`, the app now extracts the token from the URL, saves it to localStorage, and strips it from the address bar
- This skips the settings prompt entirely, so mobile users landing on an invite link go straight to the app

## Test plan
- [ ] Open `https://claude.trec.one/?token=<valid-token>` in a fresh browser/incognito — should land on the main app, not the settings view
- [ ] Verify the token is stripped from the URL bar after load
- [ ] Verify the token persists in localStorage on subsequent visits
- [ ] Open the app without a `?token=` param with no saved token — should still show settings as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)