### PR TITLE
Fix mobile button sizes not responding to viewport

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -185,7 +185,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
           onChange={handleFileChange}
           className="hidden"
         />
-        <div className="flex flex-shrink-0 flex-row items-end gap-1 pb-0.5">
+        <div className={`flex flex-shrink-0 flex-row items-end ${isMobile ? 'gap-2' : 'gap-1'} pb-0.5`}>
           {currentModel && onModelChange && (
             <div className="relative">
               <button
@@ -216,10 +216,10 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
               <button
                 onClick={() => setSkillMenuOpen(!skillMenuOpen)}
                 disabled={disabled}
-                className="flex items-center justify-center rounded p-1 text-neutral-3 hover:text-neutral-1 hover:bg-neutral-7 transition-colors disabled:opacity-30"
+                className={`flex items-center justify-center rounded ${isMobile ? 'p-2.5 min-w-[44px] min-h-[44px]' : 'p-1'} text-neutral-3 hover:text-neutral-1 hover:bg-neutral-7 transition-colors disabled:opacity-30`}
                 title="Claude Skills"
               >
-                <IconTerminal2 size={20} stroke={2} />
+                <IconTerminal2 size={isMobile ? 24 : 20} stroke={2} />
               </button>
               {skillMenuOpen && (
                 <SkillMenu
@@ -237,22 +237,22 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
           <button
             onClick={handleFileSelect}
             disabled={disabled}
-            className="flex items-center justify-center rounded p-1 text-neutral-3 hover:text-neutral-1 hover:bg-neutral-7 transition-colors disabled:opacity-30"
+            className={`flex items-center justify-center rounded ${isMobile ? 'p-2.5 min-w-[44px] min-h-[44px]' : 'p-1'} text-neutral-3 hover:text-neutral-1 hover:bg-neutral-7 transition-colors disabled:opacity-30`}
             title="Attach files"
           >
-            <IconPaperclip size={20} stroke={2} />
+            <IconPaperclip size={isMobile ? 24 : 20} stroke={2} />
           </button>
           <button
             onClick={handleSend}
             disabled={disabled || (!value.trim() && pendingFiles.length === 0)}
-            className={`flex items-center justify-center rounded p-1 transition-colors disabled:opacity-30 ${
+            className={`flex items-center justify-center rounded ${isMobile ? 'p-2.5 min-w-[44px] min-h-[44px]' : 'p-1'} transition-colors disabled:opacity-30 ${
               value.trim() || pendingFiles.length > 0
                 ? 'bg-primary-8 text-neutral-1 hover:bg-primary-7'
                 : 'text-neutral-5'
             }`}
             title="Send (Enter)"
           >
-            <IconSend size={20} stroke={2} />
+            <IconSend size={isMobile ? 24 : 20} stroke={2} />
           </button>
         </div>
       </div>

--- a/src/components/PromptButtons.tsx
+++ b/src/components/PromptButtons.tsx
@@ -33,7 +33,7 @@ interface PromptButtonsProps {
 /** Sticky prompt bar for permission approvals, single/multi-select questions, and multi-question AskUserQuestion flows. */
 export function PromptButtons({ options, question, multiSelect, promptType, questions, approvePattern, onSelect, isMobile = false }: PromptButtonsProps) {
   const isPermission = promptType === 'permission'
-  const btnPad = isMobile ? 'px-4 py-2 text-[14px]' : 'px-3 py-0.5 text-[13px]'
+  const btnPad = isMobile ? 'px-5 py-3 text-[15px] min-h-[44px]' : 'px-3 py-0.5 text-[13px]'
 
   // Auto-allow countdown for permission prompts
   const [timeLeft, setTimeLeft] = useState(15)
@@ -134,7 +134,7 @@ export function PromptButtons({ options, question, multiSelect, promptType, ques
             {displayQuestion}
           </p>
         )}
-        <div className="flex flex-wrap items-center gap-1.5">
+        <div className={`flex flex-wrap items-center ${isMobile ? 'gap-2.5' : 'gap-1.5'}`}>
           {displayOptions.map((opt) => (
             <button
               key={opt.value}


### PR DESCRIPTION
## Summary
- **InputBar**: Send, attach, and skills icon buttons now use `p-2.5` with `min-w-[44px] min-h-[44px]` on mobile (were stuck at `p-1` ~28px on all viewports). Icon sizes bump from 20px to 24px. Button gap increases on mobile.
- **PromptButtons**: Increased mobile padding to `px-5 py-3 text-[15px] min-h-[44px]` (was `px-4 py-2 text-[14px]`), and increased gap between buttons on mobile.

## Test plan
- [ ] Open on mobile device or use devtools responsive mode (<1024px)
- [ ] Verify InputBar icon buttons (send, attach, skills) are visibly larger
- [ ] Verify PromptButtons (permission approve/deny, question options) are larger
- [ ] Verify desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)