### PR TITLE
Bump mobile icon sizes to 24px

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -286,7 +286,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
                   className="flex items-center justify-center rounded min-w-[34px] min-h-[34px] p-1.5 text-neutral-3 hover:text-neutral-1 hover:bg-neutral-7 transition-colors disabled:opacity-30"
                   title="More options"
                 >
-                  <IconDots size={20} stroke={2} />
+                  <IconDots size={24} stroke={2} />
                 </button>
                 {mobileMenuOpen && (
                   <div className="absolute bottom-full mb-1 right-0 z-50 min-w-[180px] rounded-lg border border-neutral-6 bg-neutral-8 shadow-lg py-1">
@@ -348,7 +348,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
                 }`}
                 title="Send (Enter)"
               >
-                <IconSend size={20} stroke={2} />
+                <IconSend size={24} stroke={2} />
               </button>
             </>
           )}

--- a/src/components/MobileTopBar.tsx
+++ b/src/components/MobileTopBar.tsx
@@ -26,11 +26,11 @@ export function MobileTopBar({ repoName, sessionName, onMenuOpen, onNewSession, 
         className="flex items-center justify-center rounded-lg size-[34px] text-neutral-3 hover:text-neutral-1 hover:bg-neutral-6 transition-colors"
         aria-label="Open menu"
       >
-        <IconMenu2 size={20} stroke={2} />
+        <IconMenu2 size={24} stroke={2} />
       </button>
 
       <div className="flex items-center gap-2 flex-1 min-w-0 px-1.5">
-        <AppIcon size={20} className="text-primary-7 flex-shrink-0" />
+        <AppIcon size={24} className="text-primary-7 flex-shrink-0" />
         <div className="flex-1 min-w-0 truncate text-[16px] text-neutral-2">
           {repoName ? (
             <>
@@ -51,7 +51,7 @@ export function MobileTopBar({ repoName, sessionName, onMenuOpen, onNewSession, 
           className="flex items-center justify-center rounded-lg size-[34px] text-neutral-4 hover:text-neutral-1 hover:bg-neutral-6 transition-colors"
           aria-label="Settings"
         >
-          <IconSettings size={20} stroke={2} />
+          <IconSettings size={24} stroke={2} />
         </button>
 
         <button
@@ -59,7 +59,7 @@ export function MobileTopBar({ repoName, sessionName, onMenuOpen, onNewSession, 
           className="flex items-center justify-center rounded-lg size-[34px] text-neutral-4 hover:text-neutral-1 hover:bg-neutral-6 transition-colors"
           aria-label="New session"
         >
-          <IconPlus size={20} stroke={2} />
+          <IconPlus size={24} stroke={2} />
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Increase all mobile icons from 18-20px to 24px (Material Design standard)
- Affects: hamburger, app logo, settings, plus (MobileTopBar), context menu dots, send button (InputBar)
- Button tap targets remain 34px

## Test plan
- [ ] Verify icons are visually larger on mobile viewport
- [ ] Confirm tap targets still feel right at 34px container with 24px icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)