### PR TITLE
Fix mobile menu not closing when tapping content area

### DIFF
--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -444,7 +444,7 @@ export function LeftSidebar({
         onClick={onMobileClose}
       >
         <div
-          className={`h-full transition-transform duration-200 ease-out ${mobileOpen ? 'translate-x-0' : '-translate-x-full'}`}
+          className={`h-full w-fit transition-transform duration-200 ease-out ${mobileOpen ? 'translate-x-0' : '-translate-x-full'}`}
           onClick={e => e.stopPropagation()}
         >
           {sidebarContent}


### PR DESCRIPTION
## Summary
- The mobile sidebar drawer's inner wrapper was implicitly `width: 100%`, so its `stopPropagation` handler blocked clicks on the entire backdrop overlay
- Added `w-fit` to constrain the wrapper to the sidebar's 280px width, allowing taps on the content area to reach the backdrop's close handler

## Test plan
- [ ] Open on mobile viewport, open sidebar menu, tap the dimmed content area — menu should close
- [ ] Verify tapping inside the sidebar still works normally (doesn't close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)