### PR TITLE
Add tests for 7 coverage audit priorities

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mockExistsSync = vi.hoisted(() => vi.fn(() => false))
+const mockReadFileSync = vi.hoisted(() => vi.fn(() => ''))
+const mockRealpathSync = vi.hoisted(() => vi.fn((p: string) => p))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    existsSync: mockExistsSync,
+    readFileSync: mockReadFileSync,
+    realpathSync: mockRealpathSync,
+  }
+})
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('os')>()
+  return {
+    ...actual,
+    homedir: () => '/mock/home',
+  }
+})
+
+const savedEnv = { ...process.env }
+
+beforeEach(() => {
+  vi.resetModules()
+  process.env = { ...savedEnv }
+  // Remove all config-related env vars for a clean slate
+  delete process.env.PORT
+  delete process.env.CORS_ORIGIN
+  delete process.env.NODE_ENV
+  delete process.env.AUTH_TOKEN
+  delete process.env.AUTH_TOKEN_FILE
+  delete process.env.REPOS_ROOT
+  delete process.env.DATA_DIR
+  delete process.env.SCREENSHOTS_DIR
+  delete process.env.FRONTEND_DIST
+  delete process.env.GH_ORG
+
+  // Reset mock implementations to defaults
+  mockExistsSync.mockReturnValue(false)
+  mockReadFileSync.mockReturnValue('')
+  mockRealpathSync.mockImplementation((p: string) => p)
+})
+
+afterEach(() => {
+  process.env = { ...savedEnv }
+})
+
+async function loadConfig() {
+  return import('./config.js')
+}
+
+describe('config', () => {
+  describe('PORT', () => {
+    it('defaults to 32352 when PORT env is unset', async () => {
+      const config = await loadConfig()
+      expect(config.PORT).toBe(32352)
+    })
+
+    it('parses custom value from env', async () => {
+      process.env.PORT = '8080'
+      const config = await loadConfig()
+      expect(config.PORT).toBe(8080)
+    })
+
+    it('results in NaN when PORT is non-numeric', async () => {
+      process.env.PORT = 'not-a-number'
+      const config = await loadConfig()
+      expect(config.PORT).toBeNaN()
+    })
+  })
+
+  describe('CORS_ORIGIN', () => {
+    it('defaults to http://localhost:5173 when unset', async () => {
+      const config = await loadConfig()
+      expect(config.CORS_ORIGIN).toBe('http://localhost:5173')
+    })
+
+    it('uses the value from env when set', async () => {
+      process.env.CORS_ORIGIN = 'https://app.example.com'
+      const config = await loadConfig()
+      expect(config.CORS_ORIGIN).toBe('https://app.example.com')
+    })
+  })
+
+  describe('AUTH_TOKEN', () => {
+    it('reads from AUTH_TOKEN env var', async () => {
+      process.env.AUTH_TOKEN = 'direct-token-value'
+      const config = await loadConfig()
+      expect(config.AUTH_TOKEN).toBe('direct-token-value')
+    })
+
+    it('reads from AUTH_TOKEN_FILE when AUTH_TOKEN is unset', async () => {
+      process.env.AUTH_TOKEN_FILE = '/run/secrets/auth-token'
+      mockExistsSync.mockImplementation((p: unknown) =>
+        p === '/run/secrets/auth-token' ? true : false
+      )
+      mockReadFileSync.mockImplementation((p: unknown) =>
+        p === '/run/secrets/auth-token' ? '  file-token-value  \n' : ''
+      )
+      const config = await loadConfig()
+      expect(config.AUTH_TOKEN).toBe('file-token-value')
+    })
+
+    it('returns empty string when neither AUTH_TOKEN nor AUTH_TOKEN_FILE is set', async () => {
+      const config = await loadConfig()
+      expect(config.AUTH_TOKEN).toBe('')
+    })
+  })
+
+  describe('GH_ORGS', () => {
+    it('parses comma-separated orgs', async () => {
+      process.env.GH_ORG = 'org-alpha, org-beta , org-gamma'
+      const config = await loadConfig()
+      expect(config.GH_ORGS).toEqual(['org-alpha', 'org-beta', 'org-gamma'])
+    })
+
+    it('returns empty array when GH_ORG is unset', async () => {
+      const config = await loadConfig()
+      expect(config.GH_ORGS).toEqual([])
+    })
+
+    it('filters out empty entries from trailing commas', async () => {
+      process.env.GH_ORG = 'org-one,,org-two,'
+      const config = await loadConfig()
+      expect(config.GH_ORGS).toEqual(['org-one', 'org-two'])
+    })
+  })
+
+  describe('production mode', () => {
+    it('calls process.exit(1) when NODE_ENV=production and CORS_ORIGIN is unset', async () => {
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never)
+      const mockError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      process.env.NODE_ENV = 'production'
+      // CORS_ORIGIN is already deleted in beforeEach
+
+      await loadConfig()
+
+      expect(mockExit).toHaveBeenCalledWith(1)
+      expect(mockError).toHaveBeenCalled()
+
+      mockExit.mockRestore()
+      mockError.mockRestore()
+    })
+  })
+})

--- a/server/crypto-utils.test.ts
+++ b/server/crypto-utils.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect } from 'vitest'
+import {
+  redactSecrets,
+  verifyHmacSignature,
+  deriveSessionToken,
+  verifySessionToken,
+} from './crypto-utils.js'
+import crypto from 'crypto'
+
+describe('crypto-utils', () => {
+  describe('deriveSessionToken', () => {
+    it('returns a consistent hex string for the same inputs', () => {
+      const token1 = deriveSessionToken('master-secret', 'session-abc')
+      const token2 = deriveSessionToken('master-secret', 'session-abc')
+      expect(token1).toBe(token2)
+      // SHA-256 hex digest is 64 characters
+      expect(token1).toMatch(/^[0-9a-f]{64}$/)
+    })
+
+    it('returns different tokens for different master tokens', () => {
+      const token1 = deriveSessionToken('master-A', 'session-1')
+      const token2 = deriveSessionToken('master-B', 'session-1')
+      expect(token1).not.toBe(token2)
+    })
+
+    it('returns different tokens for different session IDs', () => {
+      const token1 = deriveSessionToken('master-A', 'session-1')
+      const token2 = deriveSessionToken('master-A', 'session-2')
+      expect(token1).not.toBe(token2)
+    })
+  })
+
+  describe('verifySessionToken', () => {
+    const master = 'test-master-token'
+    const sessionId = 'sess-42'
+
+    it('returns true for a correctly derived token', () => {
+      const token = deriveSessionToken(master, sessionId)
+      expect(verifySessionToken(master, sessionId, token)).toBe(true)
+    })
+
+    it('returns false when candidate is mutated by one byte', () => {
+      const token = deriveSessionToken(master, sessionId)
+      // Flip the first character
+      const mutated = (token[0] === 'a' ? 'b' : 'a') + token.slice(1)
+      expect(verifySessionToken(master, sessionId, mutated)).toBe(false)
+    })
+
+    it('returns false for wrong-length candidate (length-check short-circuit)', () => {
+      const token = deriveSessionToken(master, sessionId)
+      // Too short
+      expect(verifySessionToken(master, sessionId, token.slice(0, 32))).toBe(false)
+      // Too long
+      expect(verifySessionToken(master, sessionId, token + 'ff')).toBe(false)
+    })
+
+    it('returns false for empty candidate', () => {
+      expect(verifySessionToken(master, sessionId, '')).toBe(false)
+    })
+
+    it('returns false when master token differs', () => {
+      const token = deriveSessionToken(master, sessionId)
+      expect(verifySessionToken('wrong-master', sessionId, token)).toBe(false)
+    })
+  })
+
+  describe('verifyHmacSignature', () => {
+    const secret = 'webhook-secret'
+    const payload = Buffer.from('{"action":"opened"}')
+
+    function computeSignature(data: Buffer, key: string): string {
+      return 'sha256=' + crypto.createHmac('sha256', key).update(data).digest('hex')
+    }
+
+    it('returns true for a valid signature', () => {
+      const sig = computeSignature(payload, secret)
+      expect(verifyHmacSignature(payload, sig, secret)).toBe(true)
+    })
+
+    it('returns false for wrong-length signature', () => {
+      expect(verifyHmacSignature(payload, 'sha256=tooshort', secret)).toBe(false)
+    })
+
+    it('returns false for an empty signature', () => {
+      expect(verifyHmacSignature(payload, '', secret)).toBe(false)
+    })
+
+    it('returns false for incorrect signature of correct length', () => {
+      const sig = computeSignature(payload, secret)
+      const bad = sig.slice(0, -1) + (sig.at(-1) === 'a' ? 'b' : 'a')
+      expect(verifyHmacSignature(payload, bad, secret)).toBe(false)
+    })
+  })
+
+  describe('redactSecrets', () => {
+    it('redacts Bearer tokens', () => {
+      const input = 'Authorization header: Bearer eyJhbGciOiJIUzI1NiJ9.token.sig'
+      const result = redactSecrets(input)
+      expect(result).toContain('Bearer [REDACTED]')
+      expect(result).not.toContain('eyJhbGciOiJIUzI1NiJ9')
+    })
+
+    it('redacts Authorization headers', () => {
+      const input = 'Authorization: BasicdXNlcjpwYXNz'
+      const result = redactSecrets(input)
+      expect(result).toContain('Authorization: [REDACTED]')
+      expect(result).not.toContain('BasicdXNlcjpwYXNz')
+    })
+
+    it('redacts API key patterns', () => {
+      const input = 'using key sk-live_abc123xyz for access'
+      const result = redactSecrets(input)
+      expect(result).toContain('[REDACTED]')
+      expect(result).not.toContain('abc123xyz')
+    })
+
+    it('redacts password patterns', () => {
+      const input = 'password=super_secret_value in config'
+      const result = redactSecrets(input)
+      expect(result).toContain('password=[REDACTED]')
+      expect(result).not.toContain('super_secret_value')
+    })
+
+    it('redacts URL-embedded passwords', () => {
+      const input = 'connecting to https://admin:s3cret@db.example.com/mydb'
+      const result = redactSecrets(input)
+      expect(result).toContain('[REDACTED]@')
+      expect(result).not.toContain('s3cret')
+    })
+
+    it('returns the string unchanged when no secrets are present', () => {
+      const input = 'just a normal log line with no secrets'
+      expect(redactSecrets(input)).toBe(input)
+    })
+  })
+})

--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -2531,6 +2531,64 @@ describe('SessionManager', () => {
     })
   })
 
+  describe('setModel()', () => {
+    it('returns false for unknown sessionId', () => {
+      expect(sm.setModel('no-such-id', 'gpt-4')).toBe(false)
+    })
+
+    it('returns true and sets model on existing session', () => {
+      const s = sm.create('test', '/tmp')
+      const result = sm.setModel(s.id, 'opus')
+      expect(result).toBe(true)
+      expect(s.model).toBe('opus')
+    })
+
+    it('sets model to undefined when empty string passed', () => {
+      const s = sm.create('test', '/tmp')
+      s.model = 'opus'
+      sm.setModel(s.id, '')
+      expect(s.model).toBeUndefined()
+    })
+
+    it('restarts Claude when process is alive', () => {
+      vi.useFakeTimers()
+      const s = sm.create('test', '/tmp')
+      const cp = fakeClaudeProcess(true)
+      s.claudeProcess = cp
+
+      const stopSpy = vi.spyOn(sm, 'stopClaude')
+      const startSpy = vi.spyOn(sm, 'startClaude').mockReturnValue(true)
+
+      sm.setModel(s.id, 'sonnet')
+
+      expect(stopSpy).toHaveBeenCalledWith(s.id)
+
+      // startClaude should NOT have been called yet
+      expect(startSpy).not.toHaveBeenCalled()
+
+      // Advance past the 500ms delay
+      vi.advanceTimersByTime(500)
+      expect(startSpy).toHaveBeenCalledWith(s.id)
+
+      stopSpy.mockRestore()
+      startSpy.mockRestore()
+      vi.useRealTimers()
+    })
+
+    it('does NOT restart when process is not alive', () => {
+      const s = sm.create('test', '/tmp')
+      const cp = fakeClaudeProcess(false)
+      s.claudeProcess = cp
+
+      const stopSpy = vi.spyOn(sm, 'stopClaude')
+
+      sm.setModel(s.id, 'sonnet')
+
+      expect(stopSpy).not.toHaveBeenCalled()
+      stopSpy.mockRestore()
+    })
+  })
+
   describe('handleClaudeResult API retry', () => {
     it('broadcasts exhaustion message after MAX_API_RETRIES', () => {
       vi.useFakeTimers()

--- a/server/session-naming.test.ts
+++ b/server/session-naming.test.ts
@@ -1,0 +1,274 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SessionNaming, type SessionNamingDeps } from './session-naming.js'
+
+const mockGenerateText = vi.hoisted(() => vi.fn())
+vi.mock('ai', () => ({ generateText: (...args: any[]) => mockGenerateText(...args) }))
+vi.mock('@ai-sdk/groq', () => ({ createGroq: () => (model: string) => ({ modelId: model }) }))
+vi.mock('@ai-sdk/openai', () => ({ createOpenAI: () => (model: string) => ({ modelId: model }) }))
+vi.mock('@ai-sdk/google', () => ({ createGoogleGenerativeAI: () => (model: string) => ({ modelId: model }) }))
+vi.mock('@ai-sdk/anthropic', () => ({ createAnthropic: () => (model: string) => ({ modelId: model }) }))
+
+function makeDeps(overrides: Partial<SessionNamingDeps> = {}): SessionNamingDeps {
+  return {
+    getSession: vi.fn(() => undefined),
+    hasSession: vi.fn(() => true),
+    getSetting: vi.fn(() => 'auto'),
+    rename: vi.fn(() => true),
+    ...overrides,
+  }
+}
+
+function fakeSession(overrides: Record<string, any> = {}): any {
+  return {
+    name: 'hub:abc123',
+    _namingTimer: undefined,
+    _namingAttempts: 0,
+    _lastUserInput: 'fix the login bug',
+    outputHistory: [{ type: 'output', data: 'I will help fix the login bug.' }],
+    ...overrides,
+  }
+}
+
+describe('SessionNaming', () => {
+  let savedEnv: NodeJS.ProcessEnv
+
+  beforeEach(() => {
+    savedEnv = { ...process.env }
+    delete process.env.GROQ_API_KEY
+    delete process.env.OPENAI_API_KEY
+    delete process.env.GEMINI_API_KEY
+    delete process.env.ANTHROPIC_API_KEY
+    mockGenerateText.mockReset()
+  })
+
+  afterEach(() => {
+    process.env = savedEnv
+    vi.restoreAllMocks()
+  })
+
+  // 1. No API key — early exit
+  it('exits early with console.warn when no API keys are set', async () => {
+    const session = fakeSession()
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    await naming.executeSessionNaming('s1')
+
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No API key'))
+    expect(deps.rename).not.toHaveBeenCalled()
+    expect(mockGenerateText).not.toHaveBeenCalled()
+  })
+
+  // 2. No context yet — retry scheduled
+  it('re-schedules when no user input and no output history', async () => {
+    vi.useFakeTimers()
+    const session = fakeSession({ _lastUserInput: '', outputHistory: [] })
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+
+    await naming.executeSessionNaming('s1')
+
+    expect(mockGenerateText).not.toHaveBeenCalled()
+    expect(session._namingTimer).toBeDefined()
+    vi.useRealTimers()
+  })
+
+  // 3. scheduleSessionNaming — skips if session not found
+  it('skips scheduling when session is not found', () => {
+    vi.useFakeTimers()
+    const deps = makeDeps({ getSession: vi.fn(() => undefined) })
+    const naming = new SessionNaming(deps)
+
+    naming.scheduleSessionNaming('s1')
+
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  // 4. scheduleSessionNaming — skips if name doesn't start with 'hub:'
+  it('skips scheduling when session name does not start with hub:', () => {
+    vi.useFakeTimers()
+    const session = fakeSession({ name: 'My Custom Name' })
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+
+    naming.scheduleSessionNaming('s1')
+
+    expect(session._namingTimer).toBeUndefined()
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  // 5. scheduleSessionNaming — skips if timer already pending
+  it('skips scheduling when a timer is already pending', () => {
+    vi.useFakeTimers()
+    const existingTimer = setTimeout(() => {}, 99999)
+    const session = fakeSession({ _namingTimer: existingTimer })
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+
+    naming.scheduleSessionNaming('s1')
+
+    // Timer should remain the original one
+    expect(session._namingTimer).toBe(existingTimer)
+    vi.useRealTimers()
+  })
+
+  // 6. scheduleSessionNaming — skips after MAX_NAMING_ATTEMPTS (5)
+  it('skips scheduling when max naming attempts reached', () => {
+    vi.useFakeTimers()
+    const session = fakeSession({ _namingAttempts: 5 })
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+
+    naming.scheduleSessionNaming('s1')
+
+    expect(session._namingTimer).toBeUndefined()
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  // 7. scheduleSessionNaming — sets timer with correct delay (20s for first attempt)
+  it('sets timer with 20s delay on first attempt', () => {
+    vi.useFakeTimers()
+    const session = fakeSession({ _namingAttempts: 0 })
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+
+    naming.scheduleSessionNaming('s1')
+
+    expect(session._namingTimer).toBeDefined()
+    // Verify the timer fires after 20s
+    expect(vi.getTimerCount()).toBe(1)
+    vi.advanceTimersByTime(19_999)
+    // executeSessionNaming would be called, but session lookup returns the session
+    // Just verify the timer was set and fires at ~20s
+    expect(session._namingTimer).toBeDefined()
+    vi.useRealTimers()
+  })
+
+  // 8. executeSessionNaming — successful naming with valid AI response
+  it('renames session when AI returns a valid name', async () => {
+    process.env.GROQ_API_KEY = 'test-key'
+    const session = fakeSession()
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+    mockGenerateText.mockResolvedValue({ text: 'Fix Login Page Styling' })
+
+    await naming.executeSessionNaming('s1')
+
+    expect(deps.rename).toHaveBeenCalledWith('s1', 'Fix Login Page Styling')
+  })
+
+  // 9. executeSessionNaming — strips quotes and "session name:" prefix
+  it('strips quotes and session name prefix from AI response', async () => {
+    process.env.GROQ_API_KEY = 'test-key'
+    const session = fakeSession()
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+    mockGenerateText.mockResolvedValue({ text: '"Session Name: Fix Login Bug"' })
+
+    await naming.executeSessionNaming('s1')
+
+    expect(deps.rename).toHaveBeenCalledWith('s1', 'Fix Login Bug')
+  })
+
+  // 10. executeSessionNaming — rejects names with too few words
+  it('rejects names with fewer than 3 words and re-schedules', async () => {
+    vi.useFakeTimers()
+    process.env.GROQ_API_KEY = 'test-key'
+    const session = fakeSession()
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockGenerateText.mockResolvedValue({ text: 'Fix' })
+
+    await naming.executeSessionNaming('s1')
+
+    expect(deps.rename).not.toHaveBeenCalled()
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid name'))
+    expect(session._namingTimer).toBeDefined()
+    vi.useRealTimers()
+  })
+
+  // 11. executeSessionNaming — truncates names over 60 chars
+  it('truncates names longer than 60 characters at word boundary', async () => {
+    process.env.GROQ_API_KEY = 'test-key'
+    // 74 chars, 10 words — passes the <=80 length check but exceeds the 60-char truncation threshold
+    const longName = 'Refactor Authentication Module to Use Modern Token Based Session Management'
+    expect(longName.length).toBeGreaterThan(60)
+    expect(longName.length).toBeLessThanOrEqual(80)
+    expect(longName.split(/\s+/).length).toBeGreaterThanOrEqual(3)
+
+    const session = fakeSession()
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+    mockGenerateText.mockResolvedValue({ text: longName })
+
+    await naming.executeSessionNaming('s1')
+
+    expect(deps.rename).toHaveBeenCalled()
+    const finalName = (deps.rename as any).mock.calls[0][1]
+    expect(finalName.length).toBeLessThanOrEqual(60)
+  })
+
+  // 12. executeSessionNaming — API error triggers retry
+  it('re-schedules on API error without renaming', async () => {
+    vi.useFakeTimers()
+    process.env.GROQ_API_KEY = 'test-key'
+    const session = fakeSession()
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockGenerateText.mockRejectedValue(new Error('API rate limit'))
+
+    await naming.executeSessionNaming('s1')
+
+    expect(deps.rename).not.toHaveBeenCalled()
+    expect(session._namingTimer).toBeDefined()
+    vi.useRealTimers()
+  })
+
+  // 13. retrySessionNamingOnInteraction — sets 5s timer
+  it('sets a 5s timer on interaction retry', () => {
+    vi.useFakeTimers()
+    const session = fakeSession()
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+
+    naming.retrySessionNamingOnInteraction('s1')
+
+    expect(session._namingTimer).toBeDefined()
+    // Verify it fires at 5s
+    vi.advanceTimersByTime(4_999)
+    // Timer should still be pending
+    expect(vi.getTimerCount()).toBe(1)
+    vi.advanceTimersByTime(1)
+    // Timer should have fired
+    expect(vi.getTimerCount()).toBe(0)
+    vi.useRealTimers()
+  })
+
+  // 14. getNamingModel — respects preferred provider
+  it('uses preferred provider when setting specifies one', async () => {
+    process.env.OPENAI_API_KEY = 'test-openai-key'
+    process.env.GROQ_API_KEY = 'test-groq-key'
+    const session = fakeSession()
+    const deps = makeDeps({
+      getSession: vi.fn(() => session),
+      getSetting: vi.fn(() => 'openai'),
+    })
+    const naming = new SessionNaming(deps)
+    mockGenerateText.mockResolvedValue({ text: 'Fix Login Page Styling' })
+
+    await naming.executeSessionNaming('s1')
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: expect.objectContaining({ modelId: expect.stringContaining('gpt') }),
+      }),
+    )
+  })
+})

--- a/server/stepflow-handler.test.ts
+++ b/server/stepflow-handler.test.ts
@@ -365,6 +365,157 @@ describe('StepflowHandler', () => {
       expect(event!.error).toContain('clone failed')
     })
   })
+
+  // -------------------------------------------------------------------------
+  // postCallback SSRF protection
+  // -------------------------------------------------------------------------
+
+  describe('postCallback SSRF protection', () => {
+    const result = { sessionId: 'sess-1', status: 'completed', output: 'done' }
+    let mockFetch: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 })
+      global.fetch = mockFetch
+    })
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
+    // --- Protocol checks ---
+
+    it('throws for non-http(s) protocol', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: ['evil.com'] }), sessions)
+      await expect((handler as any).postCallback('ftp://evil.com/callback', result))
+        .rejects.toThrow('protocol ftp: not allowed')
+    })
+
+    // --- Allowlist checks ---
+
+    it('throws when host is not in allowlist', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: ['api.stepflow.io'] }), sessions)
+      await expect((handler as any).postCallback('https://evil.com/callback', result))
+        .rejects.toThrow('not in the allowlist')
+    })
+
+    it('throws when allowlist is empty', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: [] }), sessions)
+      await expect((handler as any).postCallback('https://anything.com/callback', result))
+        .rejects.toThrow('not in the allowlist')
+    })
+
+    // --- Private/link-local IP checks ---
+
+    // URL.hostname includes brackets for IPv6 and may normalize addresses,
+    // so the allowlist must use the forms that parsedUrl.hostname produces.
+    const allHosts = [
+      '127.0.0.1', 'localhost', '10.0.0.1', '192.168.1.1', '169.254.1.1',
+      '[::1]', '[fe80::1]', '[fc00::1]', '[::ffff:7f00:1]', 'api.stepflow.io',
+    ]
+
+    it('blocks private IP 127.0.0.1', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: allHosts }), sessions)
+      await expect((handler as any).postCallback('http://127.0.0.1:8080/callback', result))
+        .rejects.toThrow('private/link-local')
+    })
+
+    it('blocks private IP 10.x', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: allHosts }), sessions)
+      await expect((handler as any).postCallback('http://10.0.0.1/callback', result))
+        .rejects.toThrow('private/link-local')
+    })
+
+    it('blocks private IP 192.168.x', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: allHosts }), sessions)
+      await expect((handler as any).postCallback('http://192.168.1.1/callback', result))
+        .rejects.toThrow('private/link-local')
+    })
+
+    it('blocks private IP 169.254.x', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: allHosts }), sessions)
+      await expect((handler as any).postCallback('http://169.254.1.1/callback', result))
+        .rejects.toThrow('private/link-local')
+    })
+
+    it('blocks localhost', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: allHosts }), sessions)
+      await expect((handler as any).postCallback('http://localhost:3000/callback', result))
+        .rejects.toThrow('private/link-local')
+    })
+
+    it('blocks IPv6 ::1', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: allHosts }), sessions)
+      await expect((handler as any).postCallback('http://[::1]/callback', result))
+        .rejects.toThrow('private/link-local')
+    })
+
+    it('blocks IPv6 link-local fe80::', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: allHosts }), sessions)
+      await expect((handler as any).postCallback('http://[fe80::1]/callback', result))
+        .rejects.toThrow('private/link-local')
+    })
+
+    it('blocks IPv6 unique-local fc00/fd00', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: allHosts }), sessions)
+      await expect((handler as any).postCallback('http://[fc00::1]/callback', result))
+        .rejects.toThrow('private/link-local')
+    })
+
+    it('blocks ::ffff:127.0.0.1 — known gap: URL normalizes to ::ffff:7f00:1 bypassing regex', async () => {
+      // new URL('http://[::ffff:127.0.0.1]/...').hostname === '[::ffff:7f00:1]'
+      // The SSRF regex checks for the literal '::ffff:127.0.0.1' but the URL parser
+      // normalizes it to '::ffff:7f00:1' before the regex runs, so it is NOT blocked.
+      // This test documents the gap: the request reaches fetch instead of being rejected.
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: allHosts }), sessions)
+      await (handler as any).postCallback('http://[::ffff:127.0.0.1]/callback', result)
+      // If the SSRF check caught this, it would throw. Instead it passes through to fetch.
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    // --- Happy path ---
+
+    it('sends successful HTTPS callback with correct request shape', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: ['api.stepflow.io'] }), sessions)
+      await (handler as any).postCallback('https://api.stepflow.io/callback', result)
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const [url, opts] = mockFetch.mock.calls[0]
+      expect(url).toBe('https://api.stepflow.io/callback')
+      expect(opts.method).toBe('POST')
+      expect(opts.headers['Content-Type']).toBe('application/json')
+      expect(JSON.parse(opts.body)).toEqual(result)
+    })
+
+    it('sets HMAC signature header when callbackSecret is provided', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: ['api.stepflow.io'] }), sessions)
+      await (handler as any).postCallback('https://api.stepflow.io/callback', result, 'my-secret')
+
+      const [, opts] = mockFetch.mock.calls[0]
+      const sig = opts.headers['X-Stepflow-Signature'] as string
+      expect(sig).toBeDefined()
+      expect(sig.startsWith('sha256=')).toBe(true)
+      // After 'sha256=' should be a valid hex string
+      expect(/^[0-9a-f]+$/.test(sig.slice(7))).toBe(true)
+    })
+
+    it('omits HMAC signature header when callbackSecret is absent', async () => {
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: ['api.stepflow.io'] }), sessions)
+      await (handler as any).postCallback('https://api.stepflow.io/callback', result)
+
+      const [, opts] = mockFetch.mock.calls[0]
+      expect(opts.headers['X-Stepflow-Signature']).toBeUndefined()
+    })
+
+    // --- Error handling ---
+
+    it('throws when callback returns non-2xx response', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 502 })
+      handler = new StepflowHandler(makeConfig({ allowedCallbackHosts: ['api.stepflow.io'] }), sessions)
+      await expect((handler as any).postCallback('https://api.stepflow.io/callback', result))
+        .rejects.toThrow('returned HTTP 502')
+    })
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/hooks/useSettings.test.ts
+++ b/src/hooks/useSettings.test.ts
@@ -2,7 +2,7 @@
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { createElement, act } from 'react'
 import { createRoot } from 'react-dom/client'
 
@@ -85,6 +85,13 @@ describe('useSettings', () => {
       expect(result.current.settings.token).toBe('')
       unmount()
     })
+
+    it('defaults theme to dark when saved theme is not light', () => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ token: '', theme: 'blue' }))
+      const { result, unmount } = renderHook(() => useSettings())
+      expect(result.current.settings.theme).toBe('dark')
+      unmount()
+    })
   })
 
   describe('updateSettings', () => {
@@ -126,6 +133,58 @@ describe('useSettings', () => {
       })
 
       expect(result.current.settings.token).toBe('abc') // preserved
+      unmount()
+    })
+
+    it('remounting reads updated values from localStorage (round-trip)', () => {
+      const { result: r1, unmount: u1 } = renderHook(() => useSettings())
+      act(() => {
+        r1.current.updateSettings({ token: 'round-trip-tok' })
+      })
+      u1()
+
+      const { result: r2, unmount: u2 } = renderHook(() => useSettings())
+      expect(r2.current.settings.token).toBe('round-trip-tok')
+      u2()
+    })
+  })
+
+  describe('URL token parameter', () => {
+    let originalReplaceState: typeof window.history.replaceState
+
+    beforeEach(() => {
+      originalReplaceState = window.history.replaceState
+      window.history.replaceState = vi.fn()
+    })
+
+    afterEach(() => {
+      window.history.replaceState = originalReplaceState
+    })
+
+    it('reads token from URL ?token= parameter and persists it', () => {
+      // Use the real replaceState to set the URL, then swap in mock
+      window.history.replaceState = originalReplaceState
+      window.history.replaceState({}, '', '/?token=url-tok-123')
+      window.history.replaceState = vi.fn()
+
+      const { result, unmount } = renderHook(() => useSettings())
+      expect(result.current.settings.token).toBe('url-tok-123')
+
+      const stored = JSON.parse(localStorage.getItem(STORAGE_KEY)!)
+      expect(stored.token).toBe('url-tok-123')
+      unmount()
+    })
+
+    it('strips token from URL after reading it', () => {
+      window.history.replaceState = originalReplaceState
+      window.history.replaceState({}, '', '/?token=strip-me')
+      window.history.replaceState = vi.fn()
+
+      const { unmount } = renderHook(() => useSettings())
+
+      expect(window.history.replaceState).toHaveBeenCalled()
+      const calledUrl = (window.history.replaceState as ReturnType<typeof vi.fn>).mock.calls[0][2] as string
+      expect(calledUrl).not.toContain('token=')
       unmount()
     })
   })

--- a/src/lib/ccApi.test.ts
+++ b/src/lib/ccApi.test.ts
@@ -17,6 +17,10 @@ import {
   deleteArchivedSession,
   getRetentionDays,
   setRetentionDays,
+  getSupportProvider,
+  getWebhookConfig,
+  getWebhookEvents,
+  setSupportProvider,
 } from './ccApi'
 
 const mockFetch = vi.fn()
@@ -691,5 +695,98 @@ describe('setRetentionDays', () => {
   it('throws on non-ok response', async () => {
     mockFetch.mockResolvedValue(jsonResponse({}, 400))
     await expect(setRetentionDays('tok', 0)).rejects.toThrow('Failed to update retention settings: 400')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getSupportProvider
+// ---------------------------------------------------------------------------
+
+describe('getSupportProvider', () => {
+  it('returns preferred and available providers', async () => {
+    const data = { preferred: 'groq', available: ['groq', 'openai', 'anthropic'] }
+    mockFetch.mockResolvedValue(jsonResponse(data))
+    const result = await getSupportProvider('tok')
+    expect(result).toEqual(data)
+    expect(mockFetch).toHaveBeenCalledWith('/cc/api/settings/support-provider', {
+      headers: { Authorization: 'Bearer tok' },
+    })
+  })
+
+  it('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}, 500))
+    await expect(getSupportProvider('tok')).rejects.toThrow('Failed to get support provider: 500')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getWebhookConfig
+// ---------------------------------------------------------------------------
+
+describe('getWebhookConfig', () => {
+  it('returns config from response', async () => {
+    const config = { enabled: true, maxConcurrentSessions: 3, logLinesToInclude: 50 }
+    mockFetch.mockResolvedValue(jsonResponse({ config }))
+    const result = await getWebhookConfig('tok')
+    expect(result).toEqual(config)
+    expect(mockFetch).toHaveBeenCalledWith('/cc/api/webhooks/config', {
+      headers: { Authorization: 'Bearer tok' },
+    })
+  })
+
+  it('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}, 500))
+    await expect(getWebhookConfig('tok')).rejects.toThrow('Failed to get webhook config: 500')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// getWebhookEvents
+// ---------------------------------------------------------------------------
+
+describe('getWebhookEvents', () => {
+  it('returns events array from response', async () => {
+    const events = [{ id: 'e1', repo: 'foo/bar', branch: 'main', workflow: 'ci', conclusion: 'success', status: 'completed', receivedAt: '2026-01-01' }]
+    mockFetch.mockResolvedValue(jsonResponse({ events }))
+    const result = await getWebhookEvents('tok')
+    expect(result).toEqual(events)
+    expect(mockFetch).toHaveBeenCalledWith('/cc/api/webhooks/events', {
+      headers: { Authorization: 'Bearer tok' },
+    })
+  })
+
+  it('returns empty array when events field is missing', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}))
+    const result = await getWebhookEvents('tok')
+    expect(result).toEqual([])
+  })
+
+  it('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}, 500))
+    await expect(getWebhookEvents('tok')).rejects.toThrow('Failed to get webhook events: 500')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// setSupportProvider
+// ---------------------------------------------------------------------------
+
+describe('setSupportProvider', () => {
+  it('sends PUT with provider and resolves', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}, 200))
+    await expect(setSupportProvider('tok', 'groq')).resolves.toBeUndefined()
+    expect(mockFetch).toHaveBeenCalledWith('/cc/api/settings/support-provider', {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer tok',
+      },
+      body: JSON.stringify({ provider: 'groq' }),
+    })
+  })
+
+  it('throws on non-ok response', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({}, 400))
+    await expect(setSupportProvider('tok', 'openai')).rejects.toThrow('Failed to set support provider: 400')
   })
 })


### PR DESCRIPTION
## Summary

- Addresses the top 7 findings from the 2026-03-09 test coverage audit
- Adds 78 new tests across 3 new and 4 extended test files (855 → 933 total)
- New: `crypto-utils.test.ts` (18), `config.test.ts` (12), `session-naming.test.ts` (14)
- Extended: `stepflow-handler.test.ts` (+16), `session-manager.test.ts` (+5), `ccApi.test.ts` (+9), `useSettings.test.ts` (+3)

### Coverage targets addressed

| Priority | File | Area | Tests |
|----------|------|------|-------|
| 1 | `server/crypto-utils.ts` | `verifySessionToken` length-check short-circuit (lines 55–68) | 18 |
| 2 | `server/stepflow-handler.ts` | `postCallback` SSRF protection (lines 392–438) | 16 |
| 3 | `server/session-manager.ts` | `setModel` restart path (lines 964–1004) | 5 |
| 4 | `server/config.ts` | Environment variable edge cases (lines 25–47) | 12 |
| 5 | `server/session-naming.ts` | No-API-key and no-context early exits (lines 113–120) | 14 |
| 7 | `src/lib/ccApi.ts` | `getSupportProvider`, webhook config/events (lines 309–350) | 9 |
| 10 | `src/hooks/useSettings.ts` | localStorage round-trip persistence (lines 33–38) | 3 |

### Notable finding

The SSRF tests uncovered a known gap: `new URL('http://[::ffff:127.0.0.1]/...')` normalizes the hostname to `::ffff:7f00:1`, bypassing the regex that checks for the literal `::ffff:127.0.0.1`. Documented in the test; fix can follow separately.

## Test plan

- [x] `npm test` — 933 tests pass, 0 failures
- [ ] CI pipeline confirms all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)