### PR TITLE
Chore: update test coverage report 2026-03-09

### DIFF
--- a/.codekin/reports/test-coverage/2026-03-09.md
+++ b/.codekin/reports/test-coverage/2026-03-09.md
@@ -1,130 +1,102 @@
 # Test Coverage Report — 2026-03-09
 
-**Framework:** Vitest 4.x with `@vitest/coverage-v8`
-**Test results:** 32 test files, 795 tests passed, 0 failed
-**Branch:** `feat/workflow-list-larger-fonts`
+**Framework:** Vitest 4.0.18 with `@vitest/coverage-v8`
+**Test results:** 33 test files, 855 tests passed, 0 failed
+**Branch:** `main`
 
 ## Summary
 
 | Metric     | Coverage % |
-|------------|-----------|
-| Statements | 83.47%    |
-| Branches   | 76.92%    |
-| Functions  | 83.21%    |
-| Lines      | 84.09%    |
+|------------|------------|
+| Statements | 84.87 %    |
+| Branches   | 76.79 %    |
+| Functions  | 81.83 %    |
+| Lines      | 86.02 %    |
 
 ## Uncovered Files
 
-The following source files have **0% coverage** (no test imports them at all):
+No source files registered **0 %** in the v8 report; however, the following server-side
+route/infrastructure files have **no dedicated test file** and are absent from the
+instrumented coverage table, meaning they are at most incidentally exercised:
 
 ### Server (`server/`)
-- `server/ws-server.ts` — WebSocket server entry point
-- `server/webhook-routes.ts` — Webhook HTTP route handlers
-- `server/session-routes.ts` — Session HTTP route handlers
-- `server/auth-routes.ts` — Authentication route handlers
-- `server/upload-routes.ts` — File upload route handlers
-- `server/workflow-routes.ts` — Workflow HTTP route handlers
-- `server/stepflow-handler.ts` — Step-flow execution handler
-- `server/stepflow-prompt.ts` — Step-flow prompt builder
-- `server/stepflow-types.ts` — Step-flow type definitions
-- `server/webhook-types.ts` — Webhook type definitions
-- `server/types.ts` — Shared server type definitions
+- `server/auth-routes.ts` — authentication middleware and routes
+- `server/docs-routes.ts` — documentation serving routes
+- `server/session-routes.ts` — session CRUD HTTP handlers
+- `server/upload-routes.ts` — file upload route handlers
+- `server/webhook-routes.ts` — webhook ingestion routes
+- `server/workflow-routes.ts` — workflow management routes
+- `server/ws-message-handler.ts` — WebSocket incoming message dispatcher
+- `server/ws-server.ts` — WebSocket server setup and upgrade logic
 
-### Frontend (`src/`)
-- `src/main.tsx` — React entry point
-- `src/App.tsx` — Root application component
-- `src/types.ts` — Shared frontend type definitions
-- `src/hooks/useTentativeQueue.ts` — Tentative message queue hook
-- `src/hooks/useRepos.ts` — Repository list hook
-- `src/hooks/useWorkflows.ts` — Workflows data hook
-- `src/components/ChatView.tsx` — Chat message display
-- `src/components/InputBar.tsx` — Message input component
-- `src/components/SessionList.tsx` — Session list sidebar
-- `src/components/SessionListPanel.tsx` — Session list panel wrapper
-- `src/components/SessionBar.tsx` — Session header bar
-- `src/components/RepoSelector.tsx` — Repository selector dropdown
-- `src/components/RepoList.tsx` — Repository list component
-- `src/components/Settings.tsx` — Settings panel
-- `src/components/CommandPalette.tsx` — Command palette (Cmd+K)
-- `src/components/LeftSidebar.tsx` — Left sidebar layout
-- `src/components/RightSidebar.tsx` — Right sidebar layout
-- `src/components/StatusIndicator.tsx` — Connection status indicator
-- `src/components/TodoPanel.tsx` — Todo list panel
-- `src/components/ApprovalsPanel.tsx` — Tool approval panel
-- `src/components/ArchivedSessionsPanel.tsx` — Archived sessions panel
-- `src/components/ModuleBrowser.tsx` — Module browser component
-- `src/components/SkillBrowser.tsx` — Skill browser component
-- `src/components/SkillMenu.tsx` — Skill menu component
-- `src/components/WorkflowsView.tsx` — Workflows list view
-- `src/components/WorkflowBadges.tsx` — Workflow status badges
-- `src/components/EditWorkflowModal.tsx` — Edit workflow modal
-- `src/components/AddWorkflowModal.tsx` — Add workflow modal
-- `src/components/DropZone.tsx` — File drop zone
-- `src/components/TentativeBanner.tsx` — Tentative message banner
-- `src/components/NewSessionButton.tsx` — New session button
-- `src/components/PromptButtons.tsx` — Quick prompt buttons
-- `src/components/AppIcon.tsx` — Application icon
+### Frontend (`src/components/`)
+All React components lack dedicated test files and are absent from coverage:
+`ChatView.tsx`, `InputBar.tsx`, `LeftSidebar.tsx`, `ApprovalsPanel.tsx`,
+`ArchivedSessionsPanel.tsx`, `CommandPalette.tsx`, `DropZone.tsx`,
+`EditWorkflowModal.tsx`, `AddWorkflowModal.tsx`, `MobileTopBar.tsx`,
+`MarkdownRenderer.tsx`, `ModuleBrowser.tsx`, `NewSessionButton.tsx`,
+`PromptButtons.tsx`, `RepoList.tsx`, `RepoSection.tsx`, `RepoSelector.tsx`
 
 ## Low Coverage Files
 
-Files included in coverage with < 100% line coverage, sorted ascending:
+Sorted by statement coverage ascending (top 15 individual files):
 
-| File | Line % | Branch % | Notes |
-|------|--------|----------|-------|
-| `server/workflow-loader.ts` | **35.42%** | 39.18% | Only 29% of functions covered |
-| `server/session-manager.ts` | **72.20%** | 65.96% | Core session logic, 74% functions |
-| `.claude/hooks/lib/handler.mjs` | **81.81%** | 80.00% | Error handling paths uncovered |
-| `server/workflow-engine.ts` | **86.84%** | 69.56% | Cron/trigger paths partially covered |
-| `src/lib/workflowApi.ts` | **86.79%** | 83.78% | Error response paths |
-| `src/lib/ccApi.ts` | **90.80%** | 88.46% | Some API endpoints untested |
-| `server/webhook-handler.ts` | **90.43%** | 74.66% | Branch coverage notably low |
-| `src/hooks/useChatSocket.ts` | **92.80%** | 82.26% | Reconnection/error paths |
-| `server/webhook-github.ts` | **93.65%** | 93.75% | 2 uncovered functions |
-| `server/config.ts` | **92.30%** | 86.36% | One fallback path |
-| `src/hooks/useRouter.ts` | **94.11%** | 90.90% | Minor branch gap |
-| `server/webhook-workspace.ts` | **95.91%** | 80.00% | Edge-case branches |
-| `server/webhook-rate-limiter.ts` | **96.66%** | 85.71% | One uncovered line |
-| `server/claude-process.ts` | **97.84%** | 85.83% | Process lifecycle edges |
-| `server/session-archive.ts` | **97.72%** | 92.00% | One uncovered line |
+| File | Stmts % | Branch % | Uncovered Lines |
+|------|---------|----------|-----------------|
+| `server/crypto-utils.ts` | 64.28 | 50.00 | 55–68 |
+| `server/session-manager.ts` | 68.51 | 64.02 | ~964–1004, 1047–1049 |
+| `server/workflow-loader.ts` | 71.57 | 63.15 | ~320–345, 374, 426 |
+| `server/config.ts` | 72.72 | 75.00 | 25–27, 30, 47 |
+| `server/stepflow-handler.ts` | 78.33 | 61.95 | ~280–305, 392–438 |
+| `server/session-naming.ts` | 79.74 | 58.73 | ~113–114, 119–120 |
+| `src/lib/ccApi.ts` | 79.84 | 78.40 | ~178–180, 309–350 |
+| `src/hooks/useSettings.ts` | 82.60 | 75.00 | 33–38 |
+| `.claude/hooks/lib/handler.mjs` | 83.33 | 80.00 | 28–29 |
+| `server/workflow-engine.ts` | 84.36 | 69.14 | ~638–639, 653–667 |
+| `src/lib/workflowApi.ts` | 86.95 | 83.78 | 90–96 |
+| `src/hooks/useChatSocket.ts` | 88.31 | 79.88 | ~609, 614, 645–647 |
+| `server/webhook-workspace.ts` | 89.47 | 71.42 | 101, 106, 159–163 |
+| `server/webhook-handler.ts` | 90.00 | 75.40 | ~284–286, 372–374 |
+| `server/approval-manager.ts` | 92.24 | 88.65 | ~164, 217, 224–225 |
 
 ## Prioritised Test Proposals
 
-1. **`server/workflow-loader.ts` — `loadWorkflowDefinitions()` and YAML parsing**
-   - **Scenario:** Test loading valid/invalid YAML workflow files, missing directories, duplicate workflow IDs
-   - **Rationale:** At 35% line coverage, this is the lowest-covered file. It handles workflow discovery and parsing — errors here silently break all workflows.
+1. **`server/crypto-utils.ts` — `verifySessionToken` / length-check short-circuit (lines 55–68)**
+   - Scenario: derive a session token for a known master+sessionId pair and confirm `verifySessionToken` returns `true`; mutate the candidate by one byte and confirm rejection; supply a candidate of the wrong length and confirm the early-return `false` branch fires without reaching `timingSafeEqual`.
+   - Rationale: These HMAC helpers authenticate every WebSocket connection. The verification path (50 % branch coverage) is the highest-risk security gap in the entire codebase — a regression here would accept forged tokens.
 
-2. **`server/session-manager.ts` — WebSocket message routing and session lifecycle**
-   - **Scenario:** Test `handleMessage()` for each message type, session creation/destruction race conditions, reconnection handling
-   - **Rationale:** At 72% coverage with critical session state management, uncovered paths (lines 1324–1525) likely include error recovery and edge cases that affect user experience.
+2. **`server/stepflow-handler.ts` — `postCallback` SSRF protection (lines 392–438)**
+   - Scenario: (a) happy-path HTTPS callback — succeeds and sets HMAC header when `callbackSecret` provided; (b) non-`http(s)` protocol throws; (c) hostname not in allowlist throws; (d) private IPv4 ranges `127.x`, `10.x`, `192.168.x`, `169.254.x`, and strings `localhost`/`::1`/`fe80::*` each throw; (e) server returns non-2xx — throws.
+   - Rationale: `postCallback` is the SSRF guardrail for all outbound webhook deliveries. Branch coverage is 62 % and lines 392–438 are entirely untested.
 
-3. **`server/stepflow-handler.ts` — Step execution and state transitions**
-   - **Scenario:** Test step success/failure/timeout transitions, concurrent step execution, output collection
-   - **Rationale:** Completely untested file that handles multi-step workflow execution — a critical path for the workflow feature.
+3. **`server/session-manager.ts` — `setModel` restart path and `generateContextSummary` (lines ~964–1004, 1047–1049)**
+   - Scenario: `setModel` when the Claude process is alive (verify stop + delayed restart); when session is not alive (verify no restart); when sessionId is unknown (returns `false`). `generateContextSummary` with a mix of `assistant_text`, `tool_result`, and `user_echo` messages including text truncation at 500 chars.
+   - Rationale: `setModel` is invoked from the WebSocket command path; `generateContextSummary` feeds session auto-naming. Both are production-used with no direct test coverage.
 
-4. **`server/webhook-handler.ts` — Branch coverage gaps (74.66%)**
-   - **Scenario:** Test malformed payloads, signature verification failures, duplicate event handling, rate-limited requests
-   - **Rationale:** While line coverage is 90%, branch coverage is only 75% — many error/edge paths are unvalidated.
+4. **`server/workflow-loader.ts` — `saveWorkflowReport` git commit path (lines ~320–345, 374)**
+   - Scenario: mock `execFileSync` and `writeFileSync`; test (a) creation of a new `codekin/reports` branch when it does not yet exist; (b) stash applied and popped; (c) no stash when working tree is clean; (d) error recovery when `git commit` fails mid-operation.
+   - Rationale: The git branch-and-commit logic that persists automated workflow reports is entirely uncovered. A regression silently drops all generated reports.
 
-5. **`server/workflow-engine.ts` — Cron trigger and error recovery (lines 623–652)**
-   - **Scenario:** Test cron schedule firing, overlapping run prevention, database errors during run creation
-   - **Rationale:** Branch coverage is only 70%. The uncovered lines are in the cron scheduler tick and shutdown paths — exactly where reliability matters most.
+5. **`server/session-naming.ts` — no-API-key and no-context-yet early exits (lines 113–114, 119–120)**
+   - Scenario: call `scheduleSessionNaming` with none of `GROQ_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`, or `ANTHROPIC_API_KEY` set — assert warning is logged and no fetch occurs; also test the branch where `_lastUserInput` and accumulated output are both empty — assert retry is scheduled rather than an API call attempted.
+   - Rationale: Branch coverage is 59 %. These guards prevent silent failures when the server runs without AI credentials; neither has been exercised by tests.
 
-6. **`server/webhook-routes.ts` — HTTP endpoint integration tests**
-   - **Scenario:** Test POST/GET/DELETE routes with valid and invalid auth tokens, content types, and payloads
-   - **Rationale:** Completely untested route layer. Even basic request/response tests would catch regressions in API contracts.
+6. **`server/config.ts` — environment variable edge cases (lines 25–27, 30, 47)**
+   - Scenario: verify `getConfig()` when `CODEKIN_PORT` is non-numeric (falls back to default 32352); when `CODEKIN_AUTH_TOKEN` is absent (returns `undefined`); when `CODEKIN_ALLOWED_ORIGINS` is a comma-separated string (parsed into an array correctly).
+   - Rationale: `config.ts` is the entry point for all runtime configuration. Wrong env-var parsing would affect every deployment; these branches are completely untested.
 
-7. **`src/hooks/useTentativeQueue.ts` — Queue state management**
-   - **Scenario:** Test enqueue/dequeue ordering, queue overflow, clearing on session switch
-   - **Rationale:** Untested hook managing temporary UI state — bugs here cause ghost messages or lost user input.
+7. **`src/lib/ccApi.ts` — `sendMessage`, `stopSession`, `createSession` (lines ~309–350)**
+   - Scenario: success response for each function; non-2xx HTTP response (throws with status text); network-level `fetch` rejection (rethrows); verify `Authorization: Bearer <token>` header is forwarded on all calls.
+   - Rationale: These are the frontend's primary communication functions. The uncovered block covers multiple API call-sites and their error handling.
 
-8. **`src/hooks/useWorkflows.ts` — Workflow data fetching and caching**
-   - **Scenario:** Test initial fetch, polling refresh, error states, stale data handling
-   - **Rationale:** Untested hook that drives the entire workflows UI. Testing the data layer independently from components is straightforward and high-value.
+8. **`server/workflow-engine.ts` — step retry, cancellation, and timeout paths (lines ~638–667)**
+   - Scenario: a workflow step fails and the engine re-queues it with incremented attempt count; a running workflow is cancelled mid-step and the cancellation propagates; a step exceeds its `timeoutMs` and is marked timed-out rather than errored.
+   - Rationale: Branch coverage is 69 %. Error-handling and retry paths are core to workflow reliability but are the ones most likely broken by refactors.
 
-9. **`src/lib/ccApi.ts` — Uncovered API functions (lines 126–131, 278–290)**
-   - **Scenario:** Test the specific API call functions at the uncovered lines (likely archive/delete operations), including network error handling
-   - **Rationale:** At 91% coverage, a few targeted tests would bring this critical API layer to near-complete coverage.
+9. **`server/webhook-workspace.ts` — error recovery branches (lines 101, 106, 159–163)**
+   - Scenario: `cleanupWorkspace` when `rmSync` throws (e.g. `EACCES`) — confirm error is swallowed/logged; `createWorkspace` when the mirror fetch fails but a stale mirror exists — confirm processing continues; `mkdirSync` failure during workspace setup — confirm rejection propagates.
+   - Rationale: Workspace creation is on the hot path for every incoming webhook; the error-recovery branches (71 % branch coverage) are completely untested.
 
-10. **`server/stepflow-prompt.ts` — Prompt template generation**
-    - **Scenario:** Test prompt rendering with various step configurations, variable substitution, edge cases (empty steps, special characters)
-    - **Rationale:** Completely untested prompt builder. Malformed prompts silently produce wrong Claude behavior — these bugs are hard to trace without unit tests.
+10. **`src/hooks/useSettings.ts` — localStorage persistence round-trip (lines 33–38)**
+    - Scenario: render the hook, mutate a setting, remount in a fresh render and confirm the mutated value is re-read from `localStorage`; also confirm default values are used when `localStorage` is empty; confirm invalid JSON in storage does not throw but returns defaults.
+    - Rationale: Settings persistence affects every user's theme and connection preferences. The uncovered lines are the read/write path that could silently revert settings after a page reload.


### PR DESCRIPTION
## Summary
- Updates `.codekin/reports/test-coverage/2026-03-09.md` to reflect current `main` branch results
- Corrects test count (795 → 855), file count (32 → 33), branch name, and coverage metrics
- Rewrites the uncovered-files section to accurately describe route-layer gaps vs. true 0% files

## Test plan
- [ ] Verify report content matches `npm test` output on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)