### PR TITLE
Suppress npm warnings during install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,10 +66,10 @@ check_claude() {
 install_codekin() {
   if [[ "$CODEKIN_VERSION" == "latest" ]]; then
     info "Installing codekin (latest)..."
-    npm install -g codekin
+    npm install -g codekin --loglevel=error
   else
     info "Installing codekin@${CODEKIN_VERSION}..."
-    npm install -g "codekin@${CODEKIN_VERSION}"
+    npm install -g "codekin@${CODEKIN_VERSION}" --loglevel=error
   fi
   success "codekin $(codekin --version 2>/dev/null || echo 'installed')."
 }


### PR DESCRIPTION
Adds --loglevel=error to npm install in install.sh so upstream deprecation warnings like prebuild-install are hidden from users.