### PR TITLE
Show helpful message when GitHub CLI is not installed

### DIFF
--- a/server/upload-routes.ts
+++ b/server/upload-routes.ts
@@ -214,8 +214,12 @@ export function createUploadRouter(
       res.json({ groups, globalSkills, globalModules })
     } catch (err) {
       console.error('Failed to list repos from GitHub:', err)
+      const ghMissing = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT'
+      if (ghMissing) {
+        console.error('GitHub CLI (gh) not found. Install it: https://cli.github.com')
+      }
       // Return skills/modules even when GitHub is unavailable
-      res.json({ groups: [], globalSkills, globalModules })
+      res.json({ groups: [], globalSkills, globalModules, ghMissing })
     }
   })
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ import { RepoSelector } from './components/RepoSelector'
 
 export default function App() {
   const { settings, updateSettings } = useSettings()
-  const { groups, repos, globalSkills, globalModules } = useRepos(settings.token)
+  const { groups, repos, globalSkills, globalModules, ghMissing } = useRepos(settings.token)
   const { sessions, rename: renameSession, remove: removeSession, refresh: refreshSessions } = useSessions(settings.token)
   const { queues: tentativeQueues, addToQueue, clearQueue } = useTentativeQueue()
   const { sessionId: urlSessionId, view, navigate } = useRouter()
@@ -586,7 +586,7 @@ export default function App() {
             />
           </div>
         ) : (
-          <RepoSelector groups={groups} token={settings.token} onOpen={handleOpenSession} />
+          <RepoSelector groups={groups} token={settings.token} ghMissing={ghMissing} onOpen={handleOpenSession} />
         )}
       </div>
 

--- a/src/components/RepoSelector.tsx
+++ b/src/components/RepoSelector.tsx
@@ -15,10 +15,11 @@ import { RepoList } from './RepoList'
 interface Props {
   groups: RepoGroup[]
   token?: string
+  ghMissing?: boolean
   onOpen: (repo: Repo) => void
 }
 
-export function RepoSelector({ groups, token, onOpen }: Props) {
+export function RepoSelector({ groups, token, ghMissing, onOpen }: Props) {
   const [cloning, setCloning] = useState<string | null>(null)
 
   async function handleSelect(repo: ApiRepo) {
@@ -61,7 +62,21 @@ export function RepoSelector({ groups, token, onOpen }: Props) {
           <h2 className="text-[19px] font-medium text-neutral-2">Choose a repository to start a Claude Code session</h2>
         </div>
 
-        {totalRepos === 0 ? (
+        {ghMissing ? (
+          <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-[13px] leading-relaxed text-neutral-3">
+            <p className="mb-2 font-medium text-amber-400">GitHub CLI (gh) not found</p>
+            <p className="text-neutral-4">The repo browser needs <code className="rounded bg-neutral-8 px-1 py-0.5 text-neutral-3">gh</code> to list and clone your repositories.</p>
+            <p className="mt-2 text-neutral-4">
+              Install it:{' '}
+              <a href="https://cli.github.com" target="_blank" rel="noreferrer" className="text-amber-400 underline underline-offset-2 hover:text-amber-300">
+                https://cli.github.com
+              </a>
+            </p>
+            <p className="mt-1 text-neutral-4">
+              Then run: <code className="rounded bg-neutral-8 px-1 py-0.5 text-neutral-3">gh auth login</code>
+            </p>
+          </div>
+        ) : totalRepos === 0 ? (
           <p className="text-center text-[17px] text-neutral-6">No repositories configured</p>
         ) : (
           <RepoList

--- a/src/hooks/useRepos.ts
+++ b/src/hooks/useRepos.ts
@@ -29,6 +29,7 @@ export function useRepos(token?: string) {
   const [globalModules, setGlobalModules] = useState<Module[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [ghMissing, setGhMissing] = useState(false)
 
   // Flat list for compatibility (CommandPalette, etc.)
   const repos = groups.flatMap(g => g.repos)
@@ -39,17 +40,18 @@ export function useRepos(token?: string) {
     fetch('/cc/api/repos', { headers })
       .then(res => {
         if (!res.ok) throw new Error(`Failed to load repos: ${res.status}`)
-        return res.json() as Promise<{ groups: RepoGroup[]; globalSkills?: Skill[]; globalModules?: Module[] }>
+        return res.json() as Promise<{ groups: RepoGroup[]; globalSkills?: Skill[]; globalModules?: Module[]; ghMissing?: boolean }>
       })
       .then(data => {
         setGroups(data.groups)
         setGlobalSkills(data.globalSkills ?? [])
         setGlobalModules(data.globalModules ?? [])
+        setGhMissing(data.ghMissing ?? false)
         setError(null)
       })
       .catch(err => setError(err.message))
       .finally(() => setLoading(false))
   }, [token])
 
-  return { groups, repos, globalSkills, globalModules, loading, error }
+  return { groups, repos, globalSkills, globalModules, loading, error, ghMissing }
 }


### PR DESCRIPTION
## Summary
- Detects when `gh` CLI is missing (ENOENT error) on the server and returns `ghMissing: true` in the API response
- Surfaces a styled amber warning in the repo selector with install instructions and a link to https://cli.github.com
- Replaces the generic "No repositories configured" message when the root cause is a missing `gh` binary

## Test plan
- [ ] Temporarily rename/remove `gh` binary and verify the warning appears on the landing page
- [ ] Verify normal repo listing still works when `gh` is installed
- [ ] Verify build passes with `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)