### PR TITLE
Bump version to 0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codekin",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "license": "MIT",
   "licenseNotes": "dompurify is dual-licensed (MPL-2.0 OR Apache-2.0); both are permissively compatible with MIT for library use",
   "author": "multiplier-labs",


### PR DESCRIPTION
Bump npm package version to 0.3.4 for release. Changes since v0.3.3: suppress npm warnings (#82), gh auth check (#83), config/uninstall commands (#84), gh missing message (#85), launchd PATH fix.