### PR TITLE
Inject PATH and HOME into launchd plist

### DIFF
--- a/bin/codekin.mjs
+++ b/bin/codekin.mjs
@@ -216,6 +216,9 @@ const LAUNCHD_PLIST = join(homedir(), 'Library', 'LaunchAgents', `${LAUNCHD_LABE
 function buildPlist() {
   const { script, runner } = findServerScript()
   const envVars = readEnvFile()
+  // Inject PATH and HOME so launchd service can find gh, node, etc.
+  if (!envVars.PATH && process.env.PATH) envVars.PATH = process.env.PATH
+  if (!envVars.HOME) envVars.HOME = homedir()
   const envEntries = Object.entries(envVars)
     .map(([k, v]) => `\t\t<key>${k}</key>\n\t\t<string>${v}</string>`)
     .join('\n')


### PR DESCRIPTION
The launchd service runs with a minimal environment, so gh/node cannot be found. Injects PATH and HOME from the current user session into the plist at service install time.