### PR TITLE
Bump version to 0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codekin",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "license": "MIT",
   "licenseNotes": "dompurify is dual-licensed (MPL-2.0 OR Apache-2.0); both are permissively compatible with MIT for library use",
   "author": "multiplier-labs",


### PR DESCRIPTION
Release 0.3.6: auto-detect GitHub orgs in repo browser (#90), remove org prompt from installer (#91).