### PR TITLE
Fix docs browser auth, model init spam, and repo search focus

### DIFF
--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -430,7 +430,11 @@ export class SessionManager {
 
   private onSystemInit(cp: ClaudeProcess, session: Session, model: string): void {
     session.claudeSessionId = cp.getSessionId()
-    this.broadcastAndHistory(session, { type: 'system_message', subtype: 'init', text: `Model: ${model}`, model })
+    // Only show model message on first init or when model actually changes
+    if (!session._lastReportedModel || session._lastReportedModel !== model) {
+      session._lastReportedModel = model
+      this.broadcastAndHistory(session, { type: 'system_message', subtype: 'init', text: `Model: ${model}`, model })
+    }
   }
 
   private onTextEvent(session: Session, sessionId: string, text: string): void {

--- a/server/types.ts
+++ b/server/types.ts
@@ -53,6 +53,8 @@ export interface Session {
   _namingTimer?: ReturnType<typeof setTimeout>
   /** Number of naming attempts so far (for retry back-off). */
   _namingAttempts: number
+  /** The model reported by the last system init event, used to suppress duplicate init messages. */
+  _lastReportedModel?: string
   /** Last user input sent, stored for API error retry. */
   _lastUserInput?: string
   /** Number of consecutive API error retries for the current turn. */

--- a/src/components/NewSessionButton.tsx
+++ b/src/components/NewSessionButton.tsx
@@ -110,6 +110,7 @@ export function NewSessionButton({ groups, token, onOpen }: Props) {
               onSelect={handleSelect}
               cloningId={cloning}
               maxHeight="240px"
+              autoFocus
             />
           </div>
         </div>

--- a/src/components/RepoList.tsx
+++ b/src/components/RepoList.tsx
@@ -3,7 +3,7 @@
  * and AddWorkflowModal.
  */
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { IconGitBranch, IconCloud } from '@tabler/icons-react'
 import type { ApiRepo, RepoGroup } from '../hooks/useRepos'
 
@@ -21,6 +21,11 @@ interface Props {
 
 export function RepoList({ groups, selectedId, onSelect, cloningId, maxHeight = '240px', autoFocus }: Props) {
   const [search, setSearch] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus()
+  }, [autoFocus])
 
   const filteredGroups = search.trim()
     ? groups.map(g => ({
@@ -41,12 +46,12 @@ export function RepoList({ groups, selectedId, onSelect, cloningId, maxHeight = 
   return (
     <>
       <input
+        ref={inputRef}
         type="text"
         value={search}
         onChange={e => setSearch(e.target.value)}
         placeholder="Search repos…"
         className="mb-2 w-full rounded-lg border border-neutral-7 bg-neutral-11/50 px-3 py-2 text-[15px] text-neutral-2 placeholder-neutral-5 focus:border-accent-6 focus:outline-none"
-        autoFocus={autoFocus}
       />
       <div className="overflow-y-auto rounded-lg border border-neutral-7 bg-neutral-11/50" style={{ maxHeight }}>
         {filteredGroups.length === 0 ? (

--- a/src/hooks/useDocsBrowser.ts
+++ b/src/hooks/useDocsBrowser.ts
@@ -91,8 +91,10 @@ export function useDocsBrowser(): UseDocsBrowserReturn {
     setPickerFiles([])
 
     try {
-      const params = new URLSearchParams({ repo: repoDir, token })
-      const res = await fetch(`${BASE}/api/docs?${params}`)
+      const params = new URLSearchParams({ repo: repoDir })
+      const res = await fetch(`${BASE}/api/docs?${params}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
       if (!res.ok) throw new Error(`Failed to list docs: ${res.status}`)
       const data = await res.json()
       setPickerFiles(data.files ?? [])
@@ -117,8 +119,10 @@ export function useDocsBrowser(): UseDocsBrowserReturn {
     setPickerOpen(false)
 
     try {
-      const params = new URLSearchParams({ repo: repoDir, file: filePath, token })
-      const res = await fetch(`${BASE}/api/docs/file?${params}`)
+      const params = new URLSearchParams({ repo: repoDir, file: filePath })
+      const res = await fetch(`${BASE}/api/docs/file?${params}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
       if (!res.ok) throw new Error(`Failed to load file: ${res.status}`)
       const data = await res.json()
       setContent(data.content)


### PR DESCRIPTION
## Summary
- **Fix docs browser empty file list**: Auth token was passed as a URL query param but the server only checks the `Authorization` header — switched to `Bearer` header
- **Suppress duplicate model init messages**: Only show "Model: ..." system message on first init or when the model actually changes, instead of every turn
- **Auto-focus repo search bar**: Search input now receives focus immediately in both the empty-state repo selector and the sidebar "+" popup

## Test plan
- [ ] Click the MD icon on sidebar — verify markdown files now load in the picker
- [ ] Send multiple messages in a session — verify "Model: ..." only appears once at session start
- [ ] Load app with no active session — verify search bar is focused
- [ ] Click "+" in sidebar — verify search bar in popup is focused

🤖 Generated with [Claude Code](https://claude.com/claude-code)