### PR TITLE
Reduce frontend complexity per complexity report

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,7 +8,6 @@
  */
 
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
-import type { ChatMessage } from './types'
 import { useSettings } from './hooks/useSettings'
 import { useRepos } from './hooks/useRepos'
 import { useSessions } from './hooks/useSessions'
@@ -16,10 +15,10 @@ import { useChatSocket } from './hooks/useChatSocket'
 import { usePageVisibility } from './hooks/usePageVisibility'
 import { useRouter } from './hooks/useRouter'
 import { useTentativeQueue } from './hooks/useTentativeQueue'
-import { useSessionOrchestration, groupKey } from './hooks/useSessionOrchestration'
+import { useSessionOrchestration } from './hooks/useSessionOrchestration'
 import { useDocsBrowser } from './hooks/useDocsBrowser'
 import { useIsMobile } from './hooks/useIsMobile'
-import { uploadAndBuildMessage } from './lib/ccApi'
+import { useSendMessage } from './hooks/useSendMessage'
 import { deriveActivityLabel } from './lib/deriveActivityLabel'
 import { Settings } from './components/Settings'
 import { ChatView } from './components/ChatView'
@@ -64,9 +63,6 @@ export default function App() {
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const pendingContextRef = useRef<string | null>(null)
   const sendInputRef = useRef<(data: string) => void>(() => {})
-  const [uploadStatus, setUploadStatus] = useState<string | null>(null)
-  const [sessionPendingFiles, setSessionPendingFiles] = useState<Record<string, File[]>>({})
-  const pendingFiles = useMemo(() => activeSessionId ? (sessionPendingFiles[activeSessionId] ?? []) : [], [activeSessionId, sessionPendingFiles])
 
   const inputBarRef = useRef<InputBarHandle>(null)
   const [sessionInputs, setSessionInputs] = useState<Record<string, string>>({})
@@ -146,6 +142,45 @@ export default function App() {
     wsCreateSession,
     removeSession,
     pendingContextRef,
+  })
+
+  // Derive active repo from the active session
+  const activeRepo = activeWorkingDir
+    ? repos.find(r => r.workingDir === activeWorkingDir) ?? null
+    : null
+
+  // All available skills for the current session (global + repo)
+  const allSkills = useMemo(() => [
+    ...globalSkills,
+    ...(activeRepo?.skills ?? []),
+  ], [globalSkills, activeRepo?.skills])
+
+  // Message sending: file uploads, skill expansion, tentative queue
+  const {
+    handleSend: handleSendWithFiles,
+    handleExecuteTentative,
+    handleDiscardTentative,
+    tentativeMessages,
+    activeTentativeCount,
+    pendingFiles,
+    addFiles,
+    removeFile,
+    uploadStatus,
+  } = useSendMessage({
+    token: settings.token,
+    activeSessionId,
+    activeWorkingDir,
+    sessions,
+    allSkills,
+    sendInput,
+    tentativeQueues,
+    addToQueue,
+    clearQueue,
+    docsContext: {
+      isOpen: docsBrowser.isOpen,
+      selectedFile: docsBrowser.selectedFile,
+      repoWorkingDir: docsBrowser.repoWorkingDir,
+    },
   })
 
   // Keep sendInputRef in sync so onSessionCreated can use it
@@ -230,150 +265,6 @@ export default function App() {
     sendInput(`[Module: ${mod.name}]\n\n${mod.content}`)
   }, [sendInput])
 
-  const addFiles = useCallback((files: File[]) => {
-    if (!activeSessionId) return
-    setSessionPendingFiles(prev => ({ ...prev, [activeSessionId]: [...(prev[activeSessionId] ?? []), ...files] }))
-  }, [activeSessionId])
-
-  const removeFile = useCallback((index: number) => {
-    if (!activeSessionId) return
-    setSessionPendingFiles(prev => ({ ...prev, [activeSessionId]: (prev[activeSessionId] ?? []).filter((_, i) => i !== index) }))
-  }, [activeSessionId])
-
-  // Derive active repo from the active session
-  const activeRepo = activeWorkingDir
-    ? repos.find(r => r.workingDir === activeWorkingDir) ?? null
-    : null
-
-  // All available skills for the current session (global + repo)
-  const allSkills = useMemo(() => [
-    ...globalSkills,
-    ...(activeRepo?.skills ?? []),
-  ], [globalSkills, activeRepo?.skills])
-
-  // Expand slash commands to skill content before sending
-  const expandSkill = useCallback((text: string): string => {
-    const trimmed = text.trim()
-    if (!trimmed.startsWith('/')) return text
-
-    // Extract command and any trailing args: "/commit fix the bug" → command="/commit", args="fix the bug"
-    const spaceIdx = trimmed.indexOf(' ')
-    const command = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx)
-    const args = spaceIdx === -1 ? '' : trimmed.slice(spaceIdx + 1).trim()
-
-    const skill = allSkills.find(s => s.command === command)
-    if (!skill?.content) return text
-
-    // Replace $ARGUMENTS placeholder in skill content with actual args
-    const content = skill.content.replace(/\$ARGUMENTS/g, args || '(no arguments provided)')
-    const parts = [`[Skill: ${skill.name}]`, '', content]
-    if (args) parts.push('', `User instructions: ${args}`)
-    return parts.join('\n')
-  }, [allSkills])
-
-  const handleSendWithFiles = useCallback(async (text: string) => {
-    if (!settings.token) return
-    const expanded = expandSkill(text)
-    const displayText = expanded !== text ? text : undefined
-
-    // Include docs context if viewing a doc
-    const docsContext = docsBrowser.isOpen && docsBrowser.selectedFile && docsBrowser.repoWorkingDir
-      ? `[Viewing doc: ${docsBrowser.selectedFile} in ${docsBrowser.repoWorkingDir}]\n\n`
-      : ''
-
-    // Tentative mode: if another session for the same repo is currently processing,
-    // or if this session already has queued messages (isAlreadyTentative), hold the
-    // new message rather than sending it immediately.  This prevents two Claude
-    // processes for the same repo from interleaving edits on the same files.
-    // The queued messages are auto-executed by the useEffect below once all blocking
-    // sessions for this repo finish processing.
-    const isAlreadyTentative = (tentativeQueues[activeSessionId ?? '']?.length ?? 0) > 0
-    const hasConflict = !!activeWorkingDir &&
-      sessions.some(s => groupKey(s) === activeWorkingDir && s.isProcessing && s.id !== activeSessionId)
-    if (activeSessionId && (isAlreadyTentative || hasConflict)) {
-      addToQueue(activeSessionId, docsContext + expanded, pendingFiles)
-      if (pendingFiles.length > 0) {
-        setSessionPendingFiles(prev => ({ ...prev, [activeSessionId]: [] }))
-      }
-      return
-    }
-
-    const files = pendingFiles
-    if (files.length === 0) {
-      // displayText is the original slash command (e.g. "/commit") when `expanded`
-      // is the full skill content — the server echoes displayText to the chat so
-      // the user sees the compact command form rather than the raw skill markdown.
-      sendInput(docsContext + expanded, displayText)
-      return
-    }
-    setUploadStatus('Uploading files...')
-    try {
-      const message = await uploadAndBuildMessage(settings.token, files, docsContext + expanded)
-      if (activeSessionId) setSessionPendingFiles(prev => ({ ...prev, [activeSessionId]: [] }))
-      setUploadStatus(null)
-      sendInput(message)
-    } catch (err) {
-      setUploadStatus(`Upload failed: ${err instanceof Error ? err.message : 'unknown error'}`)
-      setTimeout(() => setUploadStatus(null), 3000)
-    }
-  }, [settings.token, activeSessionId, activeWorkingDir, sessions, tentativeQueues, addToQueue, pendingFiles, expandSkill, sendInput, docsBrowser.isOpen, docsBrowser.selectedFile, docsBrowser.repoWorkingDir])
-
-  const handleExecuteTentative = useCallback(async (sessionId: string) => {
-    const queue = tentativeQueues[sessionId] ?? []
-    clearQueue(sessionId)
-    for (let i = 0; i < queue.length; i++) {
-      const entry = queue[i]
-      if (i > 0) await new Promise(r => setTimeout(r, 100))
-      if (entry.files.length > 0 && settings.token) {
-        try {
-          const message = await uploadAndBuildMessage(settings.token, entry.files, entry.text)
-          sendInput(message)
-        } catch {
-          // Upload failed — send the text portion anyway
-          sendInput(entry.text)
-        }
-      } else {
-        sendInput(entry.text)
-      }
-    }
-  }, [tentativeQueues, clearQueue, sendInput, settings.token])
-
-  const handleDiscardTentative = useCallback((sessionId: string) => {
-    clearQueue(sessionId)
-  }, [clearQueue])
-
-  // Auto-execute tentative queue when the blocking session(s) finish
-  useEffect(() => {
-    for (const [sessionId, queue] of Object.entries(tentativeQueues)) {
-      if (queue.length === 0) continue
-      const session = sessions.find(s => s.id === sessionId)
-      if (!session) continue
-      const wDir = groupKey(session)
-      const blocking = sessions.filter(s => groupKey(s) === wDir && s.isProcessing && s.id !== sessionId)
-      if (blocking.length === 0 && sessionId === activeSessionId) {
-        void handleExecuteTentative(sessionId)
-        setTimeout(() => {
-          setUploadStatus('Session finished — starting queued session.')
-          setTimeout(() => setUploadStatus(null), 3000)
-        }, 0)
-      }
-    }
-  }, [sessions]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Tentative messages for the active session (rendered in ChatView after real messages)
-  const tentativeMessages: ChatMessage[] = activeSessionId
-    ? (tentativeQueues[activeSessionId] ?? []).map((entry, index) => ({
-        type: 'tentative' as const,
-        text: entry.files.length > 0
-          ? `${entry.text}\n📎 ${entry.files.length} file${entry.files.length > 1 ? 's' : ''} attached`
-          : entry.text,
-        index,
-        key: `tentative-${index}`,
-      }))
-    : []
-
-  const activeTentativeCount = activeSessionId ? (tentativeQueues[activeSessionId]?.length ?? 0) : 0
-
   const skillGroups = [
     { label: 'Global', skills: globalSkills },
     ...(activeRepo && activeRepo.skills.length > 0 ? [{ label: activeRepo.name, skills: activeRepo.skills }] : []),
@@ -445,16 +336,20 @@ export default function App() {
         onSendModule={handleSendModule}
         onNavigateToWorkflows={() => navigate('/workflows')}
         onBrowseDocs={handleBrowseDocs}
-        docsPickerOpen={docsBrowser.pickerOpen}
-        docsPickerRepoDir={docsBrowser.pickerRepoDir}
-        docsPickerFiles={docsBrowser.pickerFiles}
-        docsPickerLoading={docsBrowser.pickerLoading}
-        onDocsPickerSelect={handleSelectDocFile}
-        onDocsPickerClose={docsBrowser.closePicker}
-        docsStarredDocs={docsBrowser.starredDocs}
-        isMobile={isMobile}
-        mobileOpen={mobileMenuOpen}
-        onMobileClose={() => setMobileMenuOpen(false)}
+        docsPicker={{
+          open: docsBrowser.pickerOpen,
+          repoDir: docsBrowser.pickerRepoDir,
+          files: docsBrowser.pickerFiles,
+          loading: docsBrowser.pickerLoading,
+          onSelect: handleSelectDocFile,
+          onClose: docsBrowser.closePicker,
+          starredDocs: docsBrowser.starredDocs,
+        }}
+        mobile={{
+          isMobile,
+          mobileOpen: mobileMenuOpen,
+          onMobileClose: () => setMobileMenuOpen(false),
+        }}
       />
 
       {/* Main area */}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -13,7 +13,7 @@ import {
   IconLogout, IconSun, IconMoon,
   IconChevronRight, IconChevronLeft, IconSparkles, IconX,
 } from '@tabler/icons-react'
-import type { Session, Module, Repo } from '../types'
+import type { Session, Module, Repo, DocsPickerProps, MobileProps } from '../types'
 import type { RepoGroup } from '../hooks/useRepos'
 import AppIcon from './AppIcon'
 import { NewSessionButton } from './NewSessionButton'
@@ -94,19 +94,8 @@ interface Props {
   onSendModule: (mod: Module) => void
   onNavigateToWorkflows: () => void
   onBrowseDocs?: (workingDir: string) => void
-  docsPickerOpen?: boolean
-  docsPickerRepoDir?: string | null
-  docsPickerFiles?: { path: string; pinned: boolean }[]
-  docsPickerLoading?: boolean
-  onDocsPickerSelect?: (filePath: string) => void
-  onDocsPickerClose?: () => void
-  docsStarredDocs?: string[]
-  /** Mobile overlay mode — when true, sidebar renders as a slide-in drawer with backdrop */
-  isMobile?: boolean
-  /** Controls drawer visibility in mobile mode */
-  mobileOpen?: boolean
-  /** Called to close the mobile drawer */
-  onMobileClose?: () => void
+  docsPicker?: DocsPickerProps
+  mobile?: MobileProps
 }
 
 // --------------------------------------------------------------------------
@@ -142,17 +131,10 @@ export function LeftSidebar({
   onSendModule,
   onNavigateToWorkflows,
   onBrowseDocs,
-  docsPickerOpen,
-  docsPickerRepoDir,
-  docsPickerFiles,
-  docsPickerLoading,
-  onDocsPickerSelect,
-  onDocsPickerClose,
-  docsStarredDocs,
-  isMobile = false,
-  mobileOpen = false,
-  onMobileClose,
+  docsPicker = {},
+  mobile = {},
 }: Props) {
+  const { isMobile = false, mobileOpen = false, onMobileClose } = mobile
   const [collapsed, setCollapsed] = useState(() => localStorage.getItem('codekin-left-sidebar-collapsed') === 'true')
   const [width, setWidth] = useState(() => {
     const stored = localStorage.getItem(SIDEBAR_WIDTH_KEY)
@@ -369,13 +351,13 @@ export function LeftSidebar({
             onDeleteRepo={onDeleteRepo}
             onViewArchivedSession={setArchiveViewSessionId}
             onBrowseDocs={onBrowseDocs}
-            docsPickerOpen={docsPickerOpen}
-            docsPickerRepoDir={docsPickerRepoDir}
-            docsPickerFiles={docsPickerFiles}
-            docsPickerLoading={docsPickerLoading}
-            onDocsPickerSelect={onDocsPickerSelect}
-            onDocsPickerClose={onDocsPickerClose}
-            docsStarredDocs={docsStarredDocs}
+            docsPickerOpen={docsPicker.open}
+            docsPickerRepoDir={docsPicker.repoDir}
+            docsPickerFiles={docsPicker.files}
+            docsPickerLoading={docsPicker.loading}
+            onDocsPickerSelect={docsPicker.onSelect}
+            onDocsPickerClose={docsPicker.onClose}
+            docsStarredDocs={docsPicker.starredDocs}
           />
         ))}
 

--- a/src/hooks/useChatSocket.ts
+++ b/src/hooks/useChatSocket.ts
@@ -1,24 +1,23 @@
 /**
  * Core WebSocket hook for Codekin chat sessions.
  *
- * Manages the full lifecycle: connection with auto-reconnect (exponential backoff),
- * session join/leave/create, sending user input and prompt responses, and
- * converting raw WsServerMessage events into ChatMessage[] for the UI.
+ * Manages session join/leave/create, sending user input and prompt responses,
+ * and converting raw WsServerMessage events into ChatMessage[] for the UI.
  *
  * Text streaming is batched via requestAnimationFrame for ~60fps rendering
  * without flooding React state updates on every small text delta.
+ *
+ * Transport lifecycle (connect/reconnect/auth/ping) is delegated to
+ * useWsConnection, keeping this hook focused on session-level concerns.
  */
 
 import { useRef, useCallback, useEffect, useState } from 'react'
-import type { WsClientMessage, WsServerMessage, ConnectionState, ChatMessage, TaskItem } from '../types'
-import { wsUrl, checkAuthSession, redirectToLogin } from '../lib/ccApi'
+import type { WsClientMessage, WsServerMessage, ChatMessage, TaskItem } from '../types'
 import { usePromptState } from './usePromptState'
+import { useWsConnection } from './useWsConnection'
 
 /** Max chat messages kept in the browser before trimming older entries. */
 const MAX_BROWSER_MESSAGES = 500
-
-/** How often to check whether the Authelia session is still valid (ms). */
-const AUTH_CHECK_INTERVAL_MS = 60_000
 
 /** Monotonically increasing counter for stable React keys across trims. */
 let msgKeyCounter = 0
@@ -159,47 +158,26 @@ export function useChatSocket({
   onSessionsUpdated,
   onError,
 }: UseChatSocketOptions) {
-  const wsRef = useRef<WebSocket | null>(null)
   const callbacksRef = useRef({ onSessionCreated, onSessionJoined, onSessionRenamed, onSessionsUpdated, onError })
   useEffect(() => {
     callbacksRef.current = { onSessionCreated, onSessionJoined, onSessionRenamed, onSessionsUpdated, onError }
   })
-  const [connState, setConnState] = useState<ConnectionState>('disconnected')
+
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [planningMode, setPlanningMode] = useState(false)
   const [isProcessing, setIsProcessing] = useState(false)
   const [tasks, setTasks] = useState<TaskItem[]>([])
-
   const [currentModel, setCurrentModel] = useState<string | null>(() => localStorage.getItem('claude-model') ?? null)
-
-
   const [thinkingSummary, setThinkingSummary] = useState<string | null>(null)
   const [waitingSessions, setWaitingSessions] = useState<Record<string, boolean>>({})
   const { state: promptState, clear: clearPromptState, setFromMessage: setPromptFromMessage } = usePromptState()
   const currentSessionId = useRef<string | null>(null)
 
-  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const pingTimer = useRef<ReturnType<typeof setInterval> | null>(null)
-  const backoff = useRef(1000)
-  const intentionalClose = useRef(false)
-  /** Stable ref to `connect` for self-referential reconnection in ws.onclose. */
-  const connectRef = useRef<() => void>(() => {})
-
-  // Session restore on visibility change
-  const restoringRef = useRef(false)
-  const awaitingHealthPong = useRef(false)
-  const healthPongTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-
+  // ---------------------------------------------------------------------------
   // Streaming performance: batch consecutive text deltas and flush once per
   // animation frame. Without this, each small delta (often just a few chars)
   // triggers a full React render cycle, causing jank at high token throughput.
-  //
-  // Ordering invariant: pendingTextRef must be flushed to the message list
-  // *before* any non-output structural message (result, tool_active, tool_done,
-  // tool_output, system_message, user_echo) is appended.  This preserves the
-  // correct stream order — text that arrived before a tool call must appear
-  // before the tool group in the rendered UI.  Every case below that handles a
-  // structural message therefore starts with the same flush-if-pending guard.
+  // ---------------------------------------------------------------------------
   const pendingTextRef = useRef('')
   const rafRef = useRef<number | null>(null)
 
@@ -219,12 +197,6 @@ export function useChatSocket({
     })
   }, [])
 
-  /**
-   * Flush any buffered text delta to the message list before appending a
-   * structural message (result, tool_active, tool_done, tool_output,
-   * system_message, user_echo). Preserves stream ordering: text that
-   * arrived before the structural event must appear before it in the UI.
-   */
   const flushBeforeStructuralMessage = useCallback(() => {
     if (pendingTextRef.current) {
       if (rafRef.current) {
@@ -235,301 +207,212 @@ export function useChatSocket({
     }
   }, [flushPendingText])
 
-  const cleanup = useCallback(() => {
-    if (pingTimer.current) {
-      clearInterval(pingTimer.current)
-      pingTimer.current = null
+  // ---------------------------------------------------------------------------
+  // Message handler — processes all WsServerMessage types from the connection
+  // ---------------------------------------------------------------------------
+  const handleMessage = useCallback((msg: WsServerMessage) => {
+    switch (msg.type) {
+      case 'thinking':
+        setThinkingSummary(msg.summary)
+        setIsProcessing(true)
+        break
+
+      case 'output': {
+        setThinkingSummary(null)
+        setIsProcessing(true)
+        pendingTextRef.current += msg.data
+        if (!rafRef.current) {
+          rafRef.current = requestAnimationFrame(flushPendingText)
+        }
+        break
+      }
+
+      case 'result':
+        setIsProcessing(false)
+        setThinkingSummary(null)
+        flushBeforeStructuralMessage()
+        setMessages(prev => trimMessages(processMessage(prev, msg)))
+        break
+
+      case 'system_message':
+        if (msg.subtype === 'init' && msg.model) {
+          setCurrentModel(msg.model)
+          localStorage.setItem('claude-model', msg.model)
+        }
+        flushBeforeStructuralMessage()
+        setMessages(prev => trimMessages(processMessage(prev, msg)))
+        break
+
+      case 'user_echo':
+        flushBeforeStructuralMessage()
+        setMessages(prev => trimMessages(processMessage(prev, msg)))
+        break
+
+      case 'tool_active':
+        setThinkingSummary(null)
+        setIsProcessing(true)
+        flushBeforeStructuralMessage()
+        setMessages(prev => trimMessages(processMessage(prev, msg)))
+        break
+
+      case 'tool_done':
+        flushBeforeStructuralMessage()
+        setMessages(prev => trimMessages(processMessage(prev, msg)))
+        break
+
+      case 'tool_output':
+        flushBeforeStructuralMessage()
+        setMessages(prev => trimMessages(processMessage(prev, msg)))
+        break
+
+      case 'image':
+        flushBeforeStructuralMessage()
+        setMessages(prev => trimMessages(processMessage(prev, msg)))
+        break
+
+      case 'planning_mode':
+        setPlanningMode(msg.active)
+        setMessages(prev => trimMessages(processMessage(prev, msg)))
+        break
+
+      case 'todo_update':
+        setTasks(msg.tasks)
+        break
+
+      case 'prompt': {
+        const promptSessionId = msg.sessionId
+        if (promptSessionId && promptSessionId !== currentSessionId.current) {
+          setWaitingSessions(prev => ({ ...prev, [promptSessionId]: true }))
+          break
+        }
+        setIsProcessing(false)
+        setThinkingSummary(null)
+        const sid = currentSessionId.current
+        if (sid) {
+          setWaitingSessions(prev => ({ ...prev, [sid]: true }))
+        }
+        setPromptFromMessage(msg)
+        break
+      }
+
+      case 'prompt_dismiss':
+        clearPromptState()
+        break
+
+      case 'session_created':
+        currentSessionId.current = msg.sessionId
+        setMessages([])
+        setTasks([])
+        setIsProcessing(false)
+        setThinkingSummary(null)
+        callbacksRef.current.onSessionCreated?.(msg.sessionId)
+        break
+
+      case 'session_joined': {
+        currentSessionId.current = msg.sessionId
+        setIsProcessing(false)
+        setThinkingSummary(null)
+        let rebuilt: ChatMessage[] = []
+        let restoredPlanMode = false
+        let restoredTasks: TaskItem[] = []
+        if (msg.outputBuffer?.length) {
+          rebuilt = rebuildFromHistory(msg.outputBuffer)
+          for (const bufferedMsg of msg.outputBuffer) {
+            if (bufferedMsg.type === 'planning_mode') {
+              restoredPlanMode = bufferedMsg.active
+            }
+            if (bufferedMsg.type === 'todo_update') {
+              restoredTasks = bufferedMsg.tasks
+            }
+          }
+        }
+        setPlanningMode(restoredPlanMode)
+        setTasks(restoredTasks)
+        setMessages(trimMessages(rebuilt))
+        callbacksRef.current.onSessionJoined?.(msg.sessionId)
+        break
+      }
+
+      case 'claude_started':
+        setMessages(prev => trimMessages(processMessage(prev, msg)))
+        break
+
+      case 'claude_stopped':
+      case 'exit': {
+        setIsProcessing(false)
+        setThinkingSummary(null)
+        const sid = currentSessionId.current
+        if (sid) {
+          setWaitingSessions(prev => prev[sid] ? { ...prev, [sid]: false } : prev)
+        }
+        clearPromptState()
+        break
+      }
+
+      case 'error':
+        callbacksRef.current.onError?.(msg.message)
+        break
+
+      case 'session_deleted':
+        setMessages(prev => trimMessages([...prev, { type: 'system', subtype: 'error', text: 'Session was deleted', key: nextKey() }]))
+        break
+
+      case 'connected':
+      case 'pong':
+        break
+
+      case 'session_name_update':
+        callbacksRef.current.onSessionRenamed?.(msg.sessionId, msg.name)
+        break
+
+      case 'sessions_updated':
+        setWaitingSessions(prev => {
+          const sid = currentSessionId.current
+          const hasCrossSession = Object.entries(prev).some(([k, v]) => k !== sid && v)
+          if (!hasCrossSession) return prev
+          const next: Record<string, boolean> = {}
+          if (sid && prev[sid]) next[sid] = true
+          return next
+        })
+        callbacksRef.current.onSessionsUpdated?.()
+        break
+
+      case 'info':
+      case 'usage_update':
+        break
     }
-    if (reconnectTimer.current) {
-      clearTimeout(reconnectTimer.current)
-      reconnectTimer.current = null
-    }
+  }, [flushPendingText, flushBeforeStructuralMessage, clearPromptState, setPromptFromMessage])
+
+  const handleMessageRef = useRef(handleMessage)
+  useEffect(() => { handleMessageRef.current = handleMessage }, [handleMessage])
+
+  // ---------------------------------------------------------------------------
+  // Connection layer — delegates transport to useWsConnection
+  // ---------------------------------------------------------------------------
+  const onDisconnect = useCallback(() => {
+    setIsProcessing(false)
+    setThinkingSummary(null)
     if (rafRef.current) {
       cancelAnimationFrame(rafRef.current)
       rafRef.current = null
     }
-    if (healthPongTimer.current) {
-      clearTimeout(healthPongTimer.current)
-      healthPongTimer.current = null
-    }
   }, [])
 
-  const send = useCallback((msg: WsClientMessage) => {
-    const ws = wsRef.current
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify(msg))
-    }
+  const onHealthPong = useCallback((sendFn: (msg: WsClientMessage) => void) => {
+    const sid = currentSessionId.current
+    if (sid) sendFn({ type: 'join_session', sessionId: sid })
   }, [])
 
-  const connect = useCallback(() => {
-    if (!token) return
-    cleanup()
-    setConnState('connecting')
+  const { connState, send, disconnect, restoreSession, reconnect } = useWsConnection({
+    token,
+    onMessageRef: handleMessageRef,
+    onDisconnect,
+    onHealthPong,
+  })
 
-    const ws = new WebSocket(wsUrl())
-    wsRef.current = ws
-
-    ws.onopen = () => {
-      // Send auth token as first message (not in URL to avoid log exposure)
-      ws.send(JSON.stringify({ type: 'auth', token }))
-      setConnState('connected')
-      backoff.current = 1000
-      pingTimer.current = setInterval(() => {
-        send({ type: 'ping' })
-      }, 30000)
-    }
-
-    ws.onmessage = (event) => {
-      let msg: WsServerMessage
-      try {
-        msg = JSON.parse(event.data)
-      } catch {
-        return
-      }
-
-      switch (msg.type) {
-        case 'thinking':
-          setThinkingSummary(msg.summary)
-          setIsProcessing(true)
-          break
-
-        case 'output': {
-          setThinkingSummary(null)
-          setIsProcessing(true)
-          // Batch text deltas for ~60fps rendering
-          pendingTextRef.current += msg.data
-          if (!rafRef.current) {
-            rafRef.current = requestAnimationFrame(flushPendingText)
-          }
-          break
-        }
-
-        case 'result':
-          setIsProcessing(false)
-          setThinkingSummary(null)
-          flushBeforeStructuralMessage()
-          setMessages(prev => trimMessages(processMessage(prev, msg)))
-          break
-
-        case 'system_message':
-          if (msg.subtype === 'init' && msg.model) {
-            setCurrentModel(msg.model)
-            localStorage.setItem('claude-model', msg.model)
-          }
-          flushBeforeStructuralMessage()
-          setMessages(prev => trimMessages(processMessage(prev, msg)))
-          break
-
-        case 'user_echo':
-          flushBeforeStructuralMessage()
-          setMessages(prev => trimMessages(processMessage(prev, msg)))
-          break
-
-        case 'tool_active':
-          setThinkingSummary(null)
-          setIsProcessing(true)
-          flushBeforeStructuralMessage()
-          setMessages(prev => trimMessages(processMessage(prev, msg)))
-          break
-
-        case 'tool_done':
-          flushBeforeStructuralMessage()
-          setMessages(prev => trimMessages(processMessage(prev, msg)))
-          break
-
-        case 'tool_output':
-          flushBeforeStructuralMessage()
-          setMessages(prev => trimMessages(processMessage(prev, msg)))
-          break
-
-        case 'image':
-          flushBeforeStructuralMessage()
-          setMessages(prev => trimMessages(processMessage(prev, msg)))
-          break
-
-        case 'planning_mode':
-          setPlanningMode(msg.active)
-          setMessages(prev => trimMessages(processMessage(prev, msg)))
-          break
-
-        case 'todo_update':
-          setTasks(msg.tasks)
-          break
-
-        case 'prompt': {
-          // Check if this prompt is for a different session (global broadcast notification)
-          const promptSessionId = msg.sessionId
-          if (promptSessionId && promptSessionId !== currentSessionId.current) {
-            // Cross-session approval needed — update waiting indicator only
-            setWaitingSessions(prev => ({ ...prev, [promptSessionId]: true }))
-            break
-          }
-
-          // This prompt is for our session — show PromptButtons
-          setIsProcessing(false)
-          setThinkingSummary(null)
-          const sid = currentSessionId.current
-          if (sid) {
-            setWaitingSessions(prev => ({ ...prev, [sid]: true }))
-          }
-          setPromptFromMessage(msg)
-          break
-        }
-
-        case 'prompt_dismiss':
-          clearPromptState()
-          break
-
-        case 'session_created':
-          currentSessionId.current = msg.sessionId
-          setMessages([])
-          setTasks([])
-          setIsProcessing(false)
-          setThinkingSummary(null)
-          callbacksRef.current.onSessionCreated?.(msg.sessionId)
-          break
-
-        case 'session_joined': {
-          currentSessionId.current = msg.sessionId
-          setIsProcessing(false)
-          setThinkingSummary(null)
-          // Rebuild messages from output buffer (O(n) mutable builder)
-          let rebuilt: ChatMessage[] = []
-          let restoredPlanMode = false
-          let restoredTasks: TaskItem[] = []
-          if (msg.outputBuffer?.length) {
-            rebuilt = rebuildFromHistory(msg.outputBuffer)
-            for (const bufferedMsg of msg.outputBuffer) {
-              if (bufferedMsg.type === 'planning_mode') {
-                restoredPlanMode = bufferedMsg.active
-              }
-              if (bufferedMsg.type === 'todo_update') {
-                restoredTasks = bufferedMsg.tasks
-              }
-            }
-          }
-          setPlanningMode(restoredPlanMode)
-          setTasks(restoredTasks)
-          setMessages(trimMessages(rebuilt))
-          callbacksRef.current.onSessionJoined?.(msg.sessionId)
-          break
-        }
-
-        case 'claude_started':
-          setMessages(prev => trimMessages(processMessage(prev, msg)))
-          break
-
-        case 'claude_stopped':
-        case 'exit': {
-          setIsProcessing(false)
-          setThinkingSummary(null)
-          const sid = currentSessionId.current
-          if (sid) {
-            setWaitingSessions(prev => prev[sid] ? { ...prev, [sid]: false } : prev)
-          }
-          clearPromptState()
-          break
-        }
-
-        case 'error':
-          callbacksRef.current.onError?.(msg.message)
-          break
-
-        case 'session_deleted':
-          setMessages(prev => trimMessages([...prev, { type: 'system', subtype: 'error', text: 'Session was deleted', key: nextKey() }]))
-          break
-
-        case 'connected':
-          // No-op in chat mode — system_message from Claude init handles this
-          break
-
-        case 'pong':
-          if (awaitingHealthPong.current) {
-            awaitingHealthPong.current = false
-            if (healthPongTimer.current) {
-              clearTimeout(healthPongTimer.current)
-              healthPongTimer.current = null
-            }
-            // WS is alive — re-join session for fresh state
-            const sid = currentSessionId.current
-            if (sid) {
-              send({ type: 'join_session', sessionId: sid })
-            }
-          }
-          break
-        case 'session_name_update':
-          callbacksRef.current.onSessionRenamed?.(msg.sessionId, msg.name)
-          break
-
-        case 'sessions_updated':
-          // Clear stale cross-session waiting indicators. Cross-session prompt entries
-          // are set when a prompt arrives for another session, but prompt_dismiss is only
-          // broadcast to that session's clients so we never receive it here. Clearing on
-          // sessions_updated is safe: it fires when isProcessing changes, which only
-          // happens after the prompt is resolved and the session resumes/finishes.
-          setWaitingSessions(prev => {
-            const sid = currentSessionId.current
-            const hasCrossSession = Object.entries(prev).some(([k, v]) => k !== sid && v)
-            if (!hasCrossSession) return prev
-            const next: Record<string, boolean> = {}
-            if (sid && prev[sid]) next[sid] = true
-            return next
-          })
-          callbacksRef.current.onSessionsUpdated?.()
-          break
-
-        case 'info':
-        case 'usage_update':
-          break
-      }
-    }
-
-    ws.onclose = (event) => {
-      setConnState('disconnected')
-      setIsProcessing(false)
-      setThinkingSummary(null)
-      cleanup()
-      wsRef.current = null
-
-      // WebSocket closed with 4001 = auth failure from our server
-      if (event.code === 4001) {
-        redirectToLogin()
-        return
-      }
-
-      if (!intentionalClose.current) {
-        // Before reconnecting, check if the Authelia session is still valid.
-        // If it expired, redirect to login instead of reconnecting endlessly.
-        checkAuthSession().then(valid => {
-          if (!valid) {
-            redirectToLogin()
-            return
-          }
-          reconnectTimer.current = setTimeout(() => {
-            backoff.current = Math.min(backoff.current * 2, 30000)
-            connectRef.current()
-          }, backoff.current)
-        }).catch(() => {
-          // Network error during auth check — treat as transient, retry with backoff
-          reconnectTimer.current = setTimeout(connectRef.current, backoff.current)
-        })
-      }
-    }
-
-    ws.onerror = () => {
-      // onclose will fire after this
-    }
-  }, [token, cleanup, send, flushPendingText, flushBeforeStructuralMessage, clearPromptState, setPromptFromMessage])
-  useEffect(() => { connectRef.current = connect }, [connect])
-
-  const disconnect = useCallback(() => {
-    intentionalClose.current = true
-    cleanup()
-    wsRef.current?.close()
-    wsRef.current = null
-    setConnState('disconnected')
-  }, [cleanup])
-
+  // ---------------------------------------------------------------------------
+  // Session-level operations
+  // ---------------------------------------------------------------------------
   const joinSession = useCallback((sessionId: string) => {
     send({ type: 'join_session', sessionId })
   }, [send])
@@ -539,7 +422,7 @@ export function useChatSocket({
   }, [send])
 
   const sendInput = useCallback((data: string, displayText?: string) => {
-    send({ type: 'input', data, ...(displayText ? { displayText } : {}) })
+    send({ type: 'input', data, ...(displayText ? { displayText } : {}) } as WsClientMessage)
     setIsProcessing(true)
     const sid = currentSessionId.current
     if (sid) {
@@ -549,7 +432,7 @@ export function useChatSocket({
   }, [send, clearPromptState])
 
   const sendPromptResponse = useCallback((value: string | string[]) => {
-    send({ type: 'prompt_response', value, requestId: promptState.promptRequestId ?? undefined })
+    send({ type: 'prompt_response', value, requestId: promptState.promptRequestId ?? undefined } as WsClientMessage)
     setIsProcessing(true)
     const sid = currentSessionId.current
     if (sid) {
@@ -565,81 +448,9 @@ export function useChatSocket({
     setThinkingSummary(null)
   }, [send])
 
-  /**
-   * Restore the current session after a visibility change (tab focus return).
-   * Handles three cases: WS open (ping to verify, rejoin on pong), WS connecting
-   * (let existing onopen handle it), WS closed (reconnect immediately).
-   */
-  const restoreSession = useCallback(() => {
-    // Guard against rapid concurrent restore attempts
-    if (restoringRef.current) return
-    restoringRef.current = true
-    setTimeout(() => { restoringRef.current = false }, 3000)
-
-    const ws = wsRef.current
-
-    // Case 1: WS appears open — probe with ping, rejoin on pong
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      awaitingHealthPong.current = true
-      healthPongTimer.current = setTimeout(() => {
-        // No pong in 2s — zombie connection, force close
-        awaitingHealthPong.current = false
-        healthPongTimer.current = null
-        backoff.current = 1000
-        ws.close()
-      }, 2000)
-      send({ type: 'ping' })
-      return
-    }
-
-    // Case 2: WS is connecting — let existing onopen + autoJoin handle it
-    if (ws && ws.readyState === WebSocket.CONNECTING) {
-      return
-    }
-
-    // Case 3: WS is closed/null — check auth before reconnecting
-    checkAuthSession().then(valid => {
-      if (!valid) {
-        redirectToLogin()
-        return
-      }
-      backoff.current = 1000
-      if (reconnectTimer.current) {
-        clearTimeout(reconnectTimer.current)
-        reconnectTimer.current = null
-      }
-      connect()
-    }).catch(() => {
-      // Network error during auth check — treat as transient, retry with backoff
-      reconnectTimer.current = setTimeout(connectRef.current, backoff.current)
-    })
-  }, [send, connect])
-
   const clearMessages = useCallback(() => {
     setMessages([])
   }, [])
-
-  // Connect on mount when token available, disconnect on unmount
-  useEffect(() => {
-    if (token) {
-      intentionalClose.current = false
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- WebSocket connect legitimately sets connState
-      connect()
-    }
-    return () => {
-      disconnect()
-    }
-  }, [token]) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Periodic Authelia session check — detect expiry while the tab is open
-  useEffect(() => {
-    if (!token) return
-    const id = setInterval(async () => {
-      const valid = await checkAuthSession()
-      if (!valid) redirectToLogin()
-    }, AUTH_CHECK_INTERVAL_MS)
-    return () => clearInterval(id)
-  }, [token])
 
   const setModel = useCallback((model: string) => {
     send({ type: 'set_model', model })
@@ -670,7 +481,7 @@ export function useChatSocket({
     leaveSession,
     clearMessages,
     disconnect,
-    reconnect: connect,
+    reconnect,
     restoreSession,
     setModel,
   }

--- a/src/hooks/useSendMessage.ts
+++ b/src/hooks/useSendMessage.ts
@@ -1,0 +1,188 @@
+/**
+ * Encapsulates message sending, file uploads, skill expansion,
+ * tentative queue management, and docs context injection.
+ *
+ * Extracted from App.tsx to reduce its complexity and colocate
+ * all message-send logic in one place.
+ */
+
+import { useState, useCallback, useEffect, useMemo } from 'react'
+import type { ChatMessage, Session, Skill } from '../types'
+import type { QueueEntry } from './useTentativeQueue'
+import { groupKey } from './useSessionOrchestration'
+import { uploadAndBuildMessage } from '../lib/ccApi'
+
+interface UseSendMessageOptions {
+  token: string
+  activeSessionId: string | null
+  activeWorkingDir: string | null
+  sessions: Session[]
+  allSkills: Skill[]
+  sendInput: (data: string, displayText?: string) => void
+  tentativeQueues: Record<string, QueueEntry[]>
+  addToQueue: (sessionId: string, text: string, files?: File[]) => void
+  clearQueue: (sessionId: string) => void
+  docsContext: { isOpen: boolean; selectedFile: string | null; repoWorkingDir: string | null }
+}
+
+export function useSendMessage({
+  token,
+  activeSessionId,
+  activeWorkingDir,
+  sessions,
+  allSkills,
+  sendInput,
+  tentativeQueues,
+  addToQueue,
+  clearQueue,
+  docsContext,
+}: UseSendMessageOptions) {
+  const [uploadStatus, setUploadStatus] = useState<string | null>(null)
+  const [sessionPendingFiles, setSessionPendingFiles] = useState<Record<string, File[]>>({})
+
+  const pendingFiles = useMemo(
+    () => (activeSessionId ? (sessionPendingFiles[activeSessionId] ?? []) : []),
+    [activeSessionId, sessionPendingFiles],
+  )
+
+  const addFiles = useCallback((files: File[]) => {
+    if (!activeSessionId) return
+    setSessionPendingFiles(prev => ({
+      ...prev,
+      [activeSessionId]: [...(prev[activeSessionId] ?? []), ...files],
+    }))
+  }, [activeSessionId])
+
+  const removeFile = useCallback((index: number) => {
+    if (!activeSessionId) return
+    setSessionPendingFiles(prev => ({
+      ...prev,
+      [activeSessionId]: (prev[activeSessionId] ?? []).filter((_, i) => i !== index),
+    }))
+  }, [activeSessionId])
+
+  // Expand slash commands to skill content before sending
+  const expandSkill = useCallback((text: string): string => {
+    const trimmed = text.trim()
+    if (!trimmed.startsWith('/')) return text
+
+    const spaceIdx = trimmed.indexOf(' ')
+    const command = spaceIdx === -1 ? trimmed : trimmed.slice(0, spaceIdx)
+    const args = spaceIdx === -1 ? '' : trimmed.slice(spaceIdx + 1).trim()
+
+    const skill = allSkills.find(s => s.command === command)
+    if (!skill?.content) return text
+
+    const content = skill.content.replace(/\$ARGUMENTS/g, args || '(no arguments provided)')
+    const parts = [`[Skill: ${skill.name}]`, '', content]
+    if (args) parts.push('', `User instructions: ${args}`)
+    return parts.join('\n')
+  }, [allSkills])
+
+  const handleSend = useCallback(async (text: string) => {
+    if (!token) return
+    const expanded = expandSkill(text)
+    const displayText = expanded !== text ? text : undefined
+
+    // Include docs context if viewing a doc
+    const docsPrefix = docsContext.isOpen && docsContext.selectedFile && docsContext.repoWorkingDir
+      ? `[Viewing doc: ${docsContext.selectedFile} in ${docsContext.repoWorkingDir}]\n\n`
+      : ''
+
+    // Tentative mode: hold message if another session for the same repo is processing,
+    // or if this session already has queued messages
+    const isAlreadyTentative = (tentativeQueues[activeSessionId ?? '']?.length ?? 0) > 0
+    const hasConflict = !!activeWorkingDir &&
+      sessions.some(s => groupKey(s) === activeWorkingDir && s.isProcessing && s.id !== activeSessionId)
+    if (activeSessionId && (isAlreadyTentative || hasConflict)) {
+      addToQueue(activeSessionId, docsPrefix + expanded, pendingFiles)
+      if (pendingFiles.length > 0) {
+        setSessionPendingFiles(prev => ({ ...prev, [activeSessionId]: [] }))
+      }
+      return
+    }
+
+    const files = pendingFiles
+    if (files.length === 0) {
+      sendInput(docsPrefix + expanded, displayText)
+      return
+    }
+    setUploadStatus('Uploading files...')
+    try {
+      const message = await uploadAndBuildMessage(token, files, docsPrefix + expanded)
+      if (activeSessionId) setSessionPendingFiles(prev => ({ ...prev, [activeSessionId]: [] }))
+      setUploadStatus(null)
+      sendInput(message)
+    } catch (err) {
+      setUploadStatus(`Upload failed: ${err instanceof Error ? err.message : 'unknown error'}`)
+      setTimeout(() => setUploadStatus(null), 3000)
+    }
+  }, [token, activeSessionId, activeWorkingDir, sessions, tentativeQueues, addToQueue, pendingFiles, expandSkill, sendInput, docsContext.isOpen, docsContext.selectedFile, docsContext.repoWorkingDir])
+
+  const handleExecuteTentative = useCallback(async (sessionId: string) => {
+    const queue = tentativeQueues[sessionId] ?? []
+    clearQueue(sessionId)
+    for (let i = 0; i < queue.length; i++) {
+      const entry = queue[i]
+      if (i > 0) await new Promise(r => setTimeout(r, 100))
+      if (entry.files.length > 0 && token) {
+        try {
+          const message = await uploadAndBuildMessage(token, entry.files, entry.text)
+          sendInput(message)
+        } catch {
+          sendInput(entry.text)
+        }
+      } else {
+        sendInput(entry.text)
+      }
+    }
+  }, [tentativeQueues, clearQueue, sendInput, token])
+
+  const handleDiscardTentative = useCallback((sessionId: string) => {
+    clearQueue(sessionId)
+  }, [clearQueue])
+
+  // Auto-execute tentative queue when the blocking session(s) finish
+  useEffect(() => {
+    for (const [sessionId, queue] of Object.entries(tentativeQueues)) {
+      if (queue.length === 0) continue
+      const session = sessions.find(s => s.id === sessionId)
+      if (!session) continue
+      const wDir = groupKey(session)
+      const blocking = sessions.filter(s => groupKey(s) === wDir && s.isProcessing && s.id !== sessionId)
+      if (blocking.length === 0 && sessionId === activeSessionId) {
+        void handleExecuteTentative(sessionId)
+        setTimeout(() => {
+          setUploadStatus('Session finished — starting queued session.')
+          setTimeout(() => setUploadStatus(null), 3000)
+        }, 0)
+      }
+    }
+  }, [sessions]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Tentative messages for display in ChatView
+  const tentativeMessages: ChatMessage[] = activeSessionId
+    ? (tentativeQueues[activeSessionId] ?? []).map((entry, index) => ({
+        type: 'tentative' as const,
+        text: entry.files.length > 0
+          ? `${entry.text}\n📎 ${entry.files.length} file${entry.files.length > 1 ? 's' : ''} attached`
+          : entry.text,
+        index,
+        key: `tentative-${index}`,
+      }))
+    : []
+
+  const activeTentativeCount = activeSessionId ? (tentativeQueues[activeSessionId]?.length ?? 0) : 0
+
+  return {
+    handleSend,
+    handleExecuteTentative,
+    handleDiscardTentative,
+    tentativeMessages,
+    activeTentativeCount,
+    pendingFiles,
+    addFiles,
+    removeFile,
+    uploadStatus,
+  }
+}

--- a/src/hooks/useWsConnection.ts
+++ b/src/hooks/useWsConnection.ts
@@ -1,0 +1,195 @@
+/**
+ * Low-level WebSocket connection hook — owns transport lifecycle only.
+ *
+ * Handles: WebSocket creation, auth handshake, connState, ping/pong heartbeat,
+ * auto-reconnect with exponential backoff, Authelia session checks, and
+ * visibility-change session restore (health ping / zombie detection).
+ *
+ * All parsed messages are forwarded to the caller via `onMessageRef`.
+ * This hook knows nothing about chat messages, sessions, or streaming buffers.
+ */
+
+import { useRef, useCallback, useEffect, useState } from 'react'
+import type { WsClientMessage, WsServerMessage, ConnectionState } from '../types'
+import { wsUrl, checkAuthSession, redirectToLogin } from '../lib/ccApi'
+
+/** How often to check whether the Authelia session is still valid (ms). */
+const AUTH_CHECK_INTERVAL_MS = 60_000
+
+export interface UseWsConnectionOptions {
+  token: string
+  /** Ref-stable callback invoked for every parsed WsServerMessage. */
+  onMessageRef: React.RefObject<(msg: WsServerMessage) => void>
+  /** Called when the WebSocket closes (for resetting processing state, RAF cleanup, etc.). */
+  onDisconnect?: () => void
+  /** Called when a health-check pong arrives. Receives `send` so the caller can rejoin the session. */
+  onHealthPong?: (send: (msg: WsClientMessage) => void) => void
+}
+
+export function useWsConnection({
+  token,
+  onMessageRef,
+  onDisconnect,
+  onHealthPong,
+}: UseWsConnectionOptions) {
+  const wsRef = useRef<WebSocket | null>(null)
+  const [connState, setConnState] = useState<ConnectionState>('disconnected')
+
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pingTimer = useRef<ReturnType<typeof setInterval> | null>(null)
+  const backoff = useRef(1000)
+  const intentionalClose = useRef(false)
+  const connectRef = useRef<() => void>(() => {})
+
+  // Session restore / health check refs
+  const restoringRef = useRef(false)
+  const awaitingHealthPong = useRef(false)
+  const healthPongTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Stable refs for callbacks that may change
+  const onDisconnectRef = useRef(onDisconnect)
+  const onHealthPongRef = useRef(onHealthPong)
+  useEffect(() => { onDisconnectRef.current = onDisconnect }, [onDisconnect])
+  useEffect(() => { onHealthPongRef.current = onHealthPong }, [onHealthPong])
+
+  const cleanup = useCallback(() => {
+    if (pingTimer.current) { clearInterval(pingTimer.current); pingTimer.current = null }
+    if (reconnectTimer.current) { clearTimeout(reconnectTimer.current); reconnectTimer.current = null }
+    if (healthPongTimer.current) { clearTimeout(healthPongTimer.current); healthPongTimer.current = null }
+  }, [])
+
+  const send = useCallback((msg: WsClientMessage) => {
+    const ws = wsRef.current
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify(msg))
+    }
+  }, [])
+
+  const connect = useCallback(() => {
+    if (!token) return
+    cleanup()
+    setConnState('connecting')
+
+    const ws = new WebSocket(wsUrl())
+    wsRef.current = ws
+
+    ws.onopen = () => {
+      ws.send(JSON.stringify({ type: 'auth', token }))
+      setConnState('connected')
+      backoff.current = 1000
+      pingTimer.current = setInterval(() => {
+        send({ type: 'ping' })
+      }, 30000)
+    }
+
+    ws.onmessage = (event) => {
+      let msg: WsServerMessage
+      try { msg = JSON.parse(event.data) } catch { return }
+
+      // Intercept health-check pong before forwarding
+      if (msg.type === 'pong' && awaitingHealthPong.current) {
+        awaitingHealthPong.current = false
+        if (healthPongTimer.current) {
+          clearTimeout(healthPongTimer.current)
+          healthPongTimer.current = null
+        }
+        onHealthPongRef.current?.(send)
+      }
+
+      onMessageRef.current?.(msg)
+    }
+
+    ws.onclose = (event) => {
+      setConnState('disconnected')
+      cleanup()
+      wsRef.current = null
+      onDisconnectRef.current?.()
+
+      if (event.code === 4001) {
+        redirectToLogin()
+        return
+      }
+
+      if (!intentionalClose.current) {
+        checkAuthSession().then(valid => {
+          if (!valid) { redirectToLogin(); return }
+          reconnectTimer.current = setTimeout(() => {
+            backoff.current = Math.min(backoff.current * 2, 30000)
+            connectRef.current()
+          }, backoff.current)
+        }).catch(() => {
+          reconnectTimer.current = setTimeout(connectRef.current, backoff.current)
+        })
+      }
+    }
+
+    ws.onerror = () => { /* onclose will fire after this */ }
+  }, [token, cleanup, send, onMessageRef])
+  useEffect(() => { connectRef.current = connect }, [connect])
+
+  const disconnect = useCallback(() => {
+    intentionalClose.current = true
+    cleanup()
+    wsRef.current?.close()
+    wsRef.current = null
+    setConnState('disconnected')
+  }, [cleanup])
+
+  /**
+   * Restore the connection after a visibility change (tab focus return).
+   * Case 1: WS open — health ping, rejoin on pong, zombie timeout at 2s.
+   * Case 2: WS connecting — let existing onopen handle it.
+   * Case 3: WS closed — check auth, then reconnect.
+   */
+  const restoreSession = useCallback(() => {
+    if (restoringRef.current) return
+    restoringRef.current = true
+    setTimeout(() => { restoringRef.current = false }, 3000)
+
+    const ws = wsRef.current
+
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      awaitingHealthPong.current = true
+      healthPongTimer.current = setTimeout(() => {
+        awaitingHealthPong.current = false
+        healthPongTimer.current = null
+        backoff.current = 1000
+        ws.close()
+      }, 2000)
+      send({ type: 'ping' })
+      return
+    }
+
+    if (ws && ws.readyState === WebSocket.CONNECTING) return
+
+    checkAuthSession().then(valid => {
+      if (!valid) { redirectToLogin(); return }
+      backoff.current = 1000
+      if (reconnectTimer.current) { clearTimeout(reconnectTimer.current); reconnectTimer.current = null }
+      connect()
+    }).catch(() => {
+      reconnectTimer.current = setTimeout(connectRef.current, backoff.current)
+    })
+  }, [send, connect])
+
+  // Connect on mount when token available, disconnect on unmount
+  useEffect(() => {
+    if (token) {
+      intentionalClose.current = false
+      connect() // eslint-disable-line react-hooks/set-state-in-effect -- WebSocket connect legitimately sets connState
+    }
+    return () => { disconnect() }
+  }, [token]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Periodic Authelia session check
+  useEffect(() => {
+    if (!token) return
+    const id = setInterval(async () => {
+      const valid = await checkAuthSession()
+      if (!valid) redirectToLogin()
+    }, AUTH_CHECK_INTERVAL_MS)
+    return () => clearInterval(id)
+  }, [token])
+
+  return { connState, send, disconnect, restoreSession, reconnect: connect }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -168,3 +168,21 @@ export interface Settings {
   theme: 'dark' | 'light'
 }
 
+/** Docs picker state passed through LeftSidebar → RepoSection. */
+export interface DocsPickerProps {
+  open?: boolean
+  repoDir?: string | null
+  files?: { path: string; pinned: boolean }[]
+  loading?: boolean
+  starredDocs?: string[]
+  onSelect?: (filePath: string) => void
+  onClose?: () => void
+}
+
+/** Mobile layout props for components that support responsive drawer mode. */
+export interface MobileProps {
+  isMobile?: boolean
+  mobileOpen?: boolean
+  onMobileClose?: () => void
+}
+


### PR DESCRIPTION
## Summary
- Extract `useWsConnection` hook from `useChatSocket` (677→460 lines), separating WebSocket transport lifecycle from session-level message processing
- Extract `useSendMessage` hook from `App.tsx` (615→510 lines), colocating file uploads, skill expansion, and tentative queue logic
- Group `LeftSidebar`'s 37 flat props into `DocsPickerProps` and `MobileProps` sub-interfaces for better maintainability
- Items 4-7 from the complexity report were already resolved in the current codebase

## Test plan
- [x] All 933 tests pass
- [x] TypeScript compiles with no errors
- [x] Production build succeeds
- [ ] Manual smoke test: session creation, message sending, file uploads, tentative queue, docs browser, mobile layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)