### PR TITLE
Fix webhook/stepflow sessions duplicating repo in sidebar

### DIFF
--- a/server/stepflow-handler.ts
+++ b/server/stepflow-handler.ts
@@ -73,6 +73,7 @@ import type {
 import { buildStepflowPrompt } from './stepflow-prompt.js'
 import { createWorkspace, cleanupWorkspace } from './webhook-workspace.js'
 import { WebhookHandlerBase } from './webhook-handler-base.js'
+import { REPOS_ROOT } from './config.js'
 
 /**
  * How long an event may remain in `'processing'` before the watchdog marks it
@@ -349,8 +350,7 @@ export class StepflowHandler extends WebhookHandlerBase<StepflowEvent, StepflowE
 
     // Group under the canonical repo path so the UI places this session
     // alongside manual sessions for the same repo.
-    const reposRoot = process.env.REPOS_ROOT || `${process.env.HOME}/repos`
-    const groupDir = `${reposRoot}/${repoName}`
+    const groupDir = `${REPOS_ROOT}/${repoName}`
     const sessionName = `stepflow/${repoName}/${req.branch}/${kind}`
     this.sessions.create(sessionName, workspacePath, {
       source: 'stepflow',

--- a/server/webhook-handler.ts
+++ b/server/webhook-handler.ts
@@ -28,6 +28,7 @@ import { checkGhHealth, fetchFailedLogs, fetchJobs, fetchAnnotations, fetchCommi
 import { buildPrompt } from './webhook-prompt.js'
 import { createWorkspace, cleanupWorkspace } from './webhook-workspace.js'
 import { WebhookHandlerBase } from './webhook-handler-base.js'
+import { REPOS_ROOT } from './config.js'
 
 /** How long an event can stay in 'processing' before the watchdog marks it as error. */
 const PROCESSING_TIMEOUT_MS = 5 * 60 * 1000
@@ -324,8 +325,7 @@ export class WebhookHandler extends WebhookHandlerBase<WebhookEvent, WebhookEven
     // --- Create session ---
     // Use the canonical repo path as groupDir so the frontend groups webhook
     // sessions under the same tab as manual sessions for the same repo.
-    const reposRoot = process.env.REPOS_ROOT || `${process.env.HOME}/repos`
-    const groupDir = `${reposRoot}/${repoName}`
+    const groupDir = `${REPOS_ROOT}/${repoName}`
     const sessionName = `webhook/${repoName}/${wr.head_branch}/${wr.name}`
     this.sessions.create(sessionName, workspacePath, {
       source: 'webhook',


### PR DESCRIPTION
## Summary
- Webhook and stepflow handlers were constructing `reposRoot` manually (`process.env.REPOS_ROOT || $HOME/repos`) without resolving symlinks
- This caused a path mismatch with manual sessions (e.g. `/home/dev/repos/codekin` vs `/srv/repos/codekin`), creating duplicate repo entries in the sidebar
- Fixed by importing the shared `REPOS_ROOT` from `config.ts` which applies `realpathSync` to resolve symlinks

## Test plan
- [ ] Trigger a webhook event and verify the session appears under the existing repo entry in the sidebar, not as a duplicate
- [ ] Verify stepflow sessions also group correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)