### PR TITLE
Add cross-repo auto-approval inference

### DIFF
--- a/server/approval-manager.ts
+++ b/server/approval-manager.ts
@@ -14,6 +14,12 @@ import { DATA_DIR } from './config.js'
 const REPO_APPROVALS_FILE = join(DATA_DIR, 'repo-approvals.json')
 const PERSIST_DEBOUNCE_MS = 2000
 
+/**
+ * Minimum number of repos that must have independently approved the same
+ * tool/command/pattern before it is auto-approved globally (cross-repo).
+ */
+const CROSS_REPO_THRESHOLD = 2
+
 export class ApprovalManager {
   /** Repo-level auto-approval store, keyed by workingDir (repo path). */
   private repoApprovals = new Map<string, { tools: Set<string>; commands: Set<string>; patterns: Set<string> }>()
@@ -70,9 +76,20 @@ export class ApprovalManager {
    * Check if a tool/command is auto-approved for a repo.
    * For Bash commands, uses prefix matching only for safe commands;
    * dangerous commands require exact match to prevent escalation.
+   *
+   * Falls back to cross-repo inference: if the same tool/command/pattern
+   * has been approved in CROSS_REPO_THRESHOLD or more other repos,
+   * it is auto-approved everywhere.
    */
   checkAutoApproval(workingDir: string, toolName: string, toolInput: Record<string, unknown>): boolean {
-    const approvals = this.getRepoApprovalEntry(workingDir)
+    if (this.checkRepoApproval(workingDir, toolName, toolInput)) return true
+    return this.checkCrossRepoApproval(workingDir, toolName, toolInput)
+  }
+
+  /** Check approvals for a single repo (no cross-repo fallback). */
+  private checkRepoApproval(workingDir: string, toolName: string, toolInput: Record<string, unknown>): boolean {
+    const approvals = this.repoApprovals.get(workingDir)
+    if (!approvals) return false
     if (approvals.tools.has(toolName)) return true
     if (toolName === 'Bash') {
       const cmd = (typeof toolInput.command === 'string' ? toolInput.command : '').trim()
@@ -88,6 +105,50 @@ export class ApprovalManager {
         for (const approved of approvals.commands) {
           if (this.commandPrefix(approved) === cmdPrefix) return true
         }
+      }
+    }
+    return false
+  }
+
+  /**
+   * Cross-repo inference: if enough other repos have approved the same
+   * tool/command/pattern, auto-approve it for this repo too.
+   */
+  private checkCrossRepoApproval(workingDir: string, toolName: string, toolInput: Record<string, unknown>): boolean {
+    let count = 0
+    for (const [dir, entry] of this.repoApprovals) {
+      if (dir === workingDir) continue
+      // Check tool approval
+      if (toolName !== 'Bash') {
+        if (entry.tools.has(toolName)) count++
+      } else {
+        const cmd = (typeof toolInput.command === 'string' ? toolInput.command : '').trim()
+        let matched = false
+        // Exact command match
+        if (entry.commands.has(cmd)) matched = true
+        // Pattern match
+        if (!matched) {
+          for (const pattern of entry.patterns) {
+            if (this.matchesPattern(pattern, cmd)) { matched = true; break }
+          }
+        }
+        // Prefix match for safe commands
+        if (!matched) {
+          const cmdPrefix = this.commandPrefix(cmd)
+          if (cmdPrefix && ApprovalManager.SAFE_PREFIX_COMMANDS.has(cmdPrefix)) {
+            for (const approved of entry.commands) {
+              if (this.commandPrefix(approved) === cmdPrefix) { matched = true; break }
+            }
+          }
+        }
+        if (matched) count++
+      }
+      if (count >= CROSS_REPO_THRESHOLD) {
+        const label = toolName === 'Bash'
+          ? `command: ${(typeof toolInput.command === 'string' ? toolInput.command : '').slice(0, 80)}`
+          : `tool: ${toolName}`
+        console.log(`[auto-approve] cross-repo inference (${count} repos) for ${workingDir}: ${label}`)
+        return true
       }
     }
     return false
@@ -173,6 +234,49 @@ export class ApprovalManager {
       tools: Array.from(entry.tools).sort(),
       commands: Array.from(entry.commands).sort(),
       patterns: Array.from(entry.patterns).sort(),
+    }
+  }
+
+  /**
+   * Return approvals that are effective globally via cross-repo inference
+   * (approved in CROSS_REPO_THRESHOLD+ repos). Each entry includes the
+   * repos that contributed to it.
+   */
+  getGlobalApprovals(): { tools: Record<string, string[]>; commands: Record<string, string[]>; patterns: Record<string, string[]> } {
+    const toolCounts = new Map<string, string[]>()
+    const commandCounts = new Map<string, string[]>()
+    const patternCounts = new Map<string, string[]>()
+
+    for (const [dir, entry] of this.repoApprovals) {
+      for (const tool of entry.tools) {
+        const dirs = toolCounts.get(tool) || []
+        dirs.push(dir)
+        toolCounts.set(tool, dirs)
+      }
+      for (const cmd of entry.commands) {
+        const dirs = commandCounts.get(cmd) || []
+        dirs.push(dir)
+        commandCounts.set(cmd, dirs)
+      }
+      for (const pattern of entry.patterns) {
+        const dirs = patternCounts.get(pattern) || []
+        dirs.push(dir)
+        patternCounts.set(pattern, dirs)
+      }
+    }
+
+    const filterAboveThreshold = (counts: Map<string, string[]>): Record<string, string[]> => {
+      const result: Record<string, string[]> = {}
+      for (const [key, dirs] of counts) {
+        if (dirs.length >= CROSS_REPO_THRESHOLD) result[key] = dirs.sort()
+      }
+      return result
+    }
+
+    return {
+      tools: filterAboveThreshold(toolCounts),
+      commands: filterAboveThreshold(commandCounts),
+      patterns: filterAboveThreshold(patternCounts),
     }
   }
 

--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -2499,6 +2499,59 @@ describe('SessionManager', () => {
       expect(sm.checkAutoApproval('/tmp/repo-g', 'Bash', { command: '' })).toBe(false)
       expect(sm.checkAutoApproval('/tmp/repo-g', 'Bash', {})).toBe(false)
     })
+
+    it('auto-approves a tool approved in 2+ other repos (cross-repo inference)', () => {
+      ;(sm as any).addRepoApproval('/tmp/xrepo-1', { tool: 'Write' })
+      ;(sm as any).addRepoApproval('/tmp/xrepo-2', { tool: 'Write' })
+
+      // Write was never approved for xrepo-3, but 2 other repos have it
+      expect(sm.checkAutoApproval('/tmp/xrepo-3', 'Write', {})).toBe(true)
+    })
+
+    it('does not cross-repo approve a tool approved in only 1 other repo', () => {
+      ;(sm as any).addRepoApproval('/tmp/xrepo-solo', { tool: 'NotebookEdit' })
+
+      expect(sm.checkAutoApproval('/tmp/xrepo-other', 'NotebookEdit', {})).toBe(false)
+    })
+
+    it('auto-approves a Bash command approved in 2+ other repos', () => {
+      ;(sm as any).addRepoApproval('/tmp/xrepo-a', { command: 'npm test' })
+      ;(sm as any).addRepoApproval('/tmp/xrepo-b', { command: 'npm test' })
+
+      expect(sm.checkAutoApproval('/tmp/xrepo-c', 'Bash', { command: 'npm test' })).toBe(true)
+    })
+
+    it('cross-repo inference works with prefix matching for safe commands', () => {
+      ;(sm as any).addRepoApproval('/tmp/xrepo-p1', { command: 'git diff HEAD' })
+      ;(sm as any).addRepoApproval('/tmp/xrepo-p2', { command: 'git diff --staged' })
+
+      // Different git diff variant, but prefix matches in 2 repos
+      expect(sm.checkAutoApproval('/tmp/xrepo-p3', 'Bash', { command: 'git diff main' })).toBe(true)
+    })
+
+    it('cross-repo inference works with pattern matching', () => {
+      ;(sm as any).addRepoApproval('/tmp/xrepo-pat1', { pattern: 'cat *' })
+      ;(sm as any).addRepoApproval('/tmp/xrepo-pat2', { pattern: 'cat *' })
+
+      expect(sm.checkAutoApproval('/tmp/xrepo-pat3', 'Bash', { command: 'cat README.md' })).toBe(true)
+    })
+
+    it('cross-repo inference does not apply for dangerous commands', () => {
+      ;(sm as any).addRepoApproval('/tmp/xrepo-d1', { command: 'rm /tmp/x' })
+      ;(sm as any).addRepoApproval('/tmp/xrepo-d2', { command: 'rm /tmp/x' })
+
+      // Exact match works cross-repo
+      expect(sm.checkAutoApproval('/tmp/xrepo-d3', 'Bash', { command: 'rm /tmp/x' })).toBe(true)
+      // But different rm command does NOT — dangerous prefix not expanded
+      expect(sm.checkAutoApproval('/tmp/xrepo-d3', 'Bash', { command: 'rm -rf /' })).toBe(false)
+    })
+
+    it('does not count the same repo in cross-repo threshold', () => {
+      ;(sm as any).addRepoApproval('/tmp/xrepo-self', { tool: 'Agent' })
+      // Only 1 repo has it — should not self-count as 2
+      expect(sm.checkAutoApproval('/tmp/xrepo-self', 'Agent', {})).toBe(true) // direct match
+      expect(sm.checkAutoApproval('/tmp/xrepo-new', 'Agent', {})).toBe(false) // only 1 other repo
+    })
   })
 
   describe('derivePattern()', () => {

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -113,6 +113,11 @@ export class SessionManager {
     return this.approvalManager.getApprovals(workingDir)
   }
 
+  /** Return approvals effective globally via cross-repo inference. */
+  getGlobalApprovals(): { tools: Record<string, string[]>; commands: Record<string, string[]>; patterns: Record<string, string[]> } {
+    return this.approvalManager.getGlobalApprovals()
+  }
+
   /** Remove an auto-approval rule for a repo (workingDir) and persist to disk. */
   removeApproval(workingDir: string, opts: { tool?: string; command?: string; pattern?: string }, skipPersist = false): 'invalid' | boolean {
     return this.approvalManager.removeApproval(workingDir, opts, skipPersist)

--- a/server/session-routes.ts
+++ b/server/session-routes.ts
@@ -173,6 +173,14 @@ export function createSessionRouter(
     res.json(sessions.getApprovals(workingDir))
   })
 
+  /** Approvals effective globally via cross-repo inference (approved in 2+ repos). */
+  router.get('/api/approvals/global', (req, res) => {
+    const token = extractToken(req)
+    if (!verifyToken(token)) return res.status(401).json({ error: 'Unauthorized' })
+
+    res.json(sessions.getGlobalApprovals())
+  })
+
   router.delete('/api/approvals', (req, res) => {
     const token = extractToken(req)
     if (!verifyToken(token)) return res.status(401).json({ error: 'Unauthorized' })


### PR DESCRIPTION
## Summary
- If a tool or Bash command has been approved in 2+ repos, it is now auto-approved everywhere — no repeated prompts when working across repos
- Uses existing approval matching (exact, pattern, safe prefix) for cross-repo inference
- New `GET /api/approvals/global` endpoint surfaces which approvals are globally effective and which repos contributed to each

## Test plan
- [x] 7 new tests covering cross-repo inference for tools, commands, patterns, prefix matching, dangerous commands, and threshold boundaries
- [x] All 940 existing tests pass
- [x] Build and typecheck pass
- [ ] Manual: approve a command in 2 repos, verify it auto-approves in a 3rd
- [ ] Manual: verify /api/approvals/global returns correct data

Generated with Claude Code