### PR TITLE
Add commit-review as event-driven workflow in Workflows UI

### DIFF
--- a/src/components/AddWorkflowModal.tsx
+++ b/src/components/AddWorkflowModal.tsx
@@ -1,10 +1,10 @@
 /**
- * Multi-step wizard for creating a new scheduled workflow.
+ * Multi-step wizard for creating a new workflow.
  *
  * Steps:
  *   1. Select repository
  *   2. Select workflow type
- *   3. Configure schedule and optional focus areas
+ *   3. Configure schedule (or model/focus for event-driven workflows)
  */
 
 import { useState, useEffect } from 'react'
@@ -15,7 +15,7 @@ import type { ReviewRepoConfig, WorkflowKindInfo } from '../lib/workflowApi'
 import {
   WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL, MODEL_OPTIONS,
   buildCron, describeCron, slugify, kindCategory,
-  isBiweeklyDow,
+  isBiweeklyDow, isEventDriven, EVENT_CRON,
 } from '../lib/workflowHelpers'
 import { CategoryBadge } from './WorkflowBadges'
 import TimePicker from './TimePicker'
@@ -44,11 +44,11 @@ interface Props {
 // Step indicator
 // ---------------------------------------------------------------------------
 
-function StepIndicator({ current }: { current: Step }) {
+function StepIndicator({ current, eventDriven }: { current: Step; eventDriven: boolean }) {
   const steps = [
     { num: 1 as const, label: 'Repository' },
     { num: 2 as const, label: 'Workflow' },
-    { num: 3 as const, label: 'Schedule' },
+    { num: 3 as const, label: eventDriven ? 'Configure' : 'Schedule' },
   ]
 
   return (
@@ -251,92 +251,111 @@ function FrequencyButton({
   )
 }
 
-function StepSchedule({
+function StepConfigure({
   form,
   onChange,
 }: {
   form: FormState
   onChange: (patch: Partial<FormState>) => void
 }) {
+  const eventDriven = isEventDriven(form.kind)
+
   return (
     <div className="space-y-5">
-      <div>
-        <p className="text-[13px] text-neutral-4 mb-3">
-          Choose when this workflow should run automatically.
-        </p>
-
-        {/* Time picker */}
-        <label className="block text-[13px] font-medium text-neutral-3 mb-2">Time</label>
-        <TimePicker
-          hour={form.cronHour}
-          minute={form.cronMinute}
-          onChange={(h, m) => onChange({ cronHour: h, cronMinute: m })}
-        />
-      </div>
-
-      <div>
-        <label className="block text-[13px] font-medium text-neutral-3 mb-2">Frequency</label>
-        <div className="flex flex-wrap gap-1.5 mb-2">
-          {DAY_PRESETS.map(p => {
-            const selected = form.cronDow === p.dow
-            return (
-              <FrequencyButton
-                key={p.dow}
-                label={p.label}
-                dow={p.dow}
-                selected={selected}
-                onSelect={dow => onChange({ cronDow: dow })}
-              />
-            )
-          })}
+      {/* Schedule section — hidden for event-driven workflows */}
+      {eventDriven ? (
+        <div>
+          <p className="text-[13px] text-neutral-4 mb-3">
+            This workflow runs automatically on every commit via a post-commit hook.
+          </p>
+          <div className="rounded-lg border border-purple-700/40 bg-purple-900/20 px-4 py-3">
+            <span className="text-[14px] font-medium text-purple-400">Trigger: On commit</span>
+            <p className="text-[13px] text-neutral-4 mt-1">
+              Each commit will be reviewed automatically. No schedule needed.
+            </p>
+          </div>
         </div>
-        <div className="flex gap-1.5">
-          {DAY_INDIVIDUAL.map(p => {
-            const baseDow = isBiweeklyDow(form.cronDow)
-              ? form.cronDow.split('-').slice(1).join('-')
-              : form.cronDow
-            const selected = baseDow === p.dow
-            return (
-              <FrequencyButton
-                key={p.dow}
-                label={p.label}
-                dow={p.dow}
-                selected={selected}
-                onSelect={dow => {
-                  const biweekly = isBiweeklyDow(form.cronDow)
-                  onChange({ cronDow: biweekly ? `biweekly-${dow}` : dow })
-                }}
-              />
-            )
-          })}
-        </div>
-        {/* Weekly / Bi-weekly toggle — visible when a single day is selected */}
-        {(() => {
-          const isDay = DAY_INDIVIDUAL.some(d => d.dow === form.cronDow || form.cronDow === `biweekly-${d.dow}`)
-          if (!isDay) return null
-          const biweekly = isBiweeklyDow(form.cronDow)
-          const baseDow = biweekly ? form.cronDow.split('-').slice(1).join('-') : form.cronDow
-          return (
-            <div className="flex gap-1.5 mt-2">
-              <FrequencyButton
-                label="Every week"
-                dow={baseDow}
-                selected={!biweekly}
-                onSelect={dow => onChange({ cronDow: dow })}
-              />
-              <FrequencyButton
-                label="Every 2 weeks"
-                dow={`biweekly-${baseDow}`}
-                selected={biweekly}
-                onSelect={dow => onChange({ cronDow: dow })}
-              />
+      ) : (
+        <>
+          <div>
+            <p className="text-[13px] text-neutral-4 mb-3">
+              Choose when this workflow should run automatically.
+            </p>
+
+            {/* Time picker */}
+            <label className="block text-[13px] font-medium text-neutral-3 mb-2">Time</label>
+            <TimePicker
+              hour={form.cronHour}
+              minute={form.cronMinute}
+              onChange={(h, m) => onChange({ cronHour: h, cronMinute: m })}
+            />
+          </div>
+
+          <div>
+            <label className="block text-[13px] font-medium text-neutral-3 mb-2">Frequency</label>
+            <div className="flex flex-wrap gap-1.5 mb-2">
+              {DAY_PRESETS.map(p => {
+                const selected = form.cronDow === p.dow
+                return (
+                  <FrequencyButton
+                    key={p.dow}
+                    label={p.label}
+                    dow={p.dow}
+                    selected={selected}
+                    onSelect={dow => onChange({ cronDow: dow })}
+                  />
+                )
+              })}
             </div>
-          )
-        })()}
-        <div className="mt-2 text-[13px] text-neutral-5">
-          {describeCron(buildCron(form.cronHour, form.cronDow, form.cronMinute))}
-        </div>
-      </div>
+            <div className="flex gap-1.5">
+              {DAY_INDIVIDUAL.map(p => {
+                const baseDow = isBiweeklyDow(form.cronDow)
+                  ? form.cronDow.split('-').slice(1).join('-')
+                  : form.cronDow
+                const selected = baseDow === p.dow
+                return (
+                  <FrequencyButton
+                    key={p.dow}
+                    label={p.label}
+                    dow={p.dow}
+                    selected={selected}
+                    onSelect={dow => {
+                      const biweekly = isBiweeklyDow(form.cronDow)
+                      onChange({ cronDow: biweekly ? `biweekly-${dow}` : dow })
+                    }}
+                  />
+                )
+              })}
+            </div>
+            {/* Weekly / Bi-weekly toggle — visible when a single day is selected */}
+            {(() => {
+              const isDay = DAY_INDIVIDUAL.some(d => d.dow === form.cronDow || form.cronDow === `biweekly-${d.dow}`)
+              if (!isDay) return null
+              const biweekly = isBiweeklyDow(form.cronDow)
+              const baseDow = biweekly ? form.cronDow.split('-').slice(1).join('-') : form.cronDow
+              return (
+                <div className="flex gap-1.5 mt-2">
+                  <FrequencyButton
+                    label="Every week"
+                    dow={baseDow}
+                    selected={!biweekly}
+                    onSelect={dow => onChange({ cronDow: dow })}
+                  />
+                  <FrequencyButton
+                    label="Every 2 weeks"
+                    dow={`biweekly-${baseDow}`}
+                    selected={biweekly}
+                    onSelect={dow => onChange({ cronDow: dow })}
+                  />
+                </div>
+              )
+            })()}
+            <div className="mt-2 text-[13px] text-neutral-5">
+              {describeCron(buildCron(form.cronHour, form.cronDow, form.cronMinute))}
+            </div>
+          </div>
+        </>
+      )}
 
       {/* Model selection */}
       <div>
@@ -379,7 +398,7 @@ function StepSchedule({
 // AddWorkflowModal (wizard)
 // ---------------------------------------------------------------------------
 
-/** Three-step wizard modal for creating a new scheduled workflow: select repo, choose type, configure schedule. */
+/** Three-step wizard modal for creating a new workflow: select repo, choose type, configure schedule/options. */
 export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
   const [step, setStep] = useState<Step>(1)
   const [selectedRepoId, setSelectedRepoId] = useState('')
@@ -396,6 +415,7 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
 
+  const eventDriven = isEventDriven(form.kind)
   const updateForm = (patch: Partial<FormState>) => setForm(f => ({ ...f, ...patch }))
 
   const canNext = (): boolean => {
@@ -427,11 +447,14 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
     setFormError(null)
     try {
       const name = form.repoName || form.repoPath.split('/').pop() || 'workflow'
+      const cronExpression = eventDriven
+        ? EVENT_CRON
+        : buildCron(form.cronHour, form.cronDow, form.cronMinute)
       await onAdd({
         id: `${slugify(name)}-${slugify(form.kind)}`,
         name,
         repoPath: form.repoPath.trim(),
-        cronExpression: buildCron(form.cronHour, form.cronDow, form.cronMinute),
+        cronExpression,
         kind: form.kind,
         enabled: true,
         customPrompt: form.customPrompt.trim() || undefined,
@@ -460,7 +483,7 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
         </div>
 
         {/* Step indicator */}
-        <StepIndicator current={step} />
+        <StepIndicator current={step} eventDriven={eventDriven} />
 
         {/* Step content */}
         <div className="min-h-[200px]">
@@ -485,7 +508,7 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
           )}
 
           {step === 3 && (
-            <StepSchedule
+            <StepConfigure
               form={form}
               onChange={updateForm}
             />

--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -1,6 +1,6 @@
 /**
- * Modal dialog for editing an existing scheduled workflow.
- * Focused on editable fields only — schedule, workflow kind, and custom prompt.
+ * Modal dialog for editing an existing workflow.
+ * Adapts for event-driven workflows by hiding the schedule section.
  */
 
 import { useState } from 'react'
@@ -8,7 +8,7 @@ import { IconX, IconLoader2 } from '@tabler/icons-react'
 import type { ReviewRepoConfig } from '../lib/workflowApi'
 import {
   WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL, MODEL_OPTIONS, isBiweeklyDow,
-  buildCron, parseCron, describeCron, kindLabel,
+  buildCron, parseCron, describeCron, kindLabel, isEventDriven, EVENT_CRON,
 } from '../lib/workflowHelpers'
 import { CategoryBadge } from './WorkflowBadges'
 import TimePicker from './TimePicker'
@@ -41,14 +41,19 @@ export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
 
+  const eventDriven = isEventDriven(form.kind)
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setSaving(true)
     setFormError(null)
     try {
+      const cronExpression = eventDriven
+        ? EVENT_CRON
+        : buildCron(form.cronHour, form.cronDow, form.cronMinute)
       await onSave(repo.id, {
         kind: form.kind,
-        cronExpression: buildCron(form.cronHour, form.cronDow, form.cronMinute),
+        cronExpression,
         customPrompt: form.customPrompt.trim() || undefined,
         model: form.model || undefined,
       })
@@ -115,54 +120,63 @@ export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
             </div>
           </div>
 
-          {/* Schedule */}
-          <div>
-            <label className="block text-[13px] font-medium text-neutral-3 mb-2">Time</label>
-            <TimePicker
-              hour={form.cronHour}
-              minute={form.cronMinute}
-              onChange={(h, m) => setForm(f => ({ ...f, cronHour: h, cronMinute: m }))}
-              className="mb-3"
-            />
-            <label className="block text-[13px] font-medium text-neutral-3 mb-2">Frequency</label>
-            <div className="flex flex-wrap gap-1.5 mb-2">
-              {DAY_PRESETS.map(p => (
-                <button
-                  key={p.dow}
-                  type="button"
-                  onClick={() => setForm(f => ({ ...f, cronDow: p.dow }))}
-                  className={btnClass(form.cronDow === p.dow)}
-                >
-                  {p.label}
-                </button>
-              ))}
+          {/* Schedule — hidden for event-driven workflows */}
+          {eventDriven ? (
+            <div className="rounded-lg border border-purple-700/40 bg-purple-900/20 px-4 py-3">
+              <span className="text-[14px] font-medium text-purple-400">Trigger: On commit</span>
+              <p className="text-[13px] text-neutral-4 mt-1">
+                Each commit will be reviewed automatically. No schedule needed.
+              </p>
             </div>
-            <div className="flex gap-1.5">
-              {DAY_INDIVIDUAL.map(p => (
-                <button
-                  key={p.dow}
-                  type="button"
-                  onClick={() => setForm(f => ({ ...f, cronDow: biweekly ? `biweekly-${p.dow}` : p.dow }))}
-                  className={btnClass(baseDow === p.dow)}
-                >
-                  {p.label}
-                </button>
-              ))}
-            </div>
-            {isDay && (
-              <div className="flex gap-1.5 mt-2">
-                <button type="button" onClick={() => setForm(f => ({ ...f, cronDow: baseDow }))} className={btnClass(!biweekly)}>
-                  Every week
-                </button>
-                <button type="button" onClick={() => setForm(f => ({ ...f, cronDow: `biweekly-${baseDow}` }))} className={btnClass(biweekly)}>
-                  Every 2 weeks
-                </button>
+          ) : (
+            <div>
+              <label className="block text-[13px] font-medium text-neutral-3 mb-2">Time</label>
+              <TimePicker
+                hour={form.cronHour}
+                minute={form.cronMinute}
+                onChange={(h, m) => setForm(f => ({ ...f, cronHour: h, cronMinute: m }))}
+                className="mb-3"
+              />
+              <label className="block text-[13px] font-medium text-neutral-3 mb-2">Frequency</label>
+              <div className="flex flex-wrap gap-1.5 mb-2">
+                {DAY_PRESETS.map(p => (
+                  <button
+                    key={p.dow}
+                    type="button"
+                    onClick={() => setForm(f => ({ ...f, cronDow: p.dow }))}
+                    className={btnClass(form.cronDow === p.dow)}
+                  >
+                    {p.label}
+                  </button>
+                ))}
               </div>
-            )}
-            <div className="mt-2 text-[13px] text-neutral-5">
-              {describeCron(buildCron(form.cronHour, form.cronDow, form.cronMinute))}
+              <div className="flex gap-1.5">
+                {DAY_INDIVIDUAL.map(p => (
+                  <button
+                    key={p.dow}
+                    type="button"
+                    onClick={() => setForm(f => ({ ...f, cronDow: biweekly ? `biweekly-${p.dow}` : p.dow }))}
+                    className={btnClass(baseDow === p.dow)}
+                  >
+                    {p.label}
+                  </button>
+                ))}
+              </div>
+              {isDay && (
+                <div className="flex gap-1.5 mt-2">
+                  <button type="button" onClick={() => setForm(f => ({ ...f, cronDow: baseDow }))} className={btnClass(!biweekly)}>
+                    Every week
+                  </button>
+                  <button type="button" onClick={() => setForm(f => ({ ...f, cronDow: `biweekly-${baseDow}` }))} className={btnClass(biweekly)}>
+                    Every 2 weeks
+                  </button>
+                </div>
+              )}
+              <div className="mt-2 text-[13px] text-neutral-5">
+                {describeCron(buildCron(form.cronHour, form.cronDow, form.cronMinute))}
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Model selection */}
           <div>

--- a/src/components/WorkflowBadges.tsx
+++ b/src/components/WorkflowBadges.tsx
@@ -14,6 +14,7 @@ export function CategoryBadge({ kind }: { kind: string }) {
     assessment: 'border-accent-7/60 bg-accent-9/30 text-accent-4',
     organizer:  'border-success-7/60 bg-success-9/30 text-success-4',
     executor:   'border-warning-7/60 bg-warning-9/30 text-warning-4',
+    event:      'border-purple-700/60 bg-purple-900/30 text-purple-400',
   }
   return (
     <span className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-[13px] font-medium capitalize ${styles[cat]}`}>

--- a/src/components/workflows/WorkflowRow.tsx
+++ b/src/components/workflows/WorkflowRow.tsx
@@ -8,11 +8,10 @@ import {
   IconPencil, IconTrash,
 } from '@tabler/icons-react'
 import type { WorkflowRun, WorkflowRunWithSteps, CronSchedule, ReviewRepoConfig } from '../../lib/workflowApi'
-import { kindLabel, describeCron, modelLabel } from '../../lib/workflowHelpers'
+import { kindLabel, describeCron, modelLabel, isEventDriven, formatTime } from '../../lib/workflowHelpers'
 import { StatusBadge } from '../WorkflowBadges'
 import { HealthDot } from './HealthDot'
 import { MiniRunRow } from './MiniRunRow'
-import { formatTime } from '../../lib/workflowHelpers'
 
 // ---------------------------------------------------------------------------
 // WorkflowRow
@@ -48,21 +47,24 @@ export function WorkflowRow({
   onNavigateToSession?: (sessionId: string) => void
 }) {
   const [showRuns, setShowRuns] = useState(false)
+  const eventDriven = isEventDriven(repo.kind ?? '')
   const paused = schedule ? !schedule.enabled : false
   const lastRun = recentRuns[0]
 
   return (
     <div>
-      <div className={`group flex items-center gap-3 px-3 py-2 rounded-md transition-colors hover:bg-neutral-10/50 ${paused ? 'opacity-60' : ''}`}>
+      <div className={`group flex items-center gap-3 px-3 py-2 rounded-md transition-colors hover:bg-neutral-10/50 ${paused && !eventDriven ? 'opacity-60' : ''}`}>
         <HealthDot status={lastRun?.status} />
-        <span className={`text-[14px] font-medium min-w-0 truncate ${paused ? 'text-neutral-5' : 'text-neutral-2'}`}>
+        <span className={`text-[14px] font-medium min-w-0 truncate ${paused && !eventDriven ? 'text-neutral-5' : 'text-neutral-2'}`}>
           {kindLabel(repo.kind ?? '')}
         </span>
-        {paused && (
+        {paused && !eventDriven && (
           <span className="text-[12px] text-warning-5 shrink-0">paused</span>
         )}
-        <span className="text-[14px] text-neutral-5 whitespace-nowrap shrink-0">
-          {schedule ? describeCron(schedule.cronExpression) : describeCron(repo.cronExpression)}
+        <span className={`text-[14px] whitespace-nowrap shrink-0 ${eventDriven ? 'text-purple-400' : 'text-neutral-5'}`}>
+          {eventDriven
+            ? 'On commit'
+            : schedule ? describeCron(schedule.cronExpression) : describeCron(repo.cronExpression)}
         </span>
         {modelLabel(repo.model) && (
           <span className="text-[12px] text-neutral-5 bg-neutral-9 rounded px-1.5 py-0.5 shrink-0">
@@ -91,24 +93,28 @@ export function WorkflowRow({
         )}
         {/* Actions — visible on hover */}
         <div className="flex items-center gap-0.5 shrink-0 ml-auto opacity-0 group-hover:opacity-100 transition-opacity">
-          <button
-            onClick={() => onTrigger(repo.id)}
-            className="rounded p-1 text-neutral-5 hover:text-accent-3 hover:bg-neutral-9 transition-colors"
-            title="Run now"
-          >
-            <IconPlayerPlay size={14} stroke={2} />
-          </button>
-          <button
-            onClick={() => onToggleEnabled(repo.id, !schedule?.enabled)}
-            className={`rounded p-1 transition-colors ${
-              paused
-                ? 'text-success-5 hover:text-success-3 hover:bg-neutral-9'
-                : 'text-neutral-5 hover:text-warning-4 hover:bg-neutral-9'
-            }`}
-            title={paused ? 'Resume' : 'Pause'}
-          >
-            {paused ? <IconPlayerPlay size={14} stroke={2} /> : <IconPlayerPause size={14} stroke={2} />}
-          </button>
+          {!eventDriven && (
+            <button
+              onClick={() => onTrigger(repo.id)}
+              className="rounded p-1 text-neutral-5 hover:text-accent-3 hover:bg-neutral-9 transition-colors"
+              title="Run now"
+            >
+              <IconPlayerPlay size={14} stroke={2} />
+            </button>
+          )}
+          {!eventDriven && (
+            <button
+              onClick={() => onToggleEnabled(repo.id, !schedule?.enabled)}
+              className={`rounded p-1 transition-colors ${
+                paused
+                  ? 'text-success-5 hover:text-success-3 hover:bg-neutral-9'
+                  : 'text-neutral-5 hover:text-warning-4 hover:bg-neutral-9'
+              }`}
+              title={paused ? 'Resume' : 'Pause'}
+            >
+              {paused ? <IconPlayerPlay size={14} stroke={2} /> : <IconPlayerPause size={14} stroke={2} />}
+            </button>
+          )}
           <button
             onClick={() => onEdit(repo)}
             className="rounded p-1 text-neutral-5 hover:text-neutral-2 hover:bg-neutral-9 transition-colors"

--- a/src/lib/workflowHelpers.test.ts
+++ b/src/lib/workflowHelpers.test.ts
@@ -13,10 +13,29 @@ import {
   statusBadge,
   toTimeValue,
   fromTimeValue,
+  isEventDriven,
+  EVENT_CRON,
 } from './workflowHelpers.js'
 import type { WorkflowRun } from './workflowApi'
 
 describe('workflowHelpers', () => {
+  describe('isEventDriven', () => {
+    it('returns true for commit-review', () => {
+      expect(isEventDriven('commit-review')).toBe(true)
+    })
+
+    it('returns false for scheduled workflows', () => {
+      expect(isEventDriven('code-review.daily')).toBe(false)
+      expect(isEventDriven('coverage.daily')).toBe(false)
+    })
+  })
+
+  describe('EVENT_CRON', () => {
+    it('describeCron returns "On commit" for event cron', () => {
+      expect(describeCron(EVENT_CRON)).toBe('On commit')
+    })
+  })
+
   describe('buildCron', () => {
     it('builds a cron expression', () => {
       expect(buildCron(6, '*')).toBe('0 6 * * *')
@@ -143,6 +162,7 @@ describe('workflowHelpers', () => {
     it('returns label for known kinds', () => {
       expect(kindLabel('coverage.daily')).toBe('Coverage Assessment')
       expect(kindLabel('code-review.daily')).toBe('Code Review')
+      expect(kindLabel('commit-review')).toBe('Commit Review')
     })
 
     it('returns kind string for unknown kinds', () => {
@@ -153,6 +173,7 @@ describe('workflowHelpers', () => {
   describe('kindCategory', () => {
     it('returns category for known kinds', () => {
       expect(kindCategory('coverage.daily')).toBe('assessment')
+      expect(kindCategory('commit-review')).toBe('event')
     })
 
     it('returns assessment for unknown kinds', () => {

--- a/src/lib/workflowHelpers.ts
+++ b/src/lib/workflowHelpers.ts
@@ -4,17 +4,26 @@
 
 import type { WorkflowRun } from './workflowApi'
 
-export type WorkflowCategory = 'assessment' | 'organizer' | 'executor'
+export type WorkflowCategory = 'assessment' | 'organizer' | 'executor' | 'event'
 
 export const WORKFLOW_KINDS = [
   { value: 'coverage.daily', label: 'Coverage Assessment', category: 'assessment' as WorkflowCategory },
   { value: 'code-review.daily', label: 'Code Review', category: 'assessment' as WorkflowCategory },
+  { value: 'commit-review', label: 'Commit Review', category: 'event' as WorkflowCategory },
   { value: 'comment-assessment.daily', label: 'Comment Assessment', category: 'assessment' as WorkflowCategory },
   { value: 'dependency-health.daily', label: 'Dependency Health', category: 'assessment' as WorkflowCategory },
   { value: 'security-audit.weekly', label: 'Security Audit', category: 'assessment' as WorkflowCategory },
   { value: 'complexity.weekly', label: 'Complexity Report', category: 'assessment' as WorkflowCategory },
   { value: 'repo-health.weekly', label: 'Repository Health', category: 'assessment' as WorkflowCategory },
 ]
+
+/** Event-driven workflow kinds that are triggered by hooks rather than cron schedules. */
+export const EVENT_DRIVEN_KINDS = new Set(['commit-review'])
+
+/** Check if a workflow kind is event-driven (triggered by hooks, not cron). */
+export function isEventDriven(kind: string): boolean {
+  return EVENT_DRIVEN_KINDS.has(kind)
+}
 
 export const MODEL_OPTIONS = [
   { value: '', label: 'Default (Opus)' },
@@ -92,8 +101,12 @@ export function fromTimeValue(v: string): { hour: number; minute: number } {
   return { hour: h || 0, minute: m || 0 }
 }
 
+/** Sentinel cron expression for event-driven workflows (no schedule). */
+export const EVENT_CRON = 'event'
+
 /** Convert a 5-field cron expression into a human-readable description, e.g. `"Daily at 06:00"`. */
 export function describeCron(expr: string): string {
+  if (expr === EVENT_CRON) return 'On commit'
   const parts = expr.trim().split(/\s+/)
   if (parts.length !== 5) return expr
   const [min, hour, dom, , dow] = parts


### PR DESCRIPTION
## Summary
- Adds `commit-review` as a new workflow kind with an `event` category, triggered by post-commit hooks rather than cron schedules
- Add/Edit modals adapt for event-driven workflows: show "On commit" info card instead of the schedule picker, while keeping model and focus area options
- WorkflowRow displays purple "On commit" trigger label and hides pause/run-now actions that don't apply to hook-triggered workflows

## Test plan
- [x] All 943 existing tests pass
- [x] Build succeeds with no type errors
- [ ] Verify "Commit Review" appears in the workflow type grid under the "event" category badge
- [ ] Verify selecting it skips the schedule picker on step 3 and shows "On commit" info
- [ ] Verify editing a commit-review workflow hides schedule controls
- [ ] Verify the workflow row shows purple "On commit" instead of a cron description

🤖 Generated with [Claude Code](https://claude.com/claude-code)