### PR TITLE
Add commit-review event dispatcher

### DIFF
--- a/server/commit-event-handler.ts
+++ b/server/commit-event-handler.ts
@@ -1,0 +1,133 @@
+/**
+ * Commit-review event dispatcher.
+ *
+ * Receives commit events from git post-commit hooks and dispatches
+ * commit-review workflow runs after passing a multi-layer filter chain
+ * for cycle prevention and deduplication.
+ *
+ * Filter chain (defense in depth):
+ *   1. Branch filter — reject if `codekin/reports`
+ *   2. Message filter — reject if message starts with any workflow commitMessage prefix
+ *   3. Config lookup — reject if no enabled `commit-review` workflow for this repo
+ *   4. Commit hash dedup — in-memory Map with 1h TTL, reject duplicates
+ *   5. Concurrency cap — max 1 running commit-review per repo
+ */
+
+import { getWorkflowEngine } from './workflow-engine.js'
+import { loadWorkflowConfig } from './workflow-config.js'
+import { getWorkflowCommitPrefixes } from './workflow-loader.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CommitEvent {
+  repoPath: string
+  branch: string
+  commitHash: string
+  commitMessage: string
+  author: string
+}
+
+export interface CommitEventResult {
+  accepted: boolean
+  reason?: string
+  runId?: string
+}
+
+// ---------------------------------------------------------------------------
+// CommitEventHandler
+// ---------------------------------------------------------------------------
+
+/** TTL for commit hash deduplication entries (1 hour). */
+const DEDUP_TTL_MS = 60 * 60 * 1000
+
+/** Interval for cleaning up expired dedup entries (10 minutes). */
+const DEDUP_CLEANUP_INTERVAL_MS = 10 * 60 * 1000
+
+export class CommitEventHandler {
+  /** commitHash → timestamp of when it was recorded. */
+  private seenCommits = new Map<string, number>()
+  private cleanupTimer: ReturnType<typeof setInterval>
+
+  constructor() {
+    // Periodically prune expired dedup entries
+    this.cleanupTimer = setInterval(() => this.pruneExpired(), DEDUP_CLEANUP_INTERVAL_MS)
+  }
+
+  /**
+   * Process a commit event through the filter chain.
+   * Returns accepted=true if a workflow run was dispatched.
+   */
+  async handle(event: CommitEvent): Promise<CommitEventResult> {
+    // Layer 1: Branch filter
+    if (event.branch === 'codekin/reports') {
+      return { accepted: false, reason: 'Rejected: reports branch' }
+    }
+
+    // Layer 2: Message filter — reject if message starts with any workflow commit prefix
+    const prefixes = getWorkflowCommitPrefixes()
+    for (const prefix of prefixes) {
+      if (event.commitMessage.startsWith(prefix)) {
+        return { accepted: false, reason: `Rejected: workflow commit message (${prefix})` }
+      }
+    }
+
+    // Layer 3: Config lookup — find an enabled commit-review workflow for this repo
+    const config = loadWorkflowConfig()
+    const repoConfig = config.reviewRepos.find(
+      r => r.repoPath === event.repoPath && r.enabled && r.kind === 'commit-review'
+    )
+    if (!repoConfig) {
+      return { accepted: false, reason: 'Rejected: no enabled commit-review config for this repo' }
+    }
+
+    // Layer 4: Commit hash dedup
+    if (this.seenCommits.has(event.commitHash)) {
+      return { accepted: false, reason: 'Rejected: duplicate commit hash' }
+    }
+    this.seenCommits.set(event.commitHash, Date.now())
+
+    // Layer 5: Concurrency cap — max 1 running commit-review per repo
+    const engine = getWorkflowEngine()
+    const activeRuns = engine.listRuns({ kind: 'commit-review', status: 'running', limit: 100 })
+    const hasActiveRun = activeRuns.some(
+      run => (run.input as Record<string, unknown>).repoPath === event.repoPath
+    )
+    if (hasActiveRun) {
+      return { accepted: false, reason: 'Rejected: commit-review already running for this repo' }
+    }
+
+    // All filters passed — dispatch the workflow
+    try {
+      const run = await engine.startRun('commit-review', {
+        repoPath: event.repoPath,
+        repoName: repoConfig.name,
+        commitHash: event.commitHash,
+        customPrompt: repoConfig.customPrompt,
+        model: repoConfig.model,
+      })
+
+      console.log(`[commit-event] Dispatched commit-review run ${run.id} for ${event.repoPath} (${event.commitHash.slice(0, 8)})`)
+      return { accepted: true, runId: run.id }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      console.error(`[commit-event] Failed to start run for ${event.repoPath}:`, msg)
+      return { accepted: false, reason: `Failed to start run: ${msg}` }
+    }
+  }
+
+  /** Remove dedup entries older than the TTL. */
+  private pruneExpired() {
+    const cutoff = Date.now() - DEDUP_TTL_MS
+    for (const [hash, ts] of this.seenCommits) {
+      if (ts < cutoff) this.seenCommits.delete(hash)
+    }
+  }
+
+  /** Clean up resources. */
+  shutdown() {
+    clearInterval(this.cleanupTimer)
+    this.seenCommits.clear()
+  }
+}

--- a/server/commit-event-hook.sh
+++ b/server/commit-event-hook.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# Codekin post-commit hook — fires a commit event to the Codekin server.
+# Installed/managed by commit-event-hooks.ts; do not edit the section
+# between BEGIN/END CODEKIN markers manually.
+#
+# Client-side fast filters avoid unnecessary HTTP calls:
+#   1. Skip if branch = codekin/reports
+#   2. Skip if message starts with a workflow commit prefix
+#
+# Fire-and-forget: never blocks `git commit`.
+
+CONFIG_FILE="$HOME/.codekin/hook-config.json"
+
+# Bail silently if no config
+if [ ! -f "$CONFIG_FILE" ]; then
+  exit 0
+fi
+
+# Read server URL and auth token from config
+# Uses simple grep+sed to avoid jq dependency
+SERVER_URL=$(grep '"serverUrl"' "$CONFIG_FILE" | sed 's/.*"serverUrl"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+AUTH_TOKEN=$(grep '"authToken"' "$CONFIG_FILE" | sed 's/.*"authToken"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+
+if [ -z "$SERVER_URL" ] || [ -z "$AUTH_TOKEN" ]; then
+  exit 0
+fi
+
+# Gather commit info
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+COMMIT_HASH=$(git rev-parse HEAD 2>/dev/null)
+COMMIT_MESSAGE=$(git log -1 --format="%s" 2>/dev/null)
+AUTHOR=$(git log -1 --format="%an" 2>/dev/null)
+REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null)
+
+# Client-side filter 1: skip reports branch
+if [ "$BRANCH" = "codekin/reports" ]; then
+  exit 0
+fi
+
+# Client-side filter 2: skip workflow-generated commits
+case "$COMMIT_MESSAGE" in
+  "chore: commit review"*|"chore: code review"*)
+    exit 0
+    ;;
+esac
+
+# Fire-and-forget POST to the server (5s timeout, backgrounded)
+curl -s -o /dev/null -m 5 \
+  -X POST "${SERVER_URL}/api/workflows/commit-event" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer ${AUTH_TOKEN}" \
+  -d "{\"repoPath\":\"${REPO_PATH}\",\"branch\":\"${BRANCH}\",\"commitHash\":\"${COMMIT_HASH}\",\"commitMessage\":$(printf '%s' "$COMMIT_MESSAGE" | sed 's/\\/\\\\/g; s/"/\\"/g; s/$//' | { echo -n '"'; cat; echo -n '"'; }),\"author\":\"${AUTHOR}\"}" \
+  &
+
+exit 0

--- a/server/commit-event-hooks.ts
+++ b/server/commit-event-hooks.ts
@@ -1,0 +1,206 @@
+/**
+ * Git hook installation manager for commit-review event dispatching.
+ *
+ * Manages the codekin section inside each repo's post-commit hook.
+ * The hook script is inserted between BEGIN/END markers so it can
+ * coexist with other hooks and be cleanly removed.
+ *
+ * Also manages ~/.codekin/hook-config.json which provides the server
+ * URL and auth token to the shell hook script.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, unlinkSync } from 'fs'
+import { execFileSync } from 'child_process'
+import { homedir } from 'os'
+import { dirname, join } from 'path'
+import { loadWorkflowConfig } from './workflow-config.js'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BEGIN_MARKER = '# BEGIN CODEKIN COMMIT HOOK'
+const END_MARKER = '# END CODEKIN COMMIT HOOK'
+
+const HOOK_CONFIG_PATH = join(homedir(), '.codekin', 'hook-config.json')
+
+// Resolve the hook script path relative to this file.
+// In compiled mode (dist/), the shell script is at ../server/commit-event-hook.sh
+// In source mode, it's a sibling file.
+import { fileURLToPath } from 'url'
+const __ownDir = dirname(fileURLToPath(import.meta.url))
+const HOOK_SCRIPT_SOURCE = existsSync(join(__ownDir, 'commit-event-hook.sh'))
+  ? join(__ownDir, 'commit-event-hook.sh')
+  : join(__ownDir, '..', 'server', 'commit-event-hook.sh')
+
+// ---------------------------------------------------------------------------
+// Hook config (auth token + server URL for the shell script)
+// ---------------------------------------------------------------------------
+
+export interface HookConfig {
+  serverUrl: string
+  authToken: string
+}
+
+/**
+ * Write ~/.codekin/hook-config.json with the server URL and auth token.
+ * File permissions are set to 0600 (owner read/write only) since it contains a secret.
+ */
+export function ensureHookConfig(authToken: string, serverUrl: string): void {
+  const dir = dirname(HOOK_CONFIG_PATH)
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+
+  const config: HookConfig = { serverUrl, authToken }
+  writeFileSync(HOOK_CONFIG_PATH, JSON.stringify(config, null, 2), { encoding: 'utf-8', mode: 0o600 })
+  console.log(`[commit-hooks] Hook config written to ${HOOK_CONFIG_PATH}`)
+}
+
+// ---------------------------------------------------------------------------
+// Hook installation
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the hooks directory for a given repo.
+ * Respects `core.hooksPath` if configured, otherwise uses `.git/hooks/`.
+ */
+function getHooksDir(repoPath: string): string {
+  try {
+    const customPath = execFileSync(
+      'git', ['config', '--get', 'core.hooksPath'],
+      { cwd: repoPath, timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] },
+    ).toString().trim()
+    if (customPath) return customPath
+  } catch {
+    // Not set — use default
+  }
+  return join(repoPath, '.git', 'hooks')
+}
+
+/**
+ * Generate the codekin hook section that will be inserted into post-commit.
+ * Sources the shared hook script so updates to the script are picked up
+ * without reinstalling hooks.
+ */
+function generateHookSection(): string {
+  return [
+    BEGIN_MARKER,
+    `# Installed by Codekin — do not edit this section manually`,
+    `if [ -f "${HOOK_SCRIPT_SOURCE}" ]; then`,
+    `  . "${HOOK_SCRIPT_SOURCE}"`,
+    `fi`,
+    END_MARKER,
+  ].join('\n')
+}
+
+/**
+ * Install the codekin post-commit hook section into a repo.
+ * If the hook file already exists, the codekin section is appended (or replaced).
+ * If not, a new file is created with a shebang + the section.
+ */
+export function installCommitHook(repoPath: string): boolean {
+  const hooksDir = getHooksDir(repoPath)
+  const hookPath = join(hooksDir, 'post-commit')
+
+  if (!existsSync(hooksDir)) {
+    mkdirSync(hooksDir, { recursive: true })
+  }
+
+  const section = generateHookSection()
+  let content: string
+
+  if (existsSync(hookPath)) {
+    const existing = readFileSync(hookPath, 'utf-8')
+
+    // Already installed — replace existing section
+    if (existing.includes(BEGIN_MARKER)) {
+      const re = new RegExp(`${escapeRegex(BEGIN_MARKER)}[\\s\\S]*?${escapeRegex(END_MARKER)}`)
+      content = existing.replace(re, section)
+    } else {
+      // Append to existing hook
+      content = existing.trimEnd() + '\n\n' + section + '\n'
+    }
+  } else {
+    // New file
+    content = `#!/bin/sh\n\n${section}\n`
+  }
+
+  writeFileSync(hookPath, content, 'utf-8')
+  chmodSync(hookPath, 0o755)
+  console.log(`[commit-hooks] Installed post-commit hook at ${hookPath}`)
+  return true
+}
+
+/**
+ * Remove the codekin section from a repo's post-commit hook.
+ * If the file only contains the codekin section (+ shebang), removes the file entirely.
+ */
+export function uninstallCommitHook(repoPath: string): boolean {
+  const hooksDir = getHooksDir(repoPath)
+  const hookPath = join(hooksDir, 'post-commit')
+
+  if (!existsSync(hookPath)) return false
+
+  const existing = readFileSync(hookPath, 'utf-8')
+  if (!existing.includes(BEGIN_MARKER)) return false
+
+  const re = new RegExp(`\\n?${escapeRegex(BEGIN_MARKER)}[\\s\\S]*?${escapeRegex(END_MARKER)}\\n?`)
+  const cleaned = existing.replace(re, '\n').trim()
+
+  // If only the shebang remains, the hook is effectively empty
+  if (!cleaned || cleaned === '#!/bin/sh' || cleaned === '#!/bin/bash') {
+    // Remove the now-empty hook file
+    unlinkSync(hookPath)
+    console.log(`[commit-hooks] Removed empty post-commit hook at ${hookPath}`)
+  } else {
+    writeFileSync(hookPath, cleaned + '\n', 'utf-8')
+    console.log(`[commit-hooks] Removed codekin section from ${hookPath}`)
+  }
+
+  return true
+}
+
+// ---------------------------------------------------------------------------
+// Sync: install/uninstall hooks based on current config
+// ---------------------------------------------------------------------------
+
+/**
+ * Sync commit hooks with the current workflow config.
+ * Installs hooks for enabled commit-review repos, uninstalls for disabled/removed ones.
+ */
+export function syncCommitHooks(): void {
+  const config = loadWorkflowConfig()
+  const commitReviewRepos = new Set<string>()
+
+  // Install hooks for enabled commit-review repos
+  for (const repo of config.reviewRepos) {
+    if (repo.kind === 'commit-review' && repo.enabled) {
+      commitReviewRepos.add(repo.repoPath)
+      try {
+        if (existsSync(join(repo.repoPath, '.git'))) {
+          installCommitHook(repo.repoPath)
+        }
+      } catch (err) {
+        console.warn(`[commit-hooks] Failed to install hook for ${repo.repoPath}:`, err)
+      }
+    }
+  }
+
+  // Uninstall hooks for repos that are no longer configured for commit-review
+  for (const repo of config.reviewRepos) {
+    if (!commitReviewRepos.has(repo.repoPath)) {
+      try {
+        uninstallCommitHook(repo.repoPath)
+      } catch {
+        // Silently ignore — hook may not exist
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/server/workflow-loader.ts
+++ b/server/workflow-loader.ts
@@ -481,6 +481,19 @@ export function listAvailableKinds(repoPath?: string): WorkflowKindInfo[] {
 }
 
 // ---------------------------------------------------------------------------
+// Commit message prefixes (for cycle prevention)
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the commitMessage prefixes from all built-in workflow definitions.
+ * Used by the commit event handler to detect and reject commits generated
+ * by workflows themselves (cycle prevention).
+ */
+export function getWorkflowCommitPrefixes(): string[] {
+  return loadBuiltinWorkflows().map(d => d.commitMessage)
+}
+
+// ---------------------------------------------------------------------------
 // Main entry point
 // ---------------------------------------------------------------------------
 

--- a/server/workflow-routes.ts
+++ b/server/workflow-routes.ts
@@ -16,6 +16,8 @@ import {
   type ReviewRepoConfig,
 } from './workflow-config.js'
 import { listAvailableKinds, ensureRepoWorkflowsRegistered } from './workflow-loader.js'
+import { syncCommitHooks } from './commit-event-hooks.js'
+import type { CommitEventHandler } from './commit-event-handler.js'
 import type { SessionManager } from './session-manager.js'
 
 type VerifyFn = (token: string | undefined) => boolean
@@ -51,6 +53,7 @@ function isValidCron(expr: string): boolean {
 /**
  * Sync cron schedules with the current workflow config.
  * When `sessions` is provided, also registers any standalone repo workflows.
+ * Event-driven repos (cronExpression === 'event') are skipped — they don't use cron.
  */
 export function syncSchedules(sessions?: SessionManager) {
   const engine = getWorkflowEngine()
@@ -63,6 +66,11 @@ export function syncSchedules(sessions?: SessionManager) {
     // Register any standalone repo workflows before scheduling
     if (sessions) {
       ensureRepoWorkflowsRegistered(engine, sessions, repo.repoPath)
+    }
+
+    // Skip event-driven repos — they are triggered by commit hooks, not cron
+    if (repo.cronExpression === 'event') {
+      continue
     }
 
     engine.upsertSchedule({
@@ -82,7 +90,12 @@ export function syncSchedules(sessions?: SessionManager) {
   }
 }
 
-export function createWorkflowRouter(verifyToken: VerifyFn, extractToken: ExtractFn, sessions?: SessionManager): Router {
+export function createWorkflowRouter(
+  verifyToken: VerifyFn,
+  extractToken: ExtractFn,
+  sessions?: SessionManager,
+  commitEventState?: { handler: CommitEventHandler | undefined },
+): Router {
   const router = Router()
 
   /** Auth middleware for all workflow routes. */
@@ -106,6 +119,32 @@ export function createWorkflowRouter(verifyToken: VerifyFn, extractToken: Extrac
       return null
     }
   }
+
+  // -------------------------------------------------------------------------
+  // Commit event (from git post-commit hook)
+  // -------------------------------------------------------------------------
+
+  router.post('/commit-event', async (req, res) => {
+    const handler = commitEventState?.handler
+    if (!handler) {
+      return res.status(503).json({ error: 'Commit event handler not available' })
+    }
+
+    const { repoPath, branch, commitHash, commitMessage, author } = req.body
+    if (!repoPath || !branch || !commitHash || !commitMessage) {
+      return res.status(400).json({ error: 'Missing required fields: repoPath, branch, commitHash, commitMessage' })
+    }
+
+    const result = await handler.handle({
+      repoPath,
+      branch,
+      commitHash,
+      commitMessage,
+      author: author || 'unknown',
+    })
+
+    res.status(result.accepted ? 202 : 200).json(result)
+  })
 
   // -------------------------------------------------------------------------
   // Kinds
@@ -271,9 +310,10 @@ export function createWorkflowRouter(verifyToken: VerifyFn, extractToken: Extrac
       model,
     })
 
-    // Re-sync schedules with updated config
+    // Re-sync schedules and commit hooks with updated config
     try {
       syncSchedules(sessions)
+      syncCommitHooks()
     } catch {
       // Engine might not be ready yet
     }
@@ -284,7 +324,10 @@ export function createWorkflowRouter(verifyToken: VerifyFn, extractToken: Extrac
   router.patch('/config/repos/:id', (req, res) => {
     try {
       const config = updateReviewRepo(req.params.id, req.body)
-      try { syncSchedules(sessions) } catch { /* engine may not be ready */ }
+      try {
+        syncSchedules(sessions)
+        syncCommitHooks()
+      } catch { /* engine may not be ready */ }
       res.json({ config })
     } catch (err) {
       res.status(404).json({ error: err instanceof Error ? err.message : 'Repo not found' })
@@ -294,9 +337,10 @@ export function createWorkflowRouter(verifyToken: VerifyFn, extractToken: Extrac
   router.delete('/config/repos/:id', (req, res) => {
     const config = removeReviewRepo(req.params.id)
 
-    // Re-sync schedules with updated config
+    // Re-sync schedules and commit hooks with updated config
     try {
       syncSchedules(sessions)
+      syncCommitHooks()
     } catch {
       // Engine might not be ready yet
     }

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -30,6 +30,8 @@ import { StepflowHandler, loadStepflowConfig } from './stepflow-handler.js'
 import { initWorkflowEngine, shutdownWorkflowEngine, type WorkflowEvent } from './workflow-engine.js'
 import { loadMdWorkflows } from './workflow-loader.js'
 import { createWorkflowRouter, syncSchedules } from './workflow-routes.js'
+import { CommitEventHandler } from './commit-event-handler.js'
+import { ensureHookConfig, syncCommitHooks } from './commit-event-hooks.js'
 import { createAuthRouter } from './auth-routes.js'
 import { createSessionRouter } from './session-routes.js'
 import { createWebhookRouter } from './webhook-routes.js'
@@ -160,6 +162,10 @@ if (stepflowConfig.enabled) {
   console.log('[stepflow] Stepflow webhook integration disabled (STEPFLOW_WEBHOOK_ENABLED != true)')
 }
 
+// Commit event handler — instantiated after workflow engine init.
+// Wrapped in an object so the router closure captures a live reference.
+const commitEventState: { handler: CommitEventHandler | undefined } = { handler: undefined }
+
 // ---------------------------------------------------------------------------
 // Express app and REST API
 // ---------------------------------------------------------------------------
@@ -260,7 +266,10 @@ app.use(createSessionRouter(verifyToken, extractToken, sessions, verifyTokenOrSe
 app.use(createWebhookRouter(verifyToken, extractToken, webhookHandler, stepflowHandler))
 app.use(createUploadRouter(verifyToken, extractToken))
 app.use(createDocsRouter(verifyToken, extractToken))
-app.use('/api/workflows', createWorkflowRouter(verifyToken, extractToken, sessions))
+
+// Workflow router — commitEventHandler is set after engine init, but the
+// router closure captures the variable reference so it will resolve correctly.
+app.use('/api/workflows', createWorkflowRouter(verifyToken, extractToken, sessions, commitEventState))
 
 // --- SPA fallback: serve index.html for non-API routes (client-side routing) ---
 if (FRONTEND_DIST && existsSync(FRONTEND_DIST)) {
@@ -452,6 +461,15 @@ server.listen(port, '0.0.0.0', () => {
     // Sync cron schedules with config and start scheduler
     syncSchedules(sessions)
     engine.startCronScheduler()
+
+    // Initialize commit event handler and sync git hooks
+    commitEventState.handler = new CommitEventHandler()
+    if (authToken) {
+      const serverUrl = `http://localhost:${port}`
+      ensureHookConfig(authToken, serverUrl)
+      syncCommitHooks()
+    }
+
     console.log('[workflow] Workflow engine ready')
   } catch (err) {
     console.error('[workflow] Failed to initialize workflow engine:', err)
@@ -463,6 +481,7 @@ server.listen(port, '0.0.0.0', () => {
 process.on('SIGTERM', () => {
   console.log('SIGTERM received, shutting down...')
   shutdownWorkflowEngine()
+  commitEventState.handler?.shutdown()
   webhookHandler.shutdown()
   stepflowHandler.shutdown()
   sessions.shutdown()
@@ -474,6 +493,7 @@ process.on('SIGTERM', () => {
 process.on('SIGINT', () => {
   console.log('SIGINT received, shutting down...')
   shutdownWorkflowEngine()
+  commitEventState.handler?.shutdown()
   webhookHandler.shutdown()
   stepflowHandler.shutdown()
   sessions.shutdown()


### PR DESCRIPTION
## Summary
- Adds a commit-event dispatcher that automatically triggers commit-review workflows when developers commit to monitored repos
- Implements 6-layer cycle prevention (client-side branch/message filters + server-side branch/message/dedup/concurrency filters) to prevent infinite loops from report commits
- Includes git post-commit hook script, hook installation manager, and `POST /api/workflows/commit-event` endpoint
- Fixes `syncSchedules` to skip event-driven repos (`cronExpression === 'event'`) and wires `syncCommitHooks()` into config CRUD handlers

## Test plan
- [ ] Unit test `CommitEventHandler` filter chain — verify each filter rejects correctly, verify acceptance dispatches `startRun`
- [ ] Integration test: configure a test repo for commit-review, make a commit, verify workflow run is created
- [ ] Cycle test: simulate a report commit (`branch=codekin/reports`, `message=chore: commit review`) and verify rejection at both client and server layers
- [ ] Hook installation test: verify `installCommitHook` creates/chains correctly, `uninstallCommitHook` removes cleanly
- [ ] Manual E2E: add a repo via UI with commit-review kind, make a commit, observe workflow run in Workflows UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)