### PR TITLE
Fix file uploads: markdown support, 20MB limit, better errors

### DIFF
--- a/server/upload-routes.ts
+++ b/server/upload-routes.ts
@@ -156,12 +156,19 @@ export function createUploadRouter(
       cb(null, `${ts}-${safe}`)
     },
   })
-  const ALLOWED_MIME_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp']
+  const ALLOWED_MIME_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'text/markdown']
+  const ALLOWED_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.md']
   const upload = multer({
     storage,
-    limits: { fileSize: 10 * 1024 * 1024 },
+    limits: { fileSize: 20 * 1024 * 1024 },
     fileFilter: (_req, file, cb) => {
-      cb(null, ALLOWED_MIME_TYPES.includes(file.mimetype))
+      const ext = '.' + (file.originalname.split('.').pop()?.toLowerCase() ?? '')
+      const allowed = ALLOWED_MIME_TYPES.includes(file.mimetype) || ALLOWED_EXTENSIONS.includes(ext)
+      if (!allowed) {
+        cb(new Error(`File type not allowed: ${file.mimetype}`))
+        return
+      }
+      cb(null, true)
     },
   })
 
@@ -173,7 +180,16 @@ export function createUploadRouter(
       return
     }
     next()
-  }, upload.single('file'), (req, res) => {
+  }, (req, res, next) => {
+    upload.single('file')(req, res, (err) => {
+      if (err) {
+        const status = err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE' ? 413 : 400
+        res.status(status).json({ error: err.message })
+        return
+      }
+      next()
+    })
+  }, (req, res) => {
     if (!req.file) {
       res.status(400).json({ error: 'No file uploaded' })
       return

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -265,6 +265,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
           ref={fileInputRef}
           type="file"
           multiple
+          accept="image/png,image/jpeg,image/gif,image/webp,text/markdown,.md"
           onChange={handleFileChange}
           className="hidden"
         />


### PR DESCRIPTION
## Summary
- Add markdown (`.md`) to allowed upload file types alongside existing image types
- Increase max file size from 10MB to 20MB
- Return descriptive error messages when uploads are rejected (e.g. "File type not allowed: application/pdf") instead of the misleading "No file uploaded"
- Add `accept` attribute to the file input so the OS file picker only shows supported types

## Test plan
- [ ] Upload a `.md` file — should succeed
- [ ] Upload a `.png`/`.jpg` — should still work
- [ ] Upload an unsupported file type (e.g. `.pdf`) — should show a clear error message
- [ ] Upload a file >20MB — should get a 413 size error
- [ ] Verify the file picker dialog filters to supported types

🤖 Generated with [Claude Code](https://claude.com/claude-code)