### PR TITLE
Add configurable repos path for local repositories

### DIFF
--- a/server/session-routes.ts
+++ b/server/session-routes.ts
@@ -133,6 +133,27 @@ export function createSessionRouter(
     res.json({ days: sessions.archive.getRetentionDays() })
   })
 
+  // --- Repos path settings ---
+
+  router.get('/api/settings/repos-path', (req, res) => {
+    const token = extractToken(req)
+    if (!verifyToken(token)) return res.status(401).json({ error: 'Unauthorized' })
+    const path = sessions.archive.getSetting('repos_path', '')
+    res.json({ path })
+  })
+
+  router.put('/api/settings/repos-path', (req, res) => {
+    const token = extractToken(req)
+    if (!verifyToken(token)) return res.status(401).json({ error: 'Unauthorized' })
+    const { path } = req.body
+    if (typeof path !== 'string') {
+      return res.status(400).json({ error: 'path must be a string' })
+    }
+    // Empty string means "use default REPOS_ROOT"
+    sessions.archive.setSetting('repos_path', path.trim())
+    res.json({ path: path.trim() })
+  })
+
   // --- Support provider settings ---
 
   router.get('/api/settings/support-provider', (req, res) => {

--- a/server/upload-routes.ts
+++ b/server/upload-routes.ts
@@ -108,7 +108,7 @@ function scanModules(modulesDir: string) {
 const ghEnv = { ...process.env }
 delete ghEnv.GITHUB_TOKEN
 
-async function fetchGhRepos(owner: string) {
+async function fetchGhRepos(owner: string, reposRoot: string) {
   const { stdout } = await execFileAsync('gh', [
     'repo', 'list', owner,
     '--json', 'name,url,description',
@@ -117,7 +117,7 @@ async function fetchGhRepos(owner: string) {
   const repos: Array<{ name: string; url: string; description?: string }> = JSON.parse(stdout)
   repos.sort((a, b) => a.name.localeCompare(b.name))
   return repos.map((r) => {
-    const repoPath = `${REPOS_ROOT}/${r.name}`
+    const repoPath = `${reposRoot}/${r.name}`
     const cloned = existsSync(repoPath)
     return {
       id: r.name,
@@ -142,8 +142,18 @@ async function fetchGhRepos(owner: string) {
 export function createUploadRouter(
   verifyToken: VerifyFn,
   extractToken: ExtractFn,
+  getReposPath?: () => string,
 ): Router {
   const router = Router()
+
+  /** Resolve the effective repos root: DB setting > REPOS_ROOT env/default. */
+  const resolveReposRoot = () => {
+    if (getReposPath) {
+      const custom = getReposPath()
+      if (custom) return custom
+    }
+    return REPOS_ROOT
+  }
 
   // Ensure upload directory exists
   if (!existsSync(SCREENSHOTS_DIR)) mkdirSync(SCREENSHOTS_DIR, { recursive: true })
@@ -207,6 +217,7 @@ export function createUploadRouter(
       return
     }
 
+    const reposRoot = resolveReposRoot()
     const globalSkills = scanSkills(GLOBAL_SKILLS_DIR)
     const globalModules = scanModules(GLOBAL_MODULES_DIR)
 
@@ -228,15 +239,15 @@ export function createUploadRouter(
         }
       }
       for (const org of orgs) {
-        const orgRepos = await fetchGhRepos(org)
+        const orgRepos = await fetchGhRepos(org, reposRoot)
         groups.push({ owner: org, repos: orgRepos })
       }
 
       // Fetch user repos
-      const userRepos = await fetchGhRepos(username)
+      const userRepos = await fetchGhRepos(username, reposRoot)
       groups.push({ owner: username, repos: userRepos })
 
-      res.json({ groups, globalSkills, globalModules })
+      res.json({ groups, globalSkills, globalModules, reposPath: reposRoot })
     } catch (err) {
       console.error('Failed to list repos from GitHub:', err)
       const ghMissing = err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT'
@@ -244,7 +255,7 @@ export function createUploadRouter(
         console.error('GitHub CLI (gh) not found. Install it: https://cli.github.com')
       }
       // Return skills/modules even when GitHub is unavailable
-      res.json({ groups: [], globalSkills, globalModules, ghMissing })
+      res.json({ groups: [], globalSkills, globalModules, ghMissing, reposPath: reposRoot })
     }
   })
 
@@ -269,7 +280,8 @@ export function createUploadRouter(
       return
     }
 
-    const dest = join(REPOS_ROOT, name)
+    const reposRoot = resolveReposRoot()
+    const dest = join(reposRoot, name)
     if (existsSync(dest)) {
       res.json({ success: true, path: dest })
       return

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -264,7 +264,7 @@ if (FRONTEND_DIST && existsSync(FRONTEND_DIST)) {
 app.use(createAuthRouter(verifyToken, extractToken, sessions, claudeAvailable, claudeVersion, apiKeySet))
 app.use(createSessionRouter(verifyToken, extractToken, sessions, verifyTokenOrSessionToken))
 app.use(createWebhookRouter(verifyToken, extractToken, webhookHandler, stepflowHandler))
-app.use(createUploadRouter(verifyToken, extractToken))
+app.use(createUploadRouter(verifyToken, extractToken, () => sessions.archive.getSetting('repos_path', '')))
 app.use(createDocsRouter(verifyToken, extractToken))
 
 // Workflow router — commitEventHandler is set after engine init, but the

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -2,20 +2,21 @@
  * Modal settings dialog for general configuration.
  *
  * Organized into logical sections: Authentication, Preferences, Integrations.
- * Handles auth token, theme, retention, support provider, and webhook config.
+ * Handles auth token, theme, retention, support provider, repos path, and webhook config.
  */
 
 import { useState, useEffect, useCallback } from 'react'
 import {
   IconKey, IconPalette, IconBrandGithub, IconCopy, IconCheck,
   IconChevronDown, IconChevronRight, IconCircleCheckFilled, IconCircleXFilled,
-  IconRobot, IconArchive, IconBrain,
+  IconRobot, IconArchive, IconBrain, IconFolder,
 } from '@tabler/icons-react'
 import type { Settings as SettingsType } from '../types'
 import {
   verifyToken, getRetentionDays, setRetentionDays as setRetentionDaysApi,
   getSupportProvider, setSupportProvider, type SupportProvider,
   getWebhookConfig, getWebhookEvents, type WebhookConfigInfo,
+  getReposPath, setReposPath as setReposPathApi,
 } from '../lib/ccApi'
 
 const PROVIDER_LABELS: Record<SupportProvider, string> = {
@@ -111,6 +112,7 @@ export function Settings({ open, onClose, settings, onUpdate, isMobile = false }
   const [retentionDays, setRetentionDays] = useState(7)
   const [supportProvider, setSupportProviderState] = useState<SupportProvider>('auto')
   const [availableProviders, setAvailableProviders] = useState<string[]>([])
+  const [reposPath, setReposPath] = useState('')
   const [saveError, setSaveError] = useState<string | null>(null)
 
   // Webhook state
@@ -130,6 +132,7 @@ export function Settings({ open, onClose, settings, onUpdate, isMobile = false }
       setSupportProviderState(preferred)
       setAvailableProviders(available)
     }).catch(() => {})
+    getReposPath(settings.token).then(setReposPath).catch(() => {})
     getWebhookConfig(settings.token).then(setWebhookConfig).catch(() => {})
     getWebhookEvents(settings.token).then(setWebhookEvents).catch(() => {})
   }, [open, settings.token])
@@ -253,6 +256,34 @@ export function Settings({ open, onClose, settings, onUpdate, isMobile = false }
                   <span className="text-[15px] text-neutral-5">days</span>
                 </div>
                 <p className="mt-1 text-[13px] text-neutral-6">Auto-delete archived sessions older than this</p>
+              </div>
+
+              {/* Repos Path — full width */}
+              <div className="col-span-2">
+                <label className="mb-1.5 block text-[15px] text-neutral-4">
+                  <span className="flex items-center gap-1.5">
+                    <IconFolder size={14} className="text-neutral-5" />
+                    Repositories Path
+                  </span>
+                </label>
+                <input
+                  type="text"
+                  value={reposPath}
+                  onChange={e => setReposPath(e.target.value)}
+                  onBlur={() => {
+                    setReposPathApi(settings.token, reposPath).catch(() => setSaveError('Failed to save repos path'))
+                  }}
+                  onKeyDown={e => {
+                    if (e.key === 'Enter') {
+                      setReposPathApi(settings.token, reposPath).catch(() => setSaveError('Failed to save repos path'))
+                    }
+                  }}
+                  placeholder="~/repos (default)"
+                  className="w-full rounded border border-neutral-9 bg-neutral-10 px-3 py-2 text-[15px] font-mono text-neutral-2 outline-none focus:border-primary-7"
+                />
+                <p className="mt-1 text-[13px] text-neutral-6">
+                  Absolute path to your locally cloned repositories. Leave empty to use the server default.
+                </p>
               </div>
 
               {/* Support LLM Provider — full width */}

--- a/src/lib/ccApi.ts
+++ b/src/lib/ccApi.ts
@@ -301,6 +301,28 @@ export async function setRetentionDays(token: string, days: number): Promise<num
   return data.days
 }
 
+/** Get the configured repos path (empty string means server default). */
+export async function getReposPath(token: string): Promise<string> {
+  const res = await authFetch(`${BASE}/api/settings/repos-path`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) throw new Error(`Failed to get repos path: ${res.status}`)
+  const data = await res.json()
+  return data.path
+}
+
+/** Set the repos path. Empty string resets to server default. */
+export async function setReposPath(token: string, path: string): Promise<string> {
+  const res = await authFetch(`${BASE}/api/settings/repos-path`, {
+    method: 'PUT',
+    headers: headers(token),
+    body: JSON.stringify({ path }),
+  })
+  if (!res.ok) throw new Error(`Failed to set repos path: ${res.status}`)
+  const data = await res.json()
+  return data.path
+}
+
 /** Supported AI provider identifiers for support actions. */
 export type SupportProvider = 'auto' | 'groq' | 'openai' | 'gemini' | 'anthropic'
 


### PR DESCRIPTION
## Summary
- Adds a **Repositories Path** setting in Settings > Preferences so users with existing locally cloned repos can point Codekin to their repos directory
- Path is persisted server-side in the SQLite settings DB (`repos_path` key)
- Repo listing (`/api/repos`) and cloning (`/api/clone`) endpoints dynamically resolve the configured path, falling back to the `REPOS_ROOT` env default

## Test plan
- [ ] Open Settings, verify "Repositories Path" field appears in Preferences
- [ ] Set a custom path (e.g. `/home/user/projects`), blur or press Enter, verify it persists across page reload
- [ ] Clear the path, verify repo listing falls back to the default `REPOS_ROOT`
- [ ] Set a valid path containing cloned repos, verify they show as "cloned" in the repo selector
- [ ] Clone a new repo with custom path set, verify it clones into the configured directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)