### PR TITLE
Add Code Review button to chat area

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { InputBar, type InputBarHandle } from './components/InputBar'
 import { PromptButtons } from './components/PromptButtons'
 import { RepoSelector } from './components/RepoSelector'
 import { DiffPanel } from './components/DiffPanel'
+import { IconEye } from '@tabler/icons-react'
 
 export default function App() {
   const { settings, updateSettings } = useSettings()
@@ -65,6 +66,8 @@ export default function App() {
   const diffHandleMessageRef = useRef<(msg: import('./types').WsServerMessage) => void>(() => {})
   /** Callback ref for notifying the diff panel when a tool finishes (triggers auto-refresh). */
   const diffHandleToolDoneRef = useRef<(toolName: string, summary?: string) => void>(() => {})
+  /** Tracks whether file-mutating tools have fired in this session (heuristic for "has diffs"). */
+  const [hasFileChanges, setHasFileChanges] = useState(false)
   const [archiveRefreshKey, setArchiveRefreshKey] = useState(0)
   const [error, setError] = useState<string | null>(null)
   const errorTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -130,9 +133,18 @@ export default function App() {
         diffHandleMessageRef.current(msg)
       } else if (msg.type === 'tool_done') {
         diffHandleToolDoneRef.current(msg.toolName, msg.summary)
+        // Track file-mutating tools to show Code Review button
+        if (msg.toolName === 'Edit' || msg.toolName === 'Write') {
+          setHasFileChanges(true)
+        }
       }
     },
   })
+
+  // Reset file-change tracking when switching sessions
+  useEffect(() => {
+    setHasFileChanges(false) // eslint-disable-line react-hooks/set-state-in-effect -- sync with session change
+  }, [activeSessionId])
 
   // Session orchestration: switching, creating, deleting sessions & repos
   const {
@@ -501,6 +513,18 @@ export default function App() {
                 isMobile={isMobile}
               />
               <TodoPanel tasks={tasks} />
+
+              {/* Code Review button — top-right corner, visible when files have been changed */}
+              {hasFileChanges && !diffPanelOpen && (
+                <button
+                  className="absolute top-3 right-3 z-10 flex items-center gap-1.5 rounded-lg bg-primary-9/90 px-3 py-1.5 text-[13px] font-medium text-white shadow-lg backdrop-blur-sm transition-colors hover:bg-primary-8"
+                  onClick={() => setDiffPanelOpen(true)}
+                  title="Review code changes (Ctrl+Shift+D)"
+                >
+                  <IconEye size={15} />
+                  Code Review
+                </button>
+              )}
             </div>
 
             {/* Smart prompt buttons (conditional) */}


### PR DESCRIPTION
## Summary
- Adds a floating "Code Review" button in the top-right corner of the chat area when Claude has modified files (Edit/Write tool events)
- Clicking the button opens the diff panel sidebar
- Button auto-hides when the diff panel is already open, and resets when switching sessions

## Test plan
- [ ] Start a session and verify the button does not appear initially
- [ ] Ask Claude to edit a file and verify the button appears after the tool completes
- [ ] Click the button and verify the diff panel opens
- [ ] Close the diff panel and verify the button reappears
- [ ] Switch sessions and verify the button resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)