### PR TITLE
Implement repo health audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ codekin uninstall               # Remove Codekin entirely
 - **Session archive** — Full retrieval and re-activation of archived sessions
 - **Repo browser** — Auto-discovers local repos and GitHub org repos
 - **Screenshot upload** — Drag-and-drop or paste images; the file path is sent to Claude so it can read them natively
-- **Skill browser** — Browse and invoke `/skills` defined in each repo's `.claude/skills/`
+- **Skill browser** — Browse and invoke `/skills` defined in each repo's `.claude/skills/`, with inline slash-command autocomplete
+- **Diff viewer** — Side panel showing staged/unstaged file changes with per-file discard support
 - **Command palette** — `Ctrl+K` to quickly search repos, skills, and actions
 - **Approval management** — Persistent approval storage with detailed per-permission revoking
 - **Mobile-friendly** — Responsive layout that works on phones and tablets

--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -1,0 +1,398 @@
+# Codekin REST API Reference
+
+All endpoints are served by the WebSocket server (default port 32352) and proxied through nginx at `/cc`.
+
+## Authentication
+
+All endpoints (except raw webhook receivers) require a Bearer token in the `Authorization` header:
+
+```
+Authorization: Bearer <token>
+```
+
+The token is set via the `AUTH_TOKEN` environment variable or `--auth-file` CLI argument. Hook endpoints (`/api/tool-approval`, `/api/hook-decision`, `/api/hook-notify`) also accept session-scoped tokens.
+
+Unauthenticated requests return `401 Unauthorized`.
+
+---
+
+## Auth & Health
+
+### `POST /auth-verify`
+
+Verify whether a token is valid. Does not require auth itself.
+
+**Request body:** `{ "token": "..." }` (or token in Authorization header)
+**Response:** `{ "valid": true }` or `{ "valid": false }`
+
+### `GET /api/health`
+
+Server health check.
+
+**Response:**
+```json
+{
+  "status": "ok",
+  "claudeAvailable": true,
+  "claudeVersion": "1.0.0",
+  "apiKeySet": true,
+  "claudeSessions": 2,
+  "totalSessions": 5
+}
+```
+
+---
+
+## Sessions
+
+### `GET /api/sessions/list`
+
+List all active sessions.
+
+**Response:** `{ "sessions": Session[] }`
+
+### `POST /api/sessions/create`
+
+Create a new session and auto-start Claude.
+
+**Request body:** `{ "name": "...", "workingDir": "/path/to/repo" }`
+**Response:** `{ "sessionId": "...", "session": Session }`
+
+### `PATCH /api/sessions/:id/rename`
+
+Rename a session.
+
+**Request body:** `{ "name": "new name" }`
+**Response:** `{ "success": true, "name": "new name" }`
+
+### `DELETE /api/sessions/:id`
+
+Delete a session and kill any running Claude process.
+
+**Response:** `{ "success": true }` or `404`
+
+---
+
+## Session Archive
+
+### `GET /api/sessions/archived`
+
+List archived sessions (metadata only).
+
+**Query params:** `workingDir` (optional) — filter by working directory
+**Response:** `{ "sessions": ArchivedSession[] }`
+
+### `GET /api/sessions/archived/:id`
+
+Fetch a single archived session with full chat history.
+
+**Response:** `ArchivedSession` or `404`
+
+### `DELETE /api/sessions/archived/:id`
+
+Permanently delete an archived session.
+
+**Response:** `{ "success": true }` or `404`
+
+---
+
+## Settings
+
+### `GET /api/settings/retention`
+
+Get the session retention period.
+
+**Response:** `{ "days": 30 }`
+
+### `PUT /api/settings/retention`
+
+Set the session retention period.
+
+**Request body:** `{ "days": 30 }` (must be >= 1)
+**Response:** `{ "days": 30 }`
+
+### `GET /api/settings/repos-path`
+
+Get the configured repos discovery path (empty string = server default).
+
+**Response:** `{ "path": "/home/user/repos" }`
+
+### `PUT /api/settings/repos-path`
+
+Set the repos discovery path. Empty string resets to server default.
+
+**Request body:** `{ "path": "/home/user/repos" }`
+**Response:** `{ "path": "/home/user/repos" }`
+
+### `GET /api/settings/support-provider`
+
+Get the preferred AI provider for background tasks (auto-naming, etc.).
+
+**Response:** `{ "preferred": "auto", "available": ["groq", "openai", "gemini", "anthropic"] }`
+
+### `PUT /api/settings/support-provider`
+
+Set the preferred support provider.
+
+**Request body:** `{ "provider": "groq" }` (one of: `auto`, `groq`, `openai`, `gemini`, `anthropic`)
+**Response:** `{ "preferred": "groq" }`
+
+---
+
+## Approvals
+
+### `GET /api/approvals`
+
+Get auto-approval rules for a repo.
+
+**Query params:** `path` (required) — repo working directory
+**Response:** `{ "approvals": Approval[] }`
+
+### `GET /api/approvals/global`
+
+Get global auto-approval rules.
+
+**Response:** `{ "globalApprovals": Approval[] }`
+
+### `DELETE /api/approvals`
+
+Remove one or more approval rules.
+
+**Query params:** `path` (required) — repo working directory
+**Request body:** Single: `{ "tool": "...", "command": "...", "pattern": "..." }` or bulk: `{ "items": [...] }`
+**Response:** `{ "success": true, "removed": 1 }`
+
+---
+
+## Hook Endpoints
+
+These are called by Claude CLI hooks (PreToolUse / PermissionRequest) running inside session processes. They accept either the master Bearer token or a session-scoped token.
+
+### `POST /api/tool-approval`
+
+PreToolUse hook callback — check if a tool should be auto-approved or prompt the UI.
+
+**Request body:** `{ "sessionId": "...", "toolName": "Bash", "toolInput": { "command": "npm test" } }`
+**Response:** `{ "allow": true, "always": false }`
+
+### `POST /api/hook-decision`
+
+PermissionRequest hook callback — route permission decisions through the UI.
+
+**Request body:** `{ "sessionId": "...", "toolName": "Bash", "toolInput": { "command": "..." } }`
+**Response:** `{ "allow": true }`
+
+### `POST /api/hook-notify`
+
+Surface hook denial notifications in the UI.
+
+**Request body:** `{ "sessionId": "...", "notificationType": "denial", "message": "...", "toolName": "...", "toolInput": {} }`
+**Response:** `{ "ok": true }`
+
+### `POST /api/auth/validate`
+
+Validate a session token.
+
+**Request body:** `{ "sessionId": "..." }`
+**Response:** `{ "valid": true }` or `{ "valid": false, "error": "..." }`
+
+---
+
+## File Upload & Repos
+
+### `POST /api/upload`
+
+Upload a file (images or markdown, max 20MB).
+
+**Content-Type:** `multipart/form-data`
+**Form field:** `file`
+**Response:** `{ "success": true, "path": "/tmp/uploads/..." }`
+
+### `GET /api/repos`
+
+List available repositories grouped by owner.
+
+**Response:**
+```json
+{
+  "groups": [{ "owner": "user", "repos": [...] }],
+  "globalSkills": [...],
+  "globalModules": [...],
+  "reposPath": "/home/user/repos",
+  "ghMissing": false
+}
+```
+
+### `POST /api/clone`
+
+Clone a GitHub repository.
+
+**Request body:** `{ "owner": "org", "name": "repo" }`
+**Response:** `{ "success": true, "path": "/home/user/repos/repo" }`
+
+---
+
+## Documentation Browser
+
+### `GET /api/docs`
+
+List markdown files in a repo.
+
+**Query params:** `repo` (required) — repo path
+**Response:** `{ "files": [{ "path": "README.md", "pinned": false }] }`
+
+### `GET /api/docs/file`
+
+Read a single markdown file.
+
+**Query params:** `repo` (required), `file` (required) — file path relative to repo
+**Response:** `{ "path": "README.md", "content": "# ..." }` or `404`
+
+---
+
+## Webhooks
+
+### `GET /api/webhooks/events`
+
+List recent webhook events.
+
+**Response:** `{ "events": WebhookEvent[] }`
+
+### `GET /api/webhooks/events/:id`
+
+Get a single webhook event.
+
+**Response:** `{ "event": WebhookEvent }` or `404`
+
+### `GET /api/webhooks/config`
+
+Get webhook configuration.
+
+**Response:** `{ "config": { "enabled": true, "maxConcurrentSessions": 3, "logLinesToInclude": 200 } }`
+
+### `POST /api/webhooks/github`
+
+Raw GitHub webhook receiver. **No Bearer token** — uses HMAC signature verification via `x-hub-signature-256` header.
+
+### `POST /api/webhooks/stepflow`
+
+Raw Stepflow webhook receiver. **No Bearer token** — uses signature verification via `x-webhook-signature` header.
+
+---
+
+## Stepflow
+
+### `GET /api/stepflow/events`
+
+List recent stepflow events.
+
+**Response:** `{ "events": StepflowEvent[] }`
+
+### `GET /api/stepflow/events/:id`
+
+Get a single stepflow event.
+
+**Response:** `{ "event": StepflowEvent }` or `404`
+
+---
+
+## Workflows
+
+All workflow routes are mounted at the `/api/workflows/` prefix.
+
+### `POST /api/workflows/commit-event`
+
+Notify the workflow engine of a new commit (called by git post-commit hook).
+
+**Request body:** `{ "repoPath": "...", "branch": "main", "commitHash": "abc123", "commitMessage": "...", "author": "..." }`
+**Response:** `{ "accepted": true, ... }`
+
+### `GET /api/workflows/kinds`
+
+List available workflow kinds.
+
+**Query params:** `repoPath` (optional) — filter by repo
+**Response:** `{ "kinds": WorkflowKind[] }`
+
+### `GET /api/workflows/runs`
+
+List workflow runs.
+
+**Query params:** `kind`, `status` (`queued`, `running`, `succeeded`, `failed`, `canceled`), `limit`, `offset`
+**Response:** `{ "runs": Run[] }`
+
+### `GET /api/workflows/runs/:runId`
+
+Get a single workflow run.
+
+**Response:** `{ "run": Run }` or `404`
+
+### `POST /api/workflows/runs`
+
+Trigger a new workflow run.
+
+**Request body:** `{ "kind": "code-review", "input": {} }`
+**Response:** `{ "run": Run }`
+
+### `POST /api/workflows/runs/:runId/cancel`
+
+Cancel a running workflow.
+
+**Response:** `{ "success": true }` or `404`
+
+### `GET /api/workflows/schedules`
+
+List all workflow schedules.
+
+**Response:** `{ "schedules": Schedule[] }`
+
+### `POST /api/workflows/schedules`
+
+Create a new schedule.
+
+**Request body:** `{ "id": "...", "kind": "code-review", "cronExpression": "0 4 * * *", "input": {}, "enabled": true }`
+**Response:** `{ "schedule": Schedule }`
+
+### `PATCH /api/workflows/schedules/:id`
+
+Update a schedule.
+
+**Request body:** `{ "cronExpression": "...", "input": {}, "enabled": false }` (all fields optional)
+**Response:** `{ "schedule": Schedule }` or `404`
+
+### `DELETE /api/workflows/schedules/:id`
+
+Delete a schedule.
+
+**Response:** `{ "success": true }` or `404`
+
+### `POST /api/workflows/schedules/:id/trigger`
+
+Manually trigger a scheduled workflow.
+
+**Response:** `{ "run": Run }` or `404`
+
+### `GET /api/workflows/config`
+
+Get workflow engine configuration.
+
+**Response:** `{ "config": WorkflowConfig }`
+
+### `POST /api/workflows/config/repos`
+
+Add a repo workflow configuration.
+
+**Request body:** `{ "id": "...", "name": "...", "repoPath": "...", "cronExpression": "...", "enabled": true, "customPrompt": "...", "kind": "...", "model": "..." }`
+**Response:** `{ "config": WorkflowConfig }`
+
+### `PATCH /api/workflows/config/repos/:id`
+
+Update a repo workflow configuration.
+
+**Response:** `{ "config": WorkflowConfig }` or `404`
+
+### `DELETE /api/workflows/config/repos/:id`
+
+Remove a repo workflow configuration.
+
+**Response:** `{ "config": WorkflowConfig }`

--- a/docs/stream-json-protocol.md
+++ b/docs/stream-json-protocol.md
@@ -315,6 +315,12 @@ Response to a `control_request`. The `request_id` must match.
 | `error` | `message` | Error from Claude process |
 | `exit` | `code`, `signal` | Claude process exited (only when not auto-restarting) |
 | `pong` | — | Heartbeat response |
+| `diff_result` | `files`, `summary`, `branch`, `scope` | Diff viewer result (array of `DiffFile` objects with hunks/lines, a `DiffSummary`, current branch name, and scope) |
+| `diff_error` | `message` | Diff viewer error |
+| `sessions_updated` | — | Broadcast when the session list changes (creation, deletion, rename) |
+| `session_name_update` | `sessionId`, `name` | Session was renamed (e.g. by auto-naming) |
+| `webhook_event` | `event`, `repo`, `branch`, `workflow`, `conclusion`, `status`, `sessionId?` | GitHub webhook received (broadcast to all clients) |
+| `workflow_event` | `eventType`, `runId`, `kind`, `stepKey?`, `status?`, `payload?` | Workflow engine lifecycle event (broadcast to all clients) |
 
 ### Client → Server Messages
 
@@ -330,7 +336,52 @@ Response to a `control_request`. The `request_id` must match.
 | `prompt_response` | `value`, `requestId?` | Answer a permission/question prompt |
 | `resize` | `cols`, `rows` | Terminal resize (no-op in stream-json mode) |
 | `ping` | — | Heartbeat |
-| `get_usage` | — | Request usage stats (not yet implemented) |
+| `get_diff` | `scope?` | Request diff (scope: `staged`, `unstaged`, or `all`; defaults to `all`) |
+| `discard_changes` | `scope`, `paths?`, `statuses?` | Discard file changes by scope, optionally limited to specific paths |
+| `set_model` | `model` | Switch the Claude model for the current session |
+
+## Diff Viewer Types
+
+The diff viewer uses these types in `diff_result` messages (defined in `src/types.ts`):
+
+```typescript
+type DiffScope = 'staged' | 'unstaged' | 'all'
+type DiffFileStatus = 'modified' | 'added' | 'deleted' | 'renamed'
+
+interface DiffFile {
+  path: string
+  status: DiffFileStatus
+  oldPath?: string          // present when status is 'renamed'
+  isBinary: boolean
+  additions: number
+  deletions: number
+  hunks: DiffHunk[]
+}
+
+interface DiffHunk {
+  header: string            // e.g. "@@ -10,6 +10,8 @@"
+  oldStart: number
+  oldLines: number
+  newStart: number
+  newLines: number
+  lines: DiffLine[]
+}
+
+interface DiffLine {
+  type: 'add' | 'delete' | 'context'
+  content: string
+  oldLineNo?: number
+  newLineNo?: number
+}
+
+interface DiffSummary {
+  filesChanged: number
+  insertions: number
+  deletions: number
+  truncated: boolean
+  truncationReason?: string // present when truncated is true
+}
+```
 
 ## Event Processing Pipeline
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -15,6 +15,7 @@
     "noFallthroughCasesInSwitch": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
+    "noUncheckedSideEffectImports": true,
     "composite": true,
     "tsBuildInfoFile": "./dist/tsconfig.tsbuildinfo"
   },

--- a/src/lib/ccApi.test.ts
+++ b/src/lib/ccApi.test.ts
@@ -4,7 +4,6 @@ import {
   listSessions,
   createSession,
   deleteSession,
-  getHealth,
   uploadFile,
   wsUrl,
   redirectToLogin,
@@ -171,23 +170,6 @@ describe('deleteSession', () => {
   it('throws on non-ok response', async () => {
     mockFetch.mockResolvedValue(jsonResponse({}, 404))
     await expect(deleteSession('tok', 's1')).rejects.toThrow('Failed to delete session: 404')
-  })
-})
-
-describe('getHealth', () => {
-  it('returns health data', async () => {
-    const health = { status: 'ok', claudeSessions: 3 }
-    mockFetch.mockResolvedValue(jsonResponse(health))
-    const result = await getHealth('tok')
-    expect(result).toEqual(health)
-    expect(mockFetch).toHaveBeenCalledWith('/cc/api/health', {
-      headers: { Authorization: 'Bearer tok' },
-    })
-  })
-
-  it('throws on non-ok response', async () => {
-    mockFetch.mockResolvedValue(jsonResponse({}, 503))
-    await expect(getHealth('tok')).rejects.toThrow('Health check failed: 503')
   })
 })
 
@@ -396,12 +378,12 @@ describe('authFetch / checkAuthResponse (indirect)', () => {
 
   it('does NOT treat 503 as auth failure', async () => {
     mockFetch.mockResolvedValue(plainResponse(503))
-    await expect(getHealth('tok')).rejects.toThrow('Health check failed: 503')
+    await expect(listSessions('tok')).rejects.toThrow('Failed to list sessions: 503')
   })
 
   it('does NOT treat 504 as auth failure', async () => {
     mockFetch.mockResolvedValue(plainResponse(504))
-    await expect(getHealth('tok')).rejects.toThrow('Health check failed: 504')
+    await expect(listSessions('tok')).rejects.toThrow('Failed to list sessions: 504')
   })
 })
 

--- a/src/lib/ccApi.ts
+++ b/src/lib/ccApi.ts
@@ -142,15 +142,6 @@ export async function deleteSession(token: string, sessionId: string): Promise<v
   if (!res.ok) throw new Error(`Failed to delete session: ${res.status}`)
 }
 
-/** Server health check. Returns active/total session counts. */
-export async function getHealth(token: string): Promise<{ status: string; claudeSessions: number }> {
-  const res = await authFetch(`${BASE}/api/health`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error(`Health check failed: ${res.status}`)
-  return res.json()
-}
-
 /** Upload a file via the server. Returns the server-side file path. */
 export async function uploadFile(token: string, file: File): Promise<string> {
   const form = new FormData()


### PR DESCRIPTION
## Summary

- Remove unused `getHealth` export from `ccApi.ts` (dead code identified by audit)
- Add `noUncheckedSideEffectImports: true` to `server/tsconfig.json` (config alignment)
- Update README features list to mention diff viewer and slash command autocomplete
- Add comprehensive REST API reference (`docs/API-REFERENCE.md`) covering all ~40 endpoints
- Document new diff viewer WebSocket message types in `docs/stream-json-protocol.md`
- Document previously undocumented WS messages (`webhook_event`, `workflow_event`, `sessions_updated`, etc.)
- Add new client→server messages (`get_diff`, `discard_changes`, `set_model`)

## Context

Addresses recommendations 2, 5, 6, 7, 8, and 9 from the [2026-03-13 repo health audit](/.codekin/reports/repo-health/2026-03-13_repo-health.md). Branch cleanup (recommendation 2) was done separately — 7 abandoned remote branches and 37 merged remote branches were deleted.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 945 tests pass (removed 2 `getHealth` tests, updated 2 auth tests)
- [x] `npm run lint` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)