### PR TITLE
Fix task popup overlapping diff view button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -514,7 +514,7 @@ export default function App() {
               />
               <TodoPanel tasks={tasks} />
 
-              {/* Code Review button — top-right corner, visible when files have been changed */}
+              {/* Diff view button — top-right corner, visible when files have been changed */}
               {hasFileChanges && !diffPanelOpen && (
                 <button
                   className="absolute top-3 right-3 z-10 flex items-center gap-1.5 rounded-lg bg-primary-8 px-3 py-1.5 text-[13px] font-medium text-neutral-1 shadow-lg backdrop-blur-sm transition-colors hover:bg-primary-7"
@@ -522,7 +522,7 @@ export default function App() {
                   title="Review code changes (Ctrl+Shift+D)"
                 >
                   <IconEye size={15} />
-                  Code Review
+                  Diff view
                 </button>
               )}
             </div>

--- a/src/components/TodoPanel.tsx
+++ b/src/components/TodoPanel.tsx
@@ -68,7 +68,7 @@ export function TodoPanel({ tasks }: Props) {
   // Collapsed pill view
   if (!expanded) {
     return (
-      <div className="absolute top-3 right-3 z-20">
+      <div className="absolute top-14 right-3 z-20">
         <button
           onClick={() => setExpanded(true)}
           className="flex items-center gap-1.5 rounded-lg bg-neutral-9/90 backdrop-blur border border-neutral-8/60 px-2.5 py-1.5 shadow-lg hover:bg-neutral-8/90 transition-colors"
@@ -85,7 +85,7 @@ export function TodoPanel({ tasks }: Props) {
 
   // Expanded card view
   return (
-    <div className="absolute top-3 right-3 z-20 w-64 rounded-lg bg-neutral-9/90 backdrop-blur border border-neutral-8/60 shadow-lg">
+    <div className="absolute top-14 right-3 z-20 w-64 rounded-lg bg-neutral-9/90 backdrop-blur border border-neutral-8/60 shadow-lg">
       {/* Header */}
       <div className="flex items-center justify-between px-3 py-2 border-b border-neutral-8/40">
         <span className="text-[13px] font-semibold text-neutral-1 uppercase tracking-wider flex items-center gap-1.5">


### PR DESCRIPTION
## Summary
- Move TodoPanel positioning from `top-3` to `top-14` so it no longer overlaps the diff view button
- Rename "Code Review" button to "Diff view"

## Test plan
- [ ] Trigger file changes in a session and verify the "Diff view" button is fully visible
- [ ] Trigger tasks and verify the task popup appears below the button without overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)