### PR TITLE
Update DiffToolbar background color to bg-neutral-10

### DIFF
--- a/src/components/diff/DiffToolbar.tsx
+++ b/src/components/diff/DiffToolbar.tsx
@@ -42,7 +42,7 @@ export function DiffToolbar({
   }
 
   return (
-    <div className="sticky top-0 z-10 bg-neutral-11 border-b border-neutral-9 px-3 py-2 flex flex-col gap-2">
+    <div className="sticky top-0 z-10 bg-neutral-10 border-b border-neutral-9 px-3 py-2 flex flex-col gap-2">
       {/* Row 1: Branch + scope + actions */}
       <div className="flex items-center gap-2">
         {/* Branch */}


### PR DESCRIPTION
## Summary
- Changed the DiffToolbar background from `bg-neutral-11` to `bg-neutral-10` for better visual distinction

## Test plan
- [ ] Verify toolbar appearance in light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)