### PR TITLE
fix: approval countdown auto-approve not firing

### DIFF
--- a/src/components/PromptButtons.tsx
+++ b/src/components/PromptButtons.tsx
@@ -13,7 +13,7 @@
  * Rendered as a sticky bar above the input area.
  */
 
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import type { PromptOption, PromptQuestion } from '../types'
 
 interface PromptButtonsProps {
@@ -71,24 +71,27 @@ export function PromptButtons({ options, question, multiSelect, promptType, ques
     }
   }, [isMultiQuestion, currentQ, answers, questionIndex, questions, onSelect])
 
+  // Ref to latest handleSingleAnswer so the interval closure always calls the current version
+  const handleSingleAnswerRef = useRef(handleSingleAnswer)
+  handleSingleAnswerRef.current = handleSingleAnswer
+
   // Auto-allow countdown: fires only for permission prompts
   useEffect(() => {
     if (!isPermission) return
     const allowOption = options.find(o => o.value === 'allow')
     if (!allowOption) return
 
+    let remaining = 15
     const interval = setInterval(() => {
-      setTimeLeft(t => {
-        if (t <= 1) {
-          clearInterval(interval)
-          handleSingleAnswer('allow')
-          return 0
-        }
-        return t - 1
-      })
+      remaining--
+      setTimeLeft(remaining) // eslint-disable-line react-hooks/set-state-in-effect -- async timer callback
+      if (remaining <= 0) {
+        clearInterval(interval)
+        handleSingleAnswerRef.current('allow')
+      }
     }, 1000)
     return () => clearInterval(interval)
-  }, [isPermission, options, handleSingleAnswer])
+  }, [isPermission, options])
 
   const handleMultiAnswer = useCallback((values: string[]) => {
     const joined = values.join(', ')


### PR DESCRIPTION
## Summary
- The approval popup's 15-second auto-approve countdown was counting down visually but never actually firing the approve action when it reached zero
- Root cause: `handleSingleAnswer('allow')` was called inside `setTimeLeft`'s state updater function — React updaters must be pure and side effects inside them can be suppressed (especially in StrictMode). Additionally, `handleSingleAnswer` in the effect's dep array caused the interval to constantly tear down and recreate.
- Fix: use a `useRef` for the callback and a local counter variable in the `setInterval` callback, keeping the interval stable and the side effect outside the state updater

## Test plan
- [ ] Trigger a permission prompt (e.g. a Bash command)
- [ ] Let the 15s countdown run to zero without clicking
- [ ] Verify the command is auto-approved when the timer expires
- [ ] Verify manually clicking Approve/Deny/Always Allow still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)