### PR TITLE
feat: increase diff panel max width to 1200px

### DIFF
--- a/src/components/DiffPanel.tsx
+++ b/src/components/DiffPanel.tsx
@@ -12,7 +12,7 @@ import { DiffFileTree } from './diff/DiffFileTree'
 import { DiffFileCard } from './diff/DiffFileCard'
 
 const MIN_WIDTH = 280
-const MAX_WIDTH = 600
+const MAX_WIDTH = 1200
 const DEFAULT_WIDTH = 400
 const STORAGE_KEY = 'codekin-diff-panel-width'
 


### PR DESCRIPTION
## Summary
- Doubles the diff panel max width from 600px to 1200px, allowing better use of space on wider screens

## Test plan
- [ ] Resize the diff panel on a wide screen and verify it can expand up to 1200px
- [ ] Verify the panel still respects the min width (280px) and default width (400px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)