### PR TITLE
test: add unit tests for session restart and worktree fixes

### DIFF
--- a/server/claude-process-start.test.ts
+++ b/server/claude-process-start.test.ts
@@ -12,6 +12,7 @@ import { PassThrough } from 'stream'
 // Hoisted mock factory for child_process.spawn
 const mockSpawn = vi.hoisted(() => vi.fn())
 const mockExistsSync = vi.hoisted(() => vi.fn(() => true))
+const mockRealpathSync = vi.hoisted(() => vi.fn((p: string) => p))
 
 vi.mock('child_process', () => ({
   spawn: mockSpawn,
@@ -19,7 +20,7 @@ vi.mock('child_process', () => ({
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>()
-  return { ...actual, existsSync: mockExistsSync }
+  return { ...actual, existsSync: mockExistsSync, realpathSync: mockRealpathSync }
 })
 
 import { ClaudeProcess } from './claude-process.js'

--- a/server/claude-process-start.test.ts
+++ b/server/claude-process-start.test.ts
@@ -11,10 +11,16 @@ import { PassThrough } from 'stream'
 
 // Hoisted mock factory for child_process.spawn
 const mockSpawn = vi.hoisted(() => vi.fn())
+const mockExistsSync = vi.hoisted(() => vi.fn(() => true))
 
 vi.mock('child_process', () => ({
   spawn: mockSpawn,
 }))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return { ...actual, existsSync: mockExistsSync }
+})
 
 import { ClaudeProcess } from './claude-process.js'
 
@@ -175,6 +181,91 @@ describe('ClaudeProcess.start() — process event handlers', () => {
       fakeProc.stderr.emit('data', Buffer.from('   '))
 
       expect(errors).toHaveLength(0)
+    })
+  })
+
+  describe('start() with missing working directory', () => {
+    it('emits error and exit without spawning when workingDir does not exist', async () => {
+      mockExistsSync.mockReturnValue(false)
+      const cp = new ClaudeProcess('/nonexistent/path') as CP
+
+      const errors: string[] = []
+      const exits: Array<[number | null, string | null]> = []
+      cp.on('error', (msg: string) => errors.push(msg))
+      cp.on('exit', (code: number | null, signal: string | null) => exits.push([code, signal]))
+
+      cp.start()
+
+      expect(mockSpawn).not.toHaveBeenCalled()
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toContain('Working directory does not exist')
+      expect(errors[0]).toContain('/nonexistent/path')
+
+      // exit is emitted via process.nextTick
+      await new Promise(r => process.nextTick(r))
+      expect(exits).toHaveLength(1)
+      expect(exits[0]).toEqual([1, null])
+    })
+
+    it('sets hasSpawnFailed() to true when workingDir missing', () => {
+      mockExistsSync.mockReturnValue(false)
+      const cp = new ClaudeProcess('/nonexistent/path') as CP
+      cp.on('error', () => {}) // prevent unhandled error
+
+      cp.start()
+
+      expect(cp.hasSpawnFailed()).toBe(true)
+    })
+
+    it('does not set alive when workingDir missing', () => {
+      mockExistsSync.mockReturnValue(false)
+      const cp = new ClaudeProcess('/nonexistent/path') as CP
+      cp.on('error', () => {})
+
+      cp.start()
+
+      expect(cp.isAlive()).toBe(false)
+    })
+  })
+
+  describe('process "error" event with ENOENT/EACCES', () => {
+    it('sets hasSpawnFailed() on ENOENT error', () => {
+      mockExistsSync.mockReturnValue(true)
+      const cp = new ClaudeProcess('/tmp') as CP
+      cp.start()
+      cp.on('error', () => {})
+
+      const err = new Error('spawn claude ENOENT') as NodeJS.ErrnoException
+      err.code = 'ENOENT'
+      fakeProc.emit('error', err)
+
+      expect(cp.hasSpawnFailed()).toBe(true)
+    })
+
+    it('sets hasSpawnFailed() on EACCES error', () => {
+      mockExistsSync.mockReturnValue(true)
+      const cp = new ClaudeProcess('/tmp') as CP
+      cp.start()
+      cp.on('error', () => {})
+
+      const err = new Error('spawn claude EACCES') as NodeJS.ErrnoException
+      err.code = 'EACCES'
+      fakeProc.emit('error', err)
+
+      expect(cp.hasSpawnFailed()).toBe(true)
+    })
+
+    it('does not set hasSpawnFailed() for other error codes', () => {
+      mockExistsSync.mockReturnValue(true)
+      const cp = new ClaudeProcess('/tmp') as CP
+      cp.start()
+      cp.on('error', () => {})
+
+      const err = new Error('some other error') as NodeJS.ErrnoException
+      err.code = 'EPIPE'
+      fakeProc.emit('error', err)
+
+      expect(cp.hasSpawnFailed()).toBe(false)
     })
   })
 })

--- a/server/orchestrator-children.test.ts
+++ b/server/orchestrator-children.test.ts
@@ -1,6 +1,6 @@
 /** Tests for OrchestratorChildManager — verifies prompt generation for
  * worktree vs non-worktree scenarios and worktree failure context. */
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 
 vi.mock('./config.js', () => ({
   getAgentDisplayName: () => 'TestAgent',

--- a/server/orchestrator-children.test.ts
+++ b/server/orchestrator-children.test.ts
@@ -1,0 +1,128 @@
+/** Tests for OrchestratorChildManager — verifies prompt generation for
+ * worktree vs non-worktree scenarios and worktree failure context. */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./config.js', () => ({
+  getAgentDisplayName: () => 'TestAgent',
+}))
+
+import { OrchestratorChildManager, type ChildSessionRequest } from './orchestrator-children.js'
+
+function makeRequest(overrides: Partial<ChildSessionRequest> = {}): ChildSessionRequest {
+  return {
+    repo: '/repos/myproject',
+    task: 'Fix the login bug',
+    branchName: 'fix/login-bug',
+    completionPolicy: 'pr',
+    deployAfter: false,
+    useWorktree: true,
+    ...overrides,
+  }
+}
+
+function fakeSessionManager(worktreeSucceeds = true) {
+  const sentInputs: string[] = []
+  return {
+    create: vi.fn(() => ({ id: 'child-session-id' })),
+    createWorktree: vi.fn(async () => worktreeSucceeds ? '/repos/myproject-wt-child123' : null),
+    startClaude: vi.fn(),
+    sendInput: vi.fn((_, prompt: string) => { sentInputs.push(prompt) }),
+    get: vi.fn(() => ({
+      claudeProcess: {
+        isAlive: () => true,
+        on: vi.fn(),
+        once: vi.fn(),
+      },
+      outputHistory: [],
+    })),
+    onSessionExit: vi.fn(() => vi.fn()),
+    onSessionResult: vi.fn(() => vi.fn()),
+    clearProcessingFlag: vi.fn(),
+    _sentInputs: sentInputs,
+  } as any
+}
+
+describe('OrchestratorChildManager', () => {
+  describe('spawn() prompt generation', () => {
+    it('includes worktree environment section when worktree succeeds', async () => {
+      const sm = fakeSessionManager(true)
+      const mgr = new OrchestratorChildManager(sm)
+      const request = makeRequest({ useWorktree: true })
+
+      await mgr.spawn(request)
+
+      expect(sm._sentInputs).toHaveLength(1)
+      const prompt = sm._sentInputs[0]
+      expect(prompt).toContain('Worktree Environment')
+      expect(prompt).toContain('isolated git worktree')
+      expect(prompt).toContain('fix/login-bug')
+      expect(prompt).toContain('Do NOT use the `EnterWorktree`')
+    })
+
+    it('does NOT include worktree section when worktree not requested', async () => {
+      const sm = fakeSessionManager(true)
+      const mgr = new OrchestratorChildManager(sm)
+      const request = makeRequest({ useWorktree: false })
+
+      await mgr.spawn(request)
+
+      const prompt = sm._sentInputs[0]
+      expect(prompt).not.toContain('Worktree Environment')
+      expect(prompt).not.toContain('EnterWorktree')
+    })
+
+    it('includes worktree failure warning when worktree creation fails', async () => {
+      const sm = fakeSessionManager(false) // worktree fails
+      const mgr = new OrchestratorChildManager(sm)
+      const request = makeRequest({ useWorktree: true })
+
+      await mgr.spawn(request)
+
+      const prompt = sm._sentInputs[0]
+      expect(prompt).toContain('Worktree Not Available')
+      expect(prompt).toContain('directly in the main repository')
+      expect(prompt).toContain('Create branch `fix/login-bug`')
+      expect(prompt).not.toContain('Worktree Environment')
+    })
+
+    it('omits create-branch step in PR completion when in worktree', async () => {
+      const sm = fakeSessionManager(true)
+      const mgr = new OrchestratorChildManager(sm)
+      const request = makeRequest({ useWorktree: true, completionPolicy: 'pr' })
+
+      await mgr.spawn(request)
+
+      const prompt = sm._sentInputs[0]
+      // Should NOT tell Claude to create/switch branches
+      expect(prompt).not.toContain('Create and switch to branch')
+      // Should still mention push + PR
+      expect(prompt).toContain('Push the branch')
+      expect(prompt).toContain('Pull Request')
+    })
+
+    it('includes create-branch step in PR completion when NOT in worktree', async () => {
+      const sm = fakeSessionManager(false) // worktree fails
+      const mgr = new OrchestratorChildManager(sm)
+      const request = makeRequest({ useWorktree: true, completionPolicy: 'pr' })
+
+      await mgr.spawn(request)
+
+      const prompt = sm._sentInputs[0]
+      expect(prompt).toContain('Create and switch to branch')
+    })
+
+    it('passes branchName to createWorktree', async () => {
+      const sm = fakeSessionManager(true)
+      const mgr = new OrchestratorChildManager(sm)
+      const request = makeRequest({ branchName: 'feat/my-feature' })
+
+      await mgr.spawn(request)
+
+      expect(sm.createWorktree).toHaveBeenCalledWith(
+        expect.any(String),
+        '/repos/myproject',
+        'feat/my-feature',
+      )
+    })
+  })
+})

--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -3258,6 +3258,315 @@ describe('SessionManager', () => {
     })
   })
 
+  describe('createWorktree() with targetBranch', () => {
+    afterEach(() => {
+      mockExecFile.mockReset()
+    })
+
+    it('uses targetBranch as branch name instead of generating wt/ prefix', async () => {
+      const s = sm.create('wt-target', '/repos/myproject')
+
+      const gitCalls: string[][] = []
+      mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: any, cb?: any) => {
+        gitCalls.push(args)
+        if (typeof cb === 'function') {
+          if (args[0] === 'rev-parse') {
+            cb(null, '/repos/myproject\n', '')
+          } else if (args[0] === 'show-ref') {
+            // Branch does not exist yet
+            cb(new Error('not found'), '', '')
+          } else {
+            cb(null, '', '')
+          }
+        }
+        return { on: vi.fn() }
+      })
+
+      const result = await sm.createWorktree(s.id, '/repos/myproject', 'fix/my-feature')
+
+      expect(result).not.toBeNull()
+      // Should use the targetBranch name, not wt/<shortId>
+      const worktreeAddCall = gitCalls.find(a => a[0] === 'worktree' && a[1] === 'add')
+      expect(worktreeAddCall).toBeDefined()
+      expect(worktreeAddCall).toContain('fix/my-feature')
+    })
+
+    it('does NOT force-delete caller-supplied branch (non-ephemeral)', async () => {
+      const s = sm.create('wt-no-delete', '/repos/myproject')
+
+      const gitCalls: string[][] = []
+      mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: any, cb?: any) => {
+        gitCalls.push(args)
+        if (typeof cb === 'function') {
+          if (args[0] === 'rev-parse') {
+            cb(null, '/repos/myproject\n', '')
+          } else if (args[0] === 'show-ref') {
+            // Branch already exists
+            cb(null, '', '')
+          } else {
+            cb(null, '', '')
+          }
+        }
+        return { on: vi.fn() }
+      })
+
+      const result = await sm.createWorktree(s.id, '/repos/myproject', 'fix/existing-branch')
+
+      expect(result).not.toBeNull()
+      // Should NOT have called `git branch -D` for caller-supplied branch
+      const branchDeleteCall = gitCalls.find(a => a[0] === 'branch' && a[1] === '-D')
+      expect(branchDeleteCall).toBeUndefined()
+    })
+
+    it('uses show-ref to detect existing branches', async () => {
+      const s = sm.create('wt-showref', '/repos/myproject')
+
+      const gitCalls: string[][] = []
+      mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: any, cb?: any) => {
+        gitCalls.push(args)
+        if (typeof cb === 'function') {
+          if (args[0] === 'rev-parse') {
+            cb(null, '/repos/myproject\n', '')
+          } else if (args[0] === 'show-ref') {
+            // Branch exists
+            cb(null, '', '')
+          } else {
+            cb(null, '', '')
+          }
+        }
+        return { on: vi.fn() }
+      })
+
+      await sm.createWorktree(s.id, '/repos/myproject', 'feat/test')
+
+      // Verify show-ref was called with refs/heads/ for the target branch
+      const showRefCall = gitCalls.find(a =>
+        a[0] === 'show-ref' && a[1] === '--verify' && a.some(arg => arg === 'refs/heads/feat/test')
+      )
+      expect(showRefCall).toBeDefined()
+    })
+
+    it('checks out existing branch without -b flag', async () => {
+      const s = sm.create('wt-existing', '/repos/myproject')
+
+      const gitCalls: string[][] = []
+      mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: any, cb?: any) => {
+        gitCalls.push(args)
+        if (typeof cb === 'function') {
+          if (args[0] === 'rev-parse') {
+            cb(null, '/repos/myproject\n', '')
+          } else if (args[0] === 'show-ref') {
+            cb(null, '', '') // branch exists
+          } else {
+            cb(null, '', '')
+          }
+        }
+        return { on: vi.fn() }
+      })
+
+      await sm.createWorktree(s.id, '/repos/myproject', 'feat/existing')
+
+      const worktreeAddCall = gitCalls.find(a => a[0] === 'worktree' && a[1] === 'add')
+      expect(worktreeAddCall).toBeDefined()
+      // Should NOT contain -b flag for existing branch
+      expect(worktreeAddCall).not.toContain('-b')
+      expect(worktreeAddCall).toContain('feat/existing')
+    })
+
+    it('creates new branch with -b flag when branch does not exist', async () => {
+      const s = sm.create('wt-new-branch', '/repos/myproject')
+
+      const gitCalls: string[][] = []
+      mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: any, cb?: any) => {
+        gitCalls.push(args)
+        if (typeof cb === 'function') {
+          if (args[0] === 'rev-parse') {
+            cb(null, '/repos/myproject\n', '')
+          } else if (args[0] === 'show-ref') {
+            cb(new Error('not found'), '', '') // branch doesn't exist
+          } else {
+            cb(null, '', '')
+          }
+        }
+        return { on: vi.fn() }
+      })
+
+      await sm.createWorktree(s.id, '/repos/myproject', 'feat/brand-new')
+
+      const worktreeAddCall = gitCalls.find(a => a[0] === 'worktree' && a[1] === 'add')
+      expect(worktreeAddCall).toBeDefined()
+      expect(worktreeAddCall).toContain('-b')
+      expect(worktreeAddCall).toContain('feat/brand-new')
+    })
+
+    it('force-deletes ephemeral wt/ branches when no targetBranch supplied', async () => {
+      const s = sm.create('wt-ephemeral', '/repos/myproject')
+      const shortId = s.id.slice(0, 8)
+
+      const gitCalls: string[][] = []
+      mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: any, cb?: any) => {
+        gitCalls.push(args)
+        if (typeof cb === 'function') {
+          if (args[0] === 'rev-parse') {
+            cb(null, '/repos/myproject\n', '')
+          } else if (args[0] === 'show-ref') {
+            cb(null, '', '') // branch exists
+          } else {
+            cb(null, '', '')
+          }
+        }
+        return { on: vi.fn() }
+      })
+
+      // No targetBranch — ephemeral
+      await sm.createWorktree(s.id, '/repos/myproject')
+
+      const branchDeleteCall = gitCalls.find(a => a[0] === 'branch' && a[1] === '-D')
+      expect(branchDeleteCall).toBeDefined()
+      // The deleted branch should contain the shortId (ephemeral wt/ pattern)
+      expect(branchDeleteCall![2]).toContain(shortId)
+    })
+  })
+
+  describe('handleClaudeExit — spawn failure preservation', () => {
+    it('preserves claudeSessionId when spawn failed (ENOENT)', () => {
+      vi.useFakeTimers()
+      const s = sm.create('spawn-fail-test', '/tmp')
+      const session = sm.get(s.id)!
+      ;(session as any).claudeSessionId = 'my-claude-session'
+      ;(session as any).restartCount = 0
+
+      const cp = fakeClaudeProcess(false)
+      cp.hadOutput.mockReturnValue(false)
+      cp.hasSpawnFailed.mockReturnValue(true)
+
+      ;(sm as any).handleClaudeExit(cp, session, s.id, 1, null)
+
+      // claudeSessionId should be preserved (not cleared) because spawn failed
+      expect(session.claudeSessionId).toBe('my-claude-session')
+      vi.useRealTimers()
+    })
+
+    it('clears claudeSessionId when process had no output but spawn succeeded', () => {
+      vi.useFakeTimers()
+      const s = sm.create('no-output-test', '/tmp')
+      const session = sm.get(s.id)!
+      ;(session as any).claudeSessionId = 'stale-session'
+      ;(session as any).restartCount = 0
+
+      const cp = fakeClaudeProcess(false)
+      cp.hadOutput.mockReturnValue(false)
+      cp.hasSpawnFailed.mockReturnValue(false)
+
+      ;(sm as any).handleClaudeExit(cp, session, s.id, 1, null)
+
+      // claudeSessionId should be cleared since process started but produced nothing
+      expect(session.claudeSessionId).toBeNull()
+      vi.useRealTimers()
+    })
+  })
+
+  describe('handleClaudeExit — missing workingDir fallback', () => {
+    it('falls back to groupDir when workingDir no longer exists', () => {
+      vi.useFakeTimers()
+      const mockedExistsSync = vi.mocked(existsSync)
+      const s = sm.create('wt-deleted', '/repos/project-wt-abc12345')
+      const session = sm.get(s.id)!
+      ;(session as any).groupDir = '/repos/project'
+      ;(session as any).worktreePath = '/repos/project-wt-abc12345'
+      ;(session as any).restartCount = 0
+
+      // workingDir doesn't exist, but groupDir does
+      mockedExistsSync.mockImplementation((p) => {
+        const ps = String(p)
+        if (ps === '/repos/project-wt-abc12345') return false
+        if (ps === '/repos/project') return true
+        if (ps.includes('sessions.json')) return false
+        return true
+      })
+
+      const ws = fakeWs()
+      sm.join(s.id, ws)
+
+      ;(sm as any).handleClaudeExit(fakeClaudeProcess(false), session, s.id, 1, null)
+
+      // Should update workingDir to groupDir
+      expect(session.workingDir).toBe('/repos/project')
+      expect(session.worktreePath).toBeUndefined()
+
+      // Should broadcast notification about fallback
+      const messages = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+      const fallbackMsg = messages.find((m: any) =>
+        m.type === 'system_message' && m.subtype === 'notification' && m.text?.includes('was removed')
+      )
+      expect(fallbackMsg).toBeDefined()
+
+      // Reset mock
+      mockedExistsSync.mockImplementation((p) => String(p).includes('sessions.json') ? false : true)
+      vi.useRealTimers()
+    })
+
+    it('stops session when workingDir gone and no fallback groupDir', () => {
+      const mockedExistsSync = vi.mocked(existsSync)
+      const s = sm.create('wt-no-fallback', '/repos/project-wt-abc12345')
+      const session = sm.get(s.id)!
+      ;(session as any).groupDir = undefined
+      ;(session as any).restartCount = 0
+
+      // workingDir doesn't exist, no groupDir
+      mockedExistsSync.mockImplementation((p) => {
+        const ps = String(p)
+        if (ps === '/repos/project-wt-abc12345') return false
+        if (ps.includes('sessions.json')) return false
+        return true
+      })
+
+      const ws = fakeWs()
+      sm.join(s.id, ws)
+
+      ;(sm as any).handleClaudeExit(fakeClaudeProcess(false), session, s.id, 1, null)
+
+      // Should mark as stopped
+      expect(session._stoppedByUser).toBe(true)
+
+      // Should broadcast error about no fallback
+      const messages = ws.send.mock.calls.map((c: any) => JSON.parse(c[0]))
+      const errorMsg = messages.find((m: any) =>
+        m.type === 'system_message' && m.subtype === 'error' && m.text?.includes('no fallback')
+      )
+      expect(errorMsg).toBeDefined()
+
+      // Reset mock
+      mockedExistsSync.mockImplementation((p) => String(p).includes('sessions.json') ? false : true)
+    })
+
+    it('stops session when both workingDir and groupDir are gone', () => {
+      const mockedExistsSync = vi.mocked(existsSync)
+      const s = sm.create('wt-both-gone', '/repos/project-wt-abc12345')
+      const session = sm.get(s.id)!
+      ;(session as any).groupDir = '/repos/also-gone'
+      ;(session as any).restartCount = 0
+
+      mockedExistsSync.mockImplementation((p) => {
+        const ps = String(p)
+        if (ps === '/repos/project-wt-abc12345') return false
+        if (ps === '/repos/also-gone') return false
+        if (ps.includes('sessions.json')) return false
+        return true
+      })
+
+      const ws = fakeWs()
+      sm.join(s.id, ws)
+
+      ;(sm as any).handleClaudeExit(fakeClaudeProcess(false), session, s.id, 1, null)
+
+      expect(session._stoppedByUser).toBe(true)
+
+      // Reset mock
+      mockedExistsSync.mockImplementation((p) => String(p).includes('sessions.json') ? false : true)
+    })
+  })
+
   describe('discardChanges', () => {
     it('returns diff_error when session not found', async () => {
       const sm = new SessionManager()


### PR DESCRIPTION
## Summary
- Add 22 new unit tests covering recent security/reliability changes from commits c022112, 5804aca, 0e45e4f, and related PRs
- New test file `server/orchestrator-children.test.ts` for prompt generation with worktree context
- Covers: CWD validation in ClaudeProcess.start(), ENOENT/EACCES spawn-failure detection, createWorktree with caller-supplied branches (show-ref, no force-delete), handleClaudeExit workingDir fallback, and orchestrator prompt worktree/non-worktree scenarios

## Test plan
- [x] All 1351 tests pass across 48 test files
- [x] Zero unhandled errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)