### PR TITLE
fix: strip GIT_* env vars when spawning Claude CLI processes

### DIFF
--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -172,11 +172,18 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> {
     // Exclude ANTHROPIC_API_KEY / CLAUDE_CODE_API_KEY from inheritance —
     // stale or incorrect keys override the CLI's subscription/OAuth auth
     // and cause "Invalid API key" errors. Let the CLI use its own auth.
+    // Also strip GIT_* vars (except GIT_EDITOR) that the server may have
+    // inherited from the shell that launched it. In particular,
+    // GIT_INDEX_FILE=.git/index breaks worktrees where .git is a file,
+    // not a directory, causing all index-dependent git commands to fail.
     const API_KEY_VARS = new Set(['ANTHROPIC_API_KEY', 'CLAUDE_CODE_API_KEY'])
     const env: Record<string, string> = {
       ...Object.fromEntries(
         Object.entries(process.env).filter(
-          (entry): entry is [string, string] => entry[1] != null && !API_KEY_VARS.has(entry[0])
+          (entry): entry is [string, string] =>
+            entry[1] != null &&
+            !API_KEY_VARS.has(entry[0]) &&
+            (!entry[0].startsWith('GIT_') || entry[0] === 'GIT_EDITOR')
         )
       ),
       ...this.extraEnv,


### PR DESCRIPTION
## Summary
- Strip `GIT_*` environment variables (except `GIT_EDITOR`) when spawning Claude CLI child processes
- Fixes worktree sessions entering infinite restart loops because `GIT_INDEX_FILE=.git/index` breaks git commands in worktrees (where `.git` is a file, not a directory)
- Matches the approach already used in `diff-manager.ts`'s `cleanGitEnv()`

## Root cause
The server process inherits `GIT_INDEX_FILE=.git/index` from Claude Code's hook system. This relative path works in the main repo but fails in worktrees, causing `fatal: .git/index: index file open failed: Not a directory` on every git status/diff/add/commit operation.

## Test plan
- [x] Verified `git status` works in worktree after unsetting `GIT_INDEX_FILE`
- [ ] Deploy and confirm the e2c406e2 worktree session stops restart-looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)