### PR TITLE
refactor: extract session lifecycle into session-lifecycle.ts

### DIFF
--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -1,0 +1,417 @@
+/**
+ * Claude process lifecycle management extracted from SessionManager.
+ *
+ * Handles:
+ * - Starting/stopping Claude CLI processes (startClaude, stopClaude, stopClaudeAndWait)
+ * - Waiting for process readiness (waitForReady)
+ * - Wiring Claude process event handlers (wireClaudeEvents)
+ * - Handling process exit and auto-restart logic (handleClaudeExit)
+ */
+
+import { existsSync } from 'fs'
+import path from 'path'
+import { ClaudeProcess } from './claude-process.js'
+import { ApprovalManager } from './approval-manager.js'
+import type { PromptRouter } from './prompt-router.js'
+import type { Session, WsServerMessage } from './types.js'
+import { PORT } from './config.js'
+import { deriveSessionToken } from './crypto-utils.js'
+import { evaluateRestart } from './session-restart-scheduler.js'
+
+/** Dependencies injected by SessionManager so SessionLifecycle can interact with session state. */
+export interface SessionLifecycleDeps {
+  getSession(id: string): Session | undefined
+  hasSession(id: string): boolean
+  broadcast(session: Session, msg: WsServerMessage): void
+  addToHistory(session: Session, msg: WsServerMessage): void
+  broadcastAndHistory(session: Session, msg: WsServerMessage): void
+  persistToDisk(): void
+  globalBroadcast: ((msg: WsServerMessage) => void) | null
+  authToken: string
+  serverPort: number
+  approvalManager: ApprovalManager
+  promptRouter: PromptRouter
+  exitListeners: Array<(sessionId: string, code: number | null, signal: string | null, willRestart: boolean) => void>
+  // Event handler callbacks that remain in SessionManager
+  onSystemInit(cp: ClaudeProcess, session: Session, model: string): void
+  onTextEvent(session: Session, sessionId: string, text: string): void
+  onThinkingEvent(session: Session, summary: string): void
+  onToolOutputEvent(session: Session, content: string, isError: boolean): void
+  onImageEvent(session: Session, base64: string, mediaType: string): void
+  onToolActiveEvent(session: Session, toolName: string, toolInput: string | undefined): void
+  onToolDoneEvent(session: Session, toolName: string, summary: string | undefined): void
+  handleClaudeResult(session: Session, sessionId: string, result: string, isError: boolean): void
+  buildSessionContext(session: Session): string | null
+}
+
+export class SessionLifecycle {
+  private deps: SessionLifecycleDeps
+
+  constructor(deps: SessionLifecycleDeps) {
+    this.deps = deps
+  }
+
+  // ---------------------------------------------------------------------------
+  // Claude process lifecycle
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Spawn (or re-spawn) a Claude CLI process for a session.
+   * Wires up all event handlers for streaming text, tools, prompts, and auto-restart.
+   */
+  startClaude(sessionId: string): boolean {
+    const session = this.deps.getSession(sessionId)
+    if (!session) return false
+
+    // Clear stopped flag and any pending restart timer on explicit start
+    session._stoppedByUser = false
+    if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }
+
+    // Validate that the working directory still exists.  Worktree directories
+    // can be removed externally (cleanup, manual deletion, failed creation that
+    // left a stale placeholder).  Fall back to groupDir (the original repo) so
+    // the session can still function instead of entering an infinite restart loop.
+    if (!existsSync(session.workingDir) || (session.worktreePath && !existsSync(path.join(session.workingDir, '.git')))) {
+      const fallback = session.groupDir ?? session.workingDir
+      if (fallback !== session.workingDir && existsSync(fallback)) {
+        const deadPath = session.workingDir
+        console.warn(`[startClaude] Working directory ${deadPath} missing or not a valid worktree — falling back to ${fallback}`)
+        session.workingDir = fallback
+        session.worktreePath = undefined
+        this.deps.persistToDisk()
+        this.deps.globalBroadcast?.({ type: 'sessions_updated' })
+        const fallbackMsg: WsServerMessage = {
+          type: 'system_message',
+          subtype: 'notification',
+          text: `Worktree directory ${deadPath} no longer exists. Falling back to original repository: ${fallback}`,
+        }
+        this.deps.addToHistory(session, fallbackMsg)
+        this.deps.broadcast(session, fallbackMsg)
+      } else if (!existsSync(session.workingDir)) {
+        console.error(`[startClaude] Working directory ${session.workingDir} does not exist and no fallback available — cannot start`)
+        session._stoppedByUser = true  // prevent restart loop
+        const errMsg: WsServerMessage = {
+          type: 'system_message',
+          subtype: 'error',
+          text: `Working directory ${session.workingDir} no longer exists and no fallback is available. Session cannot start.`,
+        }
+        this.deps.addToHistory(session, errMsg)
+        this.deps.broadcast(session, errMsg)
+        return false
+      }
+    }
+
+    // Kill existing process if any — remove listeners first to prevent the
+    // old process's exit handler from clobbering the new process reference
+    // and triggering an unwanted auto-restart cycle.
+    if (session.claudeProcess) {
+      session.claudeProcess.removeAllListeners()
+      session.claudeProcess.stop()
+    }
+
+    // Derive a session-scoped token instead of forwarding the master auth token.
+    // This limits child process privileges to approve/deny for their own session only.
+    const sessionToken = this.deps.authToken
+      ? deriveSessionToken(this.deps.authToken, sessionId)
+      : ''
+    // Both CODEKIN_TOKEN (legacy name, used by older hooks) and CODEKIN_AUTH_TOKEN
+    // (current canonical name) are set to the same derived value for backward compatibility.
+    const extraEnv: Record<string, string> = {
+      CODEKIN_SESSION_ID: sessionId,
+      CODEKIN_PORT: String(this.deps.serverPort || PORT),
+      CODEKIN_TOKEN: sessionToken,
+      CODEKIN_AUTH_TOKEN: sessionToken,
+      CODEKIN_SESSION_TYPE: session.source || 'manual',
+      ...(session.permissionMode === 'dangerouslySkipPermissions' ? { CODEKIN_SKIP_PERMISSIONS: '1' } : {}),
+    }
+    // Pass CLAUDE_PROJECT_DIR so hooks and CLAUDE.md resolve correctly
+    // even when the session's working directory differs from the project root
+    // (e.g. worktrees, webhook workspaces).  Note: this does NOT control
+    // session storage path — Claude CLI uses the CWD for that.
+    if (session.groupDir) {
+      extraEnv.CLAUDE_PROJECT_DIR = session.groupDir
+    } else if (process.env.CLAUDE_PROJECT_DIR) {
+      extraEnv.CLAUDE_PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR
+    }
+    // When claudeSessionId exists, the session has run before and a JSONL file
+    // exists on disk.  Use --resume (not --session-id) to continue it — --session-id
+    // creates a *new* session and fails with "already in use" if the JSONL exists.
+    const resume = !!session.claudeSessionId
+
+    // Build comprehensive allowedTools from session-level overrides + registry approvals
+    const repoDir = session.groupDir ?? session.workingDir
+    const registryPatterns = this.deps.approvalManager.getAllowedToolsForRepo(repoDir)
+    const mergedAllowedTools = [...new Set([...(session.allowedTools || []), ...registryPatterns])]
+    const cp = new ClaudeProcess(session.workingDir, {
+      sessionId: session.claudeSessionId || undefined,
+      extraEnv,
+      model: session.model,
+      permissionMode: session.permissionMode,
+      resume,
+      allowedTools: mergedAllowedTools,
+    })
+
+    this.wireClaudeEvents(cp, session, sessionId)
+
+    cp.start()
+    session.claudeProcess = cp
+    this.deps.globalBroadcast?.({ type: 'sessions_updated' })
+
+    const startMsg: WsServerMessage = { type: 'claude_started', sessionId }
+    this.deps.addToHistory(session, startMsg)
+    this.deps.broadcast(session, startMsg)
+    return true
+  }
+
+  /**
+   * Wait for a session's Claude process to emit its system_init event,
+   * indicating it is ready to accept input. Resolves immediately if the
+   * session already has a claudeSessionId (process previously initialized).
+   * Times out after `timeoutMs` (default 30s) to avoid hanging indefinitely.
+   */
+  waitForReady(sessionId: string, timeoutMs = 30_000): Promise<void> {
+    const session = this.deps.getSession(sessionId)
+    if (!session?.claudeProcess) return Promise.resolve()
+    // If the process already completed init in a prior turn, resolve immediately
+    if (session.claudeSessionId) return Promise.resolve()
+
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        console.warn(`[waitForReady] Timed out waiting for system_init on ${sessionId} after ${timeoutMs}ms`)
+        resolve()
+      }, timeoutMs)
+      session.claudeProcess!.once('system_init', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+  }
+
+  /**
+   * Attach all ClaudeProcess event listeners for a session.
+   * Called by startClaude() to keep that method focused on process setup.
+   */
+  wireClaudeEvents(cp: ClaudeProcess, session: Session, sessionId: string): void {
+    cp.on('system_init', (model) => this.deps.onSystemInit(cp, session, model))
+    cp.on('text', (text) => this.deps.onTextEvent(session, sessionId, text))
+    cp.on('thinking', (summary) => this.deps.onThinkingEvent(session, summary))
+    cp.on('tool_output', (content, isError) => this.deps.onToolOutputEvent(session, content, isError))
+    cp.on('image', (base64Data, mediaType) => this.deps.onImageEvent(session, base64Data, mediaType))
+    cp.on('tool_active', (toolName, toolInput) => this.deps.onToolActiveEvent(session, toolName, toolInput))
+    cp.on('tool_done', (toolName, summary) => this.deps.onToolDoneEvent(session, toolName, summary))
+    cp.on('planning_mode', (active) => {
+      // Route EnterPlanMode through PlanManager for UI state tracking.
+      // ExitPlanMode (active=false) is ignored here — the PreToolUse hook
+      // is the enforcement gate, and it calls handleExitPlanModeApproval()
+      // which transitions PlanManager to 'reviewing'.
+      if (active) {
+        session.planManager.onEnterPlanMode()
+      }
+      // ExitPlanMode stream event intentionally ignored — hook handles it.
+    })
+    cp.on('todo_update', (tasks) => { this.deps.broadcastAndHistory(session, { type: 'todo_update', tasks }) })
+    cp.on('prompt', (...args) => this.deps.promptRouter.onPromptEvent(session, ...args))
+    cp.on('control_request', (requestId, toolName, toolInput) => this.deps.promptRouter.onControlRequestEvent(cp, session, sessionId, requestId, toolName, toolInput))
+    cp.on('result', (result, isError) => {
+      session.planManager.onTurnEnd()
+      this.deps.handleClaudeResult(session, sessionId, result, isError)
+    })
+    cp.on('error', (message) => this.deps.broadcast(session, { type: 'error', message }))
+    cp.on('exit', (code, signal) => { cp.removeAllListeners(); this.handleClaudeExit(cp, session, sessionId, code, signal) })
+  }
+
+  /**
+   * Handle a Claude process 'exit' event: clean up state, notify exit listeners,
+   * and either auto-restart (within limits) or broadcast the final exit message.
+   *
+   * Uses evaluateRestart() for the restart decision, keeping this method focused
+   * on state updates, listener notification, and message broadcasting.
+   */
+  handleClaudeExit(exitedProcess: ClaudeProcess, session: Session, sessionId: string, code: number | null, signal: string | null): void {
+    // Guard: ignore exit events from stale processes that were replaced by a
+    // new startClaude() call.  Without this, the old process's exit handler
+    // would null out session.claudeProcess (which now points to the NEW
+    // process), orphaning it and triggering an unwanted auto-restart cycle.
+    if (session.claudeProcess && session.claudeProcess !== exitedProcess) {
+      console.log(`[restart] Ignoring exit from stale process for session ${sessionId}`)
+      return
+    }
+    session.claudeProcess = null
+    session.isProcessing = false
+    session.planManager.reset()
+    this.deps.globalBroadcast?.({ type: 'sessions_updated' })
+
+    // "Session ID is already in use" means another process holds the lock.
+    // Retrying with the same session ID will fail every time, so treat this
+    // as a non-restartable exit (same as stopped-by-user).
+    const sessionConflict = exitedProcess.hasSessionConflict()
+
+    // If the process exited without ever producing stdout output, --resume
+    // hung on a broken/stale session. Clear claudeSessionId so the next
+    // restart attempt uses a fresh session instead of retrying the same
+    // broken resume — which would just hang again.
+    // Exception: if spawn() itself failed (ENOENT/EACCES), the process never
+    // started — the session data on disk is fine, so preserve the ID for retry.
+    if (!exitedProcess.hadOutput() && session.claudeSessionId && !exitedProcess.hasSpawnFailed()) {
+      console.warn(`[restart] Session ${sessionId} produced no output before exit — clearing claudeSessionId to force fresh session`)
+      session.claudeSessionId = null
+    }
+    if (exitedProcess.hasSpawnFailed()) {
+      console.warn(`[restart] Session ${sessionId} spawn failed (binary not found) — preserving claudeSessionId for retry`)
+    }
+
+    // Before evaluating restart, check if the working directory still exists.
+    // If a worktree was deleted mid-session, fall back to the original repo
+    // instead of entering a guaranteed restart death loop where every attempt
+    // fails with the same missing CWD.
+    if (!existsSync(session.workingDir)) {
+      const fallback = session.groupDir
+      if (fallback && existsSync(fallback)) {
+        const deadPath = session.workingDir
+        console.warn(`[restart] Working directory ${deadPath} no longer exists — falling back to ${fallback}`)
+        session.workingDir = fallback
+        session.worktreePath = undefined
+        this.deps.persistToDisk()
+        this.deps.globalBroadcast?.({ type: 'sessions_updated' })
+        const fallbackMsg: WsServerMessage = {
+          type: 'system_message',
+          subtype: 'notification',
+          text: `Worktree directory ${deadPath} was removed. Restarting in original repository: ${fallback}`,
+        }
+        this.deps.addToHistory(session, fallbackMsg)
+        this.deps.broadcast(session, fallbackMsg)
+      } else {
+        // No fallback available — don't waste restart attempts
+        console.error(`[restart] Working directory ${session.workingDir} does not exist and no fallback — stopping session`)
+        session._stoppedByUser = true
+        for (const listener of this.deps.exitListeners) {
+          try { listener(sessionId, code, signal, false) } catch { /* listener error */ }
+        }
+        const msg: WsServerMessage = {
+          type: 'system_message',
+          subtype: 'error',
+          text: `Working directory ${session.workingDir} no longer exists and no fallback is available. Please delete this session and create a new one.`,
+        }
+        this.deps.addToHistory(session, msg)
+        this.deps.broadcast(session, msg)
+        this.deps.broadcast(session, { type: 'exit', code: code ?? -1, signal })
+        return
+      }
+    }
+
+    const action = evaluateRestart({
+      restartCount: session.restartCount,
+      lastRestartAt: session.lastRestartAt,
+      stoppedByUser: session._stoppedByUser || sessionConflict,
+    })
+
+    if (action.kind === 'stopped_by_user') {
+      for (const listener of this.deps.exitListeners) {
+        try { listener(sessionId, code, signal, false) } catch { /* listener error */ }
+      }
+      const text = sessionConflict
+        ? 'Claude process exited: session ID is already in use by another process. Please restart manually.'
+        : `Claude process exited: code=${code}, signal=${signal}`
+      const msg: WsServerMessage = { type: 'system_message', subtype: 'exit', text }
+      this.deps.addToHistory(session, msg)
+      this.deps.broadcast(session, msg)
+      this.deps.broadcast(session, { type: 'exit', code: code ?? -1, signal })
+      return
+    }
+
+    if (action.kind === 'restart') {
+      session.restartCount = action.updatedCount
+      session.lastRestartAt = action.updatedLastRestartAt
+
+      for (const listener of this.deps.exitListeners) {
+        try { listener(sessionId, code, signal, true) } catch { /* listener error */ }
+      }
+
+      const msg: WsServerMessage = {
+        type: 'system_message',
+        subtype: 'restart',
+        text: `Claude process exited unexpectedly (code=${code}, signal=${signal}). Restarting (attempt ${action.attempt}/${action.maxAttempts})...`,
+      }
+      this.deps.addToHistory(session, msg)
+      this.deps.broadcast(session, msg)
+
+      // Clear any previously scheduled restart to prevent duplicate spawns
+      if (session._restartTimer) clearTimeout(session._restartTimer)
+      session._restartTimer = setTimeout(() => {
+        session._restartTimer = undefined
+        // Verify session still exists and hasn't been stopped
+        if (!this.deps.hasSession(sessionId) || session._stoppedByUser) return
+        // startClaude uses --resume when claudeSessionId exists, so the CLI
+        // picks up the full conversation history from the JSONL automatically.
+        this.startClaude(sessionId)
+
+        // Fallback: if claudeSessionId was already null (fresh session that
+        // crashed before system_init), inject a context summary so the new
+        // session has some awareness of prior conversation.
+        if (!session.claudeSessionId && session.claudeProcess && session.outputHistory.length > 0) {
+          session.claudeProcess.once('system_init', () => {
+            const context = this.deps.buildSessionContext(session)
+            if (context) {
+              session.claudeProcess?.sendMessage(
+                context + '\n\n[Session resumed after process restart. Continue where you left off. If you were in the middle of a task, resume it.]',
+              )
+            }
+          })
+        }
+      }, action.delayMs)
+      return
+    }
+
+    // action.kind === 'exhausted'
+    for (const listener of this.deps.exitListeners) {
+      try { listener(sessionId, code, signal, false) } catch { /* listener error */ }
+    }
+    const msg: WsServerMessage = {
+      type: 'system_message',
+      subtype: 'error',
+      text: `Claude process exited unexpectedly (code=${code}, signal=${signal}). Auto-restart disabled after ${action.maxAttempts} attempts. Please restart manually.`,
+    }
+    this.deps.addToHistory(session, msg)
+    this.deps.broadcast(session, msg)
+    this.deps.broadcast(session, { type: 'exit', code: code ?? -1, signal })
+  }
+
+  stopClaude(sessionId: string): void {
+    const session = this.deps.getSession(sessionId)
+    if (session?.claudeProcess) {
+      session._stoppedByUser = true
+      if (session._apiRetryTimer) clearTimeout(session._apiRetryTimer)
+      if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }
+      session.claudeProcess.removeAllListeners()
+      session.claudeProcess.stop()
+      session.claudeProcess = null
+      this.deps.broadcast(session, { type: 'claude_stopped' })
+    }
+  }
+
+  /**
+   * Stop the Claude process and wait for it to fully exit before resolving.
+   * This prevents race conditions when restarting with the same session ID
+   * (e.g. during mid-session worktree migration).
+   */
+  async stopClaudeAndWait(sessionId: string): Promise<void> {
+    const session = this.deps.getSession(sessionId)
+    if (!session?.claudeProcess) return
+
+    const cp = session.claudeProcess
+    session._stoppedByUser = true
+    if (session._apiRetryTimer) clearTimeout(session._apiRetryTimer)
+    if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }
+    cp.removeAllListeners()
+    cp.stop()
+    this.deps.broadcast(session, { type: 'claude_stopped' })
+
+    // Wait for the underlying OS process to fully exit BEFORE nulling the
+    // reference.  Previously this was set to null before the await, which
+    // allowed another caller (e.g. move_to_worktree) to call startClaude()
+    // while the old process was still alive — causing concurrent git access
+    // and index corruption.
+    await cp.waitForExit()
+    session.claudeProcess = null
+  }
+}

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -15,7 +15,8 @@
  * - SessionNaming: AI-powered session name generation with retry logic
  * - SessionPersistence: disk I/O for session state
  * - DiffManager: stateless git-diff operations
- * - evaluateRestart: pure restart-decision logic
+ * - SessionLifecycle: Claude process start/stop/restart and event wiring
+ * - evaluateRestart: pure restart-decision logic (used by SessionLifecycle)
  */
 
 import { randomUUID } from 'crypto'
@@ -33,11 +34,10 @@ import { cleanupWorkspace } from './webhook-workspace.js'
 import { PORT } from './config.js'
 import { ApprovalManager } from './approval-manager.js'
 import { PromptRouter } from './prompt-router.js'
+import { SessionLifecycle } from './session-lifecycle.js'
 import { SessionNaming } from './session-naming.js'
 import { SessionPersistence } from './session-persistence.js'
-import { deriveSessionToken } from './crypto-utils.js'
 import { cleanGitEnv, DiffManager } from './diff-manager.js'
-import { evaluateRestart } from './session-restart-scheduler.js'
 
 const execFileAsync = promisify(execFile)
 
@@ -112,6 +112,8 @@ export class SessionManager {
   private diffManager: DiffManager
   /** Delegated prompt routing and tool approval logic. */
   private promptRouter: PromptRouter
+  /** Delegated Claude process lifecycle (start, stop, restart, event wiring). */
+  private sessionLifecycle: SessionLifecycle
   /** Interval handle for the idle session reaper. */
   private _idleReaperInterval: ReturnType<typeof setInterval> | null = null
 
@@ -127,6 +129,32 @@ export class SessionManager {
       globalBroadcast: (msg) => this._globalBroadcast?.(msg),
       approvalManager: this._approvalManager,
       promptListeners: this._promptListeners,
+    })
+    // Use a local ref so the getter closures capture `this` (the SessionManager instance)
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this
+    this.sessionLifecycle = new SessionLifecycle({
+      getSession: (id) => this.sessions.get(id),
+      hasSession: (id) => this.sessions.has(id),
+      broadcast: (session, msg) => this.broadcast(session, msg),
+      addToHistory: (session, msg) => this.addToHistory(session, msg),
+      broadcastAndHistory: (session, msg) => this.broadcastAndHistory(session, msg),
+      persistToDisk: () => this.persistToDisk(),
+      get globalBroadcast() { return self._globalBroadcast },
+      get authToken() { return self._authToken },
+      get serverPort() { return self._serverPort },
+      approvalManager: this._approvalManager,
+      promptRouter: this.promptRouter,
+      exitListeners: this._exitListeners,
+      onSystemInit: (cp, session, model) => this.onSystemInit(cp, session, model),
+      onTextEvent: (session, sessionId, text) => this.onTextEvent(session, sessionId, text),
+      onThinkingEvent: (session, summary) => this.onThinkingEvent(session, summary),
+      onToolOutputEvent: (session, content, isError) => this.onToolOutputEvent(session, content, isError),
+      onImageEvent: (session, base64, mediaType) => this.onImageEvent(session, base64, mediaType),
+      onToolActiveEvent: (session, toolName, toolInput) => this.onToolActiveEvent(session, toolName, toolInput),
+      onToolDoneEvent: (session, toolName, summary) => this.onToolDoneEvent(session, toolName, summary),
+      handleClaudeResult: (session, sessionId, result, isError) => this.handleClaudeResult(session, sessionId, result, isError),
+      buildSessionContext: (session) => this.buildSessionContext(session),
     })
     this.sessionPersistence = new SessionPersistence(this.sessions)
     this.sessionNaming = new SessionNaming({
@@ -821,167 +849,18 @@ export class SessionManager {
 
   /**
    * Spawn (or re-spawn) a Claude CLI process for a session.
-   * Wires up all event handlers for streaming text, tools, prompts, and auto-restart.
+   * Delegates to SessionLifecycle.
    */
   startClaude(sessionId: string): boolean {
-    const session = this.sessions.get(sessionId)
-    if (!session) return false
-
-    // Clear stopped flag and any pending restart timer on explicit start
-    session._stoppedByUser = false
-    if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }
-
-    // Validate that the working directory still exists.  Worktree directories
-    // can be removed externally (cleanup, manual deletion, failed creation that
-    // left a stale placeholder).  Fall back to groupDir (the original repo) so
-    // the session can still function instead of entering an infinite restart loop.
-    if (!existsSync(session.workingDir) || (session.worktreePath && !existsSync(path.join(session.workingDir, '.git')))) {
-      const fallback = session.groupDir ?? session.workingDir
-      if (fallback !== session.workingDir && existsSync(fallback)) {
-        const deadPath = session.workingDir
-        console.warn(`[startClaude] Working directory ${deadPath} missing or not a valid worktree — falling back to ${fallback}`)
-        session.workingDir = fallback
-        session.worktreePath = undefined
-        this.persistToDisk()
-        this._globalBroadcast?.({ type: 'sessions_updated' })
-        const fallbackMsg: WsServerMessage = {
-          type: 'system_message',
-          subtype: 'notification',
-          text: `Worktree directory ${deadPath} no longer exists. Falling back to original repository: ${fallback}`,
-        }
-        this.addToHistory(session, fallbackMsg)
-        this.broadcast(session, fallbackMsg)
-      } else if (!existsSync(session.workingDir)) {
-        console.error(`[startClaude] Working directory ${session.workingDir} does not exist and no fallback available — cannot start`)
-        session._stoppedByUser = true  // prevent restart loop
-        const errMsg: WsServerMessage = {
-          type: 'system_message',
-          subtype: 'error',
-          text: `Working directory ${session.workingDir} no longer exists and no fallback is available. Session cannot start.`,
-        }
-        this.addToHistory(session, errMsg)
-        this.broadcast(session, errMsg)
-        return false
-      }
-    }
-
-    // Kill existing process if any — remove listeners first to prevent the
-    // old process's exit handler from clobbering the new process reference
-    // and triggering an unwanted auto-restart cycle.
-    if (session.claudeProcess) {
-      session.claudeProcess.removeAllListeners()
-      session.claudeProcess.stop()
-    }
-
-    // Derive a session-scoped token instead of forwarding the master auth token.
-    // This limits child process privileges to approve/deny for their own session only.
-    const sessionToken = this._authToken
-      ? deriveSessionToken(this._authToken, sessionId)
-      : ''
-    // Both CODEKIN_TOKEN (legacy name, used by older hooks) and CODEKIN_AUTH_TOKEN
-    // (current canonical name) are set to the same derived value for backward compatibility.
-    const extraEnv: Record<string, string> = {
-      CODEKIN_SESSION_ID: sessionId,
-      CODEKIN_PORT: String(this._serverPort || PORT),
-      CODEKIN_TOKEN: sessionToken,
-      CODEKIN_AUTH_TOKEN: sessionToken,
-      CODEKIN_SESSION_TYPE: session.source || 'manual',
-      ...(session.permissionMode === 'dangerouslySkipPermissions' ? { CODEKIN_SKIP_PERMISSIONS: '1' } : {}),
-    }
-    // Pass CLAUDE_PROJECT_DIR so hooks and CLAUDE.md resolve correctly
-    // even when the session's working directory differs from the project root
-    // (e.g. worktrees, webhook workspaces).  Note: this does NOT control
-    // session storage path — Claude CLI uses the CWD for that.
-    if (session.groupDir) {
-      extraEnv.CLAUDE_PROJECT_DIR = session.groupDir
-    } else if (process.env.CLAUDE_PROJECT_DIR) {
-      extraEnv.CLAUDE_PROJECT_DIR = process.env.CLAUDE_PROJECT_DIR
-    }
-    // When claudeSessionId exists, the session has run before and a JSONL file
-    // exists on disk.  Use --resume (not --session-id) to continue it — --session-id
-    // creates a *new* session and fails with "already in use" if the JSONL exists.
-    const resume = !!session.claudeSessionId
-
-    // Build comprehensive allowedTools from session-level overrides + registry approvals
-    const repoDir = session.groupDir ?? session.workingDir
-    const registryPatterns = this._approvalManager.getAllowedToolsForRepo(repoDir)
-    const mergedAllowedTools = [...new Set([...(session.allowedTools || []), ...registryPatterns])]
-    const cp = new ClaudeProcess(session.workingDir, {
-      sessionId: session.claudeSessionId || undefined,
-      extraEnv,
-      model: session.model,
-      permissionMode: session.permissionMode,
-      resume,
-      allowedTools: mergedAllowedTools,
-    })
-
-    this.wireClaudeEvents(cp, session, sessionId)
-
-    cp.start()
-    session.claudeProcess = cp
-    this._globalBroadcast?.({ type: 'sessions_updated' })
-
-    const startMsg: WsServerMessage = { type: 'claude_started', sessionId }
-    this.addToHistory(session, startMsg)
-    this.broadcast(session, startMsg)
-    return true
+    return this.sessionLifecycle.startClaude(sessionId)
   }
 
   /**
-   * Wait for a session's Claude process to emit its system_init event,
-   * indicating it is ready to accept input. Resolves immediately if the
-   * session already has a claudeSessionId (process previously initialized).
-   * Times out after `timeoutMs` (default 30s) to avoid hanging indefinitely.
+   * Wait for a session's Claude process to emit its system_init event.
+   * Delegates to SessionLifecycle.
    */
   waitForReady(sessionId: string, timeoutMs = 30_000): Promise<void> {
-    const session = this.sessions.get(sessionId)
-    if (!session?.claudeProcess) return Promise.resolve()
-    // If the process already completed init in a prior turn, resolve immediately
-    if (session.claudeSessionId) return Promise.resolve()
-
-    return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        console.warn(`[waitForReady] Timed out waiting for system_init on ${sessionId} after ${timeoutMs}ms`)
-        resolve()
-      }, timeoutMs)
-      session.claudeProcess!.once('system_init', () => {
-        clearTimeout(timer)
-        resolve()
-      })
-    })
-  }
-
-  /**
-   * Attach all ClaudeProcess event listeners for a session.
-   * Extracted from startClaude() to keep that method focused on process setup.
-   */
-  private wireClaudeEvents(cp: ClaudeProcess, session: Session, sessionId: string): void {
-    cp.on('system_init', (model) => this.onSystemInit(cp, session, model))
-    cp.on('text', (text) => this.onTextEvent(session, sessionId, text))
-    cp.on('thinking', (summary) => this.onThinkingEvent(session, summary))
-    cp.on('tool_output', (content, isError) => this.onToolOutputEvent(session, content, isError))
-    cp.on('image', (base64Data, mediaType) => this.onImageEvent(session, base64Data, mediaType))
-    cp.on('tool_active', (toolName, toolInput) => this.onToolActiveEvent(session, toolName, toolInput))
-    cp.on('tool_done', (toolName, summary) => this.onToolDoneEvent(session, toolName, summary))
-    cp.on('planning_mode', (active) => {
-      // Route EnterPlanMode through PlanManager for UI state tracking.
-      // ExitPlanMode (active=false) is ignored here — the PreToolUse hook
-      // is the enforcement gate, and it calls handleExitPlanModeApproval()
-      // which transitions PlanManager to 'reviewing'.
-      if (active) {
-        session.planManager.onEnterPlanMode()
-      }
-      // ExitPlanMode stream event intentionally ignored — hook handles it.
-    })
-    cp.on('todo_update', (tasks) => { this.broadcastAndHistory(session, { type: 'todo_update', tasks }) })
-    cp.on('prompt', (...args) => this.promptRouter.onPromptEvent(session, ...args))
-    cp.on('control_request', (requestId, toolName, toolInput) => this.promptRouter.onControlRequestEvent(cp, session, sessionId, requestId, toolName, toolInput))
-    cp.on('result', (result, isError) => {
-      session.planManager.onTurnEnd()
-      this.handleClaudeResult(session, sessionId, result, isError)
-    })
-    cp.on('error', (message) => this.broadcast(session, { type: 'error', message }))
-    cp.on('exit', (code, signal) => { cp.removeAllListeners(); this.handleClaudeExit(cp, session, sessionId, code, signal) })
+    return this.sessionLifecycle.waitForReady(sessionId, timeoutMs)
   }
 
   /** Broadcast a message and add it to the session's output history. */
@@ -1195,160 +1074,9 @@ export class SessionManager {
     }
   }
 
-  /**
-   * Handle a Claude process 'exit' event: clean up state, notify exit listeners,
-   * and either auto-restart (within limits) or broadcast the final exit message.
-   *
-   * Uses evaluateRestart() for the restart decision, keeping this method focused
-   * on state updates, listener notification, and message broadcasting.
-   */
-  private handleClaudeExit(exitedProcess: ClaudeProcess, session: Session, sessionId: string, code: number | null, signal: string | null): void {
-    // Guard: ignore exit events from stale processes that were replaced by a
-    // new startClaude() call.  Without this, the old process's exit handler
-    // would null out session.claudeProcess (which now points to the NEW
-    // process), orphaning it and triggering an unwanted auto-restart cycle.
-    if (session.claudeProcess && session.claudeProcess !== exitedProcess) {
-      console.log(`[restart] Ignoring exit from stale process for session ${sessionId}`)
-      return
-    }
-    session.claudeProcess = null
-    session.isProcessing = false
-    session.planManager.reset()
-    this._globalBroadcast?.({ type: 'sessions_updated' })
-
-    // "Session ID is already in use" means another process holds the lock.
-    // Retrying with the same session ID will fail every time, so treat this
-    // as a non-restartable exit (same as stopped-by-user).
-    const sessionConflict = exitedProcess.hasSessionConflict()
-
-    // If the process exited without ever producing stdout output, --resume
-    // hung on a broken/stale session. Clear claudeSessionId so the next
-    // restart attempt uses a fresh session instead of retrying the same
-    // broken resume — which would just hang again.
-    // Exception: if spawn() itself failed (ENOENT/EACCES), the process never
-    // started — the session data on disk is fine, so preserve the ID for retry.
-    if (!exitedProcess.hadOutput() && session.claudeSessionId && !exitedProcess.hasSpawnFailed()) {
-      console.warn(`[restart] Session ${sessionId} produced no output before exit — clearing claudeSessionId to force fresh session`)
-      session.claudeSessionId = null
-    }
-    if (exitedProcess.hasSpawnFailed()) {
-      console.warn(`[restart] Session ${sessionId} spawn failed (binary not found) — preserving claudeSessionId for retry`)
-    }
-
-    // Before evaluating restart, check if the working directory still exists.
-    // If a worktree was deleted mid-session, fall back to the original repo
-    // instead of entering a guaranteed restart death loop where every attempt
-    // fails with the same missing CWD.
-    if (!existsSync(session.workingDir)) {
-      const fallback = session.groupDir
-      if (fallback && existsSync(fallback)) {
-        const deadPath = session.workingDir
-        console.warn(`[restart] Working directory ${deadPath} no longer exists — falling back to ${fallback}`)
-        session.workingDir = fallback
-        session.worktreePath = undefined
-        this.persistToDisk()
-        this._globalBroadcast?.({ type: 'sessions_updated' })
-        const fallbackMsg: WsServerMessage = {
-          type: 'system_message',
-          subtype: 'notification',
-          text: `Worktree directory ${deadPath} was removed. Restarting in original repository: ${fallback}`,
-        }
-        this.addToHistory(session, fallbackMsg)
-        this.broadcast(session, fallbackMsg)
-      } else {
-        // No fallback available — don't waste restart attempts
-        console.error(`[restart] Working directory ${session.workingDir} does not exist and no fallback — stopping session`)
-        session._stoppedByUser = true
-        for (const listener of this._exitListeners) {
-          try { listener(sessionId, code, signal, false) } catch { /* listener error */ }
-        }
-        const msg: WsServerMessage = {
-          type: 'system_message',
-          subtype: 'error',
-          text: `Working directory ${session.workingDir} no longer exists and no fallback is available. Please delete this session and create a new one.`,
-        }
-        this.addToHistory(session, msg)
-        this.broadcast(session, msg)
-        this.broadcast(session, { type: 'exit', code: code ?? -1, signal })
-        return
-      }
-    }
-
-    const action = evaluateRestart({
-      restartCount: session.restartCount,
-      lastRestartAt: session.lastRestartAt,
-      stoppedByUser: session._stoppedByUser || sessionConflict,
-    })
-
-    if (action.kind === 'stopped_by_user') {
-      for (const listener of this._exitListeners) {
-        try { listener(sessionId, code, signal, false) } catch { /* listener error */ }
-      }
-      const text = sessionConflict
-        ? 'Claude process exited: session ID is already in use by another process. Please restart manually.'
-        : `Claude process exited: code=${code}, signal=${signal}`
-      const msg: WsServerMessage = { type: 'system_message', subtype: 'exit', text }
-      this.addToHistory(session, msg)
-      this.broadcast(session, msg)
-      this.broadcast(session, { type: 'exit', code: code ?? -1, signal })
-      return
-    }
-
-    if (action.kind === 'restart') {
-      session.restartCount = action.updatedCount
-      session.lastRestartAt = action.updatedLastRestartAt
-
-      for (const listener of this._exitListeners) {
-        try { listener(sessionId, code, signal, true) } catch { /* listener error */ }
-      }
-
-      const msg: WsServerMessage = {
-        type: 'system_message',
-        subtype: 'restart',
-        text: `Claude process exited unexpectedly (code=${code}, signal=${signal}). Restarting (attempt ${action.attempt}/${action.maxAttempts})...`,
-      }
-      this.addToHistory(session, msg)
-      this.broadcast(session, msg)
-
-      // Clear any previously scheduled restart to prevent duplicate spawns
-      if (session._restartTimer) clearTimeout(session._restartTimer)
-      session._restartTimer = setTimeout(() => {
-        session._restartTimer = undefined
-        // Verify session still exists and hasn't been stopped
-        if (!this.sessions.has(sessionId) || session._stoppedByUser) return
-        // startClaude uses --resume when claudeSessionId exists, so the CLI
-        // picks up the full conversation history from the JSONL automatically.
-        this.startClaude(sessionId)
-
-        // Fallback: if claudeSessionId was already null (fresh session that
-        // crashed before system_init), inject a context summary so the new
-        // session has some awareness of prior conversation.
-        if (!session.claudeSessionId && session.claudeProcess && session.outputHistory.length > 0) {
-          session.claudeProcess.once('system_init', () => {
-            const context = this.buildSessionContext(session)
-            if (context) {
-              session.claudeProcess?.sendMessage(
-                context + '\n\n[Session resumed after process restart. Continue where you left off. If you were in the middle of a task, resume it.]',
-              )
-            }
-          })
-        }
-      }, action.delayMs)
-      return
-    }
-
-    // action.kind === 'exhausted'
-    for (const listener of this._exitListeners) {
-      try { listener(sessionId, code, signal, false) } catch { /* listener error */ }
-    }
-    const msg: WsServerMessage = {
-      type: 'system_message',
-      subtype: 'error',
-      text: `Claude process exited unexpectedly (code=${code}, signal=${signal}). Auto-restart disabled after ${action.maxAttempts} attempts. Please restart manually.`,
-    }
-    this.addToHistory(session, msg)
-    this.broadcast(session, msg)
-    this.broadcast(session, { type: 'exit', code: code ?? -1, signal })
+  /** Handle Claude process exit. Delegates to SessionLifecycle. @internal — used by tests. */
+  handleClaudeExit(...args: Parameters<SessionLifecycle['handleClaudeExit']>): void {
+    this.sessionLifecycle.handleClaudeExit(...args)
   }
 
   /**
@@ -1477,43 +1205,17 @@ export class SessionManager {
     return true
   }
 
+  /** Stop the Claude process for a session. Delegates to SessionLifecycle. */
   stopClaude(sessionId: string): void {
-    const session = this.sessions.get(sessionId)
-    if (session?.claudeProcess) {
-      session._stoppedByUser = true
-      if (session._apiRetryTimer) clearTimeout(session._apiRetryTimer)
-      if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }
-      session.claudeProcess.removeAllListeners()
-      session.claudeProcess.stop()
-      session.claudeProcess = null
-      this.broadcast(session, { type: 'claude_stopped' })
-    }
+    this.sessionLifecycle.stopClaude(sessionId)
   }
 
   /**
    * Stop the Claude process and wait for it to fully exit before resolving.
-   * This prevents race conditions when restarting with the same session ID
-   * (e.g. during mid-session worktree migration).
+   * Delegates to SessionLifecycle.
    */
   async stopClaudeAndWait(sessionId: string): Promise<void> {
-    const session = this.sessions.get(sessionId)
-    if (!session?.claudeProcess) return
-
-    const cp = session.claudeProcess
-    session._stoppedByUser = true
-    if (session._apiRetryTimer) clearTimeout(session._apiRetryTimer)
-    if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }
-    cp.removeAllListeners()
-    cp.stop()
-    this.broadcast(session, { type: 'claude_stopped' })
-
-    // Wait for the underlying OS process to fully exit BEFORE nulling the
-    // reference.  Previously this was set to null before the await, which
-    // allowed another caller (e.g. move_to_worktree) to call startClaude()
-    // while the old process was still alive — causing concurrent git access
-    // and index corruption.
-    await cp.waitForExit()
-    session.claudeProcess = null
+    return this.sessionLifecycle.stopClaudeAndWait(sessionId)
   }
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Extracts 6 Claude process lifecycle methods (`startClaude`, `waitForReady`, `wireClaudeEvents`, `handleClaudeExit`, `stopClaude`, `stopClaudeAndWait`) from `SessionManager` into a new `SessionLifecycle` class in `server/session-lifecycle.ts`
- `SessionManager` retains thin delegation wrappers so the public API is unchanged
- Follows the same dependency-injection pattern established by `PromptRouter` in PR #303 (Step 1 of this refactoring plan)

## Details
This is Step 2 of the session-manager extraction refactoring plan. The `SessionLifecycle` class receives a `SessionLifecycleDeps` interface that provides access to SessionManager state and callbacks (broadcast, addToHistory, event handlers, etc.) — the same pattern used by `PromptRouter`.

No behavior changes — pure code extraction refactor. All 1351 existing tests pass.

## Test plan
- [x] All existing tests pass (`npm test` — 1351/1351)
- [x] TypeScript build passes (`tsc -b`)
- [x] Production build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)