### PR TITLE
fix: address three security audit findings (M1, M2, W-2/L4)

### DIFF
--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -176,7 +176,7 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> {
     // inherited from the shell that launched it. In particular,
     // GIT_INDEX_FILE=.git/index breaks worktrees where .git is a file,
     // not a directory, causing all index-dependent git commands to fail.
-    const API_KEY_VARS = new Set(['ANTHROPIC_API_KEY', 'CLAUDE_CODE_API_KEY'])
+    const API_KEY_VARS = new Set(['ANTHROPIC_API_KEY', 'CLAUDE_CODE_API_KEY', 'AUTH_TOKEN', 'AUTH_TOKEN_FILE'])
     const env: Record<string, string> = {
       ...Object.fromEntries(
         Object.entries(process.env).filter(

--- a/server/config.ts
+++ b/server/config.ts
@@ -28,7 +28,8 @@ if (process.env.NODE_ENV === 'production' && !process.env.CORS_ORIGIN) {
   process.exit(1)
 }
 if (process.env.NODE_ENV === 'production' && CORS_ORIGIN.includes('localhost')) {
-  console.warn('[config] WARNING: CORS_ORIGIN contains "localhost" in production mode. This is likely misconfigured.')
+  console.error('[config] ERROR: CORS_ORIGIN contains "localhost" in production mode. This is likely misconfigured.')
+  process.exit(1)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useRef, useCallback, useState } from 'react'
 import Markdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
+import DOMPurify from 'dompurify'
 import hljs from '../lib/hljs'
 import { IconArrowDown, IconRobotFace } from '@tabler/icons-react'
 import type { ChatMessage } from '../types'
@@ -181,7 +182,7 @@ function AssistantMessage({ msg, fontSize, variant = 'default', repeatCount }: {
                         padding: '1em',
                         overflowX: 'auto',
                       }}
-                      dangerouslySetInnerHTML={{ __html: highlightCode(codeString, match[1]) }}
+                      dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(highlightCode(codeString, match[1])) }}
                     />
                     <CodeCopyButton code={codeString} />
                   </div>


### PR DESCRIPTION
## Summary

Three targeted fixes from the 2026-04-09 security audit:

- **M1 — XSS via highlightCode**: `ChatView.tsx` passed `highlightCode()` output directly to `dangerouslySetInnerHTML` without sanitization. Now wrapped with `DOMPurify.sanitize()`, matching the existing pattern in `MarkdownRenderer.tsx`.
- **M2 — CORS localhost in production**: `config.ts` only logged a warning when `CORS_ORIGIN` contained "localhost" in production. Escalated to `console.error` + `process.exit(1)`, matching the existing guard for unset `CORS_ORIGIN`.
- **W-2/L4 — AUTH_TOKEN leaks to child processes**: `claude-process.ts` spread `process.env` into child Claude CLI processes, including `AUTH_TOKEN` and `AUTH_TOKEN_FILE`. Added both to the exclusion set alongside the existing API key vars. The session-scoped `CODEKIN_AUTH_TOKEN` (passed via `extraEnv`) is unaffected.

## Test plan

- [x] All 1351 existing tests pass
- [x] Build succeeds with no type errors
- [ ] Verify DOMPurify sanitizes code blocks in ChatView (manual)
- [ ] Verify production startup aborts with localhost CORS_ORIGIN
- [ ] Verify spawned Claude CLI processes do not inherit AUTH_TOKEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)