### PR TITLE
chore: housekeeping cleanup 2026-04-09

### DIFF
--- a/docs/INSTALL-DISTRIBUTION.md
+++ b/docs/INSTALL-DISTRIBUTION.md
@@ -138,7 +138,7 @@ All configuration is via environment variables. Defaults suit a local install; o
 | `FRONTEND_DIST` | (set by CLI) | Path to built frontend `dist/` directory |
 | `REPOS_ROOT` | `~/repos` | Root directory scanned for local repositories |
 | `DATA_DIR` | `~/.codekin` | Codekin data directory (sessions, uploads, etc.) |
-| `CORS_ORIGIN` | `*` | Restrict CORS for remote access |
+| `CORS_ORIGIN` | `http://localhost:5173` | Restrict CORS for remote access |
 | `GH_ORG` | — | Comma-separated GitHub orgs for repo listing |
 | `SCREENSHOTS_DIR` | `~/.codekin/screenshots` | Directory for uploaded file storage |
 

--- a/server/orchestrator-reports.ts
+++ b/server/orchestrator-reports.ts
@@ -97,18 +97,6 @@ export function scanRepoReports(repoPath: string): ReportMeta[] {
 }
 
 /**
- * Scan multiple repos for reports.
- */
-export function scanAllReports(repoPaths: string[]): ReportMeta[] {
-  const all: ReportMeta[] = []
-  for (const repoPath of repoPaths) {
-    all.push(...scanRepoReports(repoPath))
-  }
-  all.sort((a, b) => b.date.localeCompare(a.date))
-  return all
-}
-
-/**
  * Read a report's full content.
  */
 export function readReport(filePath: string): ReportContent | null {
@@ -158,5 +146,10 @@ export function getLatestReport(repoPath: string, category: string): ReportMeta 
  * Get reports that are newer than a given date.
  */
 export function getReportsSince(repoPaths: string[], sinceDate: string): ReportMeta[] {
-  return scanAllReports(repoPaths).filter(r => r.date >= sinceDate)
+  const all: ReportMeta[] = []
+  for (const repoPath of repoPaths) {
+    all.push(...scanRepoReports(repoPath))
+  }
+  all.sort((a, b) => b.date.localeCompare(a.date))
+  return all.filter(r => r.date >= sinceDate)
 }

--- a/src/lib/ccApi.ts
+++ b/src/lib/ccApi.ts
@@ -143,15 +143,6 @@ export async function deleteSession(token: string, sessionId: string): Promise<v
   if (!res.ok) throw new Error(`Failed to delete session: ${res.status}`)
 }
 
-/** Get the orchestrator session status. */
-export async function getOrchestratorStatus(token: string): Promise<{ sessionId: string | null; status: string; agentName?: string }> {
-  const res = await authFetch(`${BASE}/api/orchestrator/status`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error(`Failed to get orchestrator status: ${res.status}`)
-  return res.json()
-}
-
 /** Ensure the orchestrator session is running and return its session ID. */
 export async function startOrchestrator(token: string): Promise<{ sessionId: string; status: string; agentName?: string }> {
   const res = await authFetch(`${BASE}/api/orchestrator/start`, {
@@ -159,81 +150,6 @@ export async function startOrchestrator(token: string): Promise<{ sessionId: str
     headers: headers(token),
   })
   if (!res.ok) throw new Error(`Failed to start orchestrator: ${res.status}`)
-  return res.json()
-}
-
-/** Get reports for a repo or since a date. */
-export async function getOrchestratorReports(token: string, opts: { repo?: string; since?: string }): Promise<{ reports: unknown[] }> {
-  const params = new URLSearchParams()
-  if (opts.repo) params.set('repo', opts.repo)
-  if (opts.since) params.set('since', opts.since)
-  const res = await authFetch(`${BASE}/api/orchestrator/reports?${params}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error(`Failed to get reports: ${res.status}`)
-  return res.json()
-}
-
-/** List Orchestrator child sessions. */
-export async function getOrchestratorChildren(token: string): Promise<{ children: unknown[] }> {
-  const res = await authFetch(`${BASE}/api/orchestrator/children`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error(`Failed to get children: ${res.status}`)
-  return res.json()
-}
-
-/** Spawn an orchestrator child session. */
-export async function spawnOrchestratorChild(token: string, request: {
-  repo: string; task: string; branchName: string;
-  completionPolicy?: string; deployAfter?: boolean; useWorktree?: boolean;
-}): Promise<{ child: unknown }> {
-  const res = await authFetch(`${BASE}/api/orchestrator/children`, {
-    method: 'POST',
-    headers: headers(token),
-    body: JSON.stringify(request),
-  })
-  if (!res.ok) throw new Error(`Failed to spawn child: ${res.status}`)
-  return res.json()
-}
-
-/** Query orchestrator memory. */
-export async function queryOrchestratorMemory(token: string, opts?: { q?: string; type?: string; limit?: number }): Promise<{ items: unknown[] }> {
-  const params = new URLSearchParams()
-  if (opts?.q) params.set('q', opts.q)
-  if (opts?.type) params.set('type', opts.type)
-  if (opts?.limit) params.set('limit', String(opts.limit))
-  const res = await authFetch(`${BASE}/api/orchestrator/memory?${params}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error(`Failed to query memory: ${res.status}`)
-  return res.json()
-}
-
-/** Get orchestrator trust records. */
-export async function getOrchestratorTrust(token: string): Promise<{ records: unknown[] }> {
-  const res = await authFetch(`${BASE}/api/orchestrator/trust`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error(`Failed to get trust records: ${res.status}`)
-  return res.json()
-}
-
-/** Get orchestrator dashboard stats. */
-export async function getOrchestratorDashboard(token: string): Promise<{ stats: Record<string, number> }> {
-  const res = await authFetch(`${BASE}/api/orchestrator/dashboard`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error(`Failed to get dashboard: ${res.status}`)
-  return res.json()
-}
-
-/** Get orchestrator notifications. */
-export async function getOrchestratorNotifications(token: string, all = false): Promise<{ notifications: unknown[] }> {
-  const res = await authFetch(`${BASE}/api/orchestrator/notifications?all=${all}`, {
-    headers: { Authorization: `Bearer ${token}` },
-  })
-  if (!res.ok) throw new Error(`Failed to get notifications: ${res.status}`)
   return res.json()
 }
 

--- a/src/lib/workflowHelpers.ts
+++ b/src/lib/workflowHelpers.ts
@@ -59,9 +59,6 @@ export const DAY_INDIVIDUAL = [
   { label: 'Sun', dow: '0' },
 ]
 
-/** Combined list of all day-of-week options (presets + individual days) for the schedule picker. */
-export const DAY_PATTERNS = [...DAY_PRESETS, ...DAY_INDIVIDUAL]
-
 /** Check if a dow value represents a bi-weekly schedule (e.g. `"biweekly"` or `"biweekly-1"`). */
 export function isBiweeklyDow(dow: string): boolean {
   return dow.startsWith('biweekly')


### PR DESCRIPTION
## Summary

- Remove 8 unused orchestrator client API functions from `src/lib/ccApi.ts` (~84 lines): `getOrchestratorStatus`, `getOrchestratorReports`, `getOrchestratorChildren`, `spawnOrchestratorChild`, `queryOrchestratorMemory`, `getOrchestratorTrust`, `getOrchestratorDashboard`, `getOrchestratorNotifications`
- Remove unused `scanAllReports` from `server/orchestrator-reports.ts` (inlined into `getReportsSince`)
- Remove unused `DAY_PATTERNS` export from `src/lib/workflowHelpers.ts`
- Fix `CORS_ORIGIN` default in `docs/INSTALL-DISTRIBUTION.md` from `*` to `http://localhost:5173` to match `server/config.ts`

### Items from report not actioned

- **9 stale remote branches**: Already deleted (no longer exist on remote)
- **`src/types.ts` orchestrator types**: The listed types (`ChildSessionRequest`, `ChildStatus`, `ChildSession`, `TrustLevel`, `TrustRecord`, `MemoryCandidate`, `SkillLevel`, `DecisionRecord`) do not exist in `src/types.ts` — they live in server files where they are actively used
- **`commit-event-hooks.ts`**: `installCommitHook` and `uninstallCommitHook` are used by `syncCommitHooks()`, which is imported by `ws-server.ts` and `workflow-routes.ts` — removing them would break the build
- **Lint errors**: 0 errors found (637 warnings only, no errors). PR #309 was not needed.

## Test plan

- [x] All 1351 tests pass
- [x] ESLint: 0 errors
- [x] `startOrchestrator` (used by OrchestratorView) was preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)