### PR TITLE
fix: strip uninformative agent noise from chat

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -157,7 +157,21 @@ function highlightCode(code: string, lang: string): string {
   return code.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
+/** Strip uninformative noise lines the agent emits (e.g. "Ignoring.", "Ignoring — all unmanaged.", "All clear.") */
+const NOISE_RE = /^\s*(Ignoring\b.*|All clear)\.?\s*$/
+function stripNoise(text: string): string {
+  return text
+    .split('\n')
+    .filter((line) => !NOISE_RE.test(line))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim()
+}
+
 function AssistantMessage({ msg, fontSize, variant = 'default', repeatCount }: { msg: ChatMessage & { type: 'assistant' }; fontSize: number; variant?: ChatViewVariant; repeatCount?: number }) {
+  const displayText = stripNoise(msg.text)
+  if (!displayText) return null
+
   return (
     <div className={`px-4 py-2 ${variant === 'orchestrator' ? 'orchestrator-assistant-msg' : ''}`}>
       <div
@@ -211,7 +225,7 @@ function AssistantMessage({ msg, fontSize, variant = 'default', repeatCount }: {
             },
           }}
         >
-          {msg.text}
+          {displayText}
         </Markdown>
         {repeatCount && repeatCount > 1 && (
           <span className="inline-block ml-1 text-[12px] text-neutral-5 bg-neutral-10 rounded-full px-2 py-0.5 align-middle">


### PR DESCRIPTION
## Summary
- Filter out terse "Ignoring.", "Ignoring — all unmanaged.", and "All clear." lines that agents emit between tool calls, which clutter the chat without providing useful info to the user
- If an entire assistant message is noise, it renders nothing instead of an empty bubble
- Regex-based per-line filter in `AssistantMessage` so meaningful content in the same message is preserved

## Test plan
- [ ] Open an agent session and verify "Ignoring" / "All clear" lines no longer appear in chat
- [ ] Verify normal assistant messages with real content still render correctly
- [ ] All 1351 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)