### PR TITLE
fix: respect permission mode for file tool auto-approval

### DIFF
--- a/server/native-permissions.ts
+++ b/server/native-permissions.ts
@@ -119,7 +119,7 @@ export async function removeNativePermission(repoDir: string, permission: string
  * - Read (file tool, pre-approved) → `null`
  */
 export function toNativePermission(toolName: string, toolInput: Record<string, unknown>): string | null {
-  // File tools are pre-approved by permission mode — no need to persist
+  // File tools are handled by permission mode in PromptRouter — no need to persist
   const preApproved = new Set(['Read', 'Write', 'Edit', 'Glob', 'Grep', 'NotebookEdit'])
   if (preApproved.has(toolName)) return null
 

--- a/server/prompt-router.ts
+++ b/server/prompt-router.ts
@@ -271,6 +271,10 @@ export class PromptRouter {
     }
 
     const autoResult = this.resolveAutoApproval(session, toolName, toolInput)
+    if (autoResult === 'permissionMode') {
+      console.log(`[tool-approval] auto-approved (permissionMode=${session.permissionMode}): ${toolName}`)
+      return Promise.resolve({ allow: true, always: false })
+    }
     if (autoResult === 'registry') {
       console.log(`[tool-approval] auto-approved (registry): ${toolName}`)
       return Promise.resolve({ allow: true, always: true })
@@ -590,7 +594,19 @@ export class PromptRouter {
    * by the session's allowedTools list, 'headless' if the session has no clients
    * and is a non-interactive source, or 'prompt' if the user needs to decide.
    */
-  resolveAutoApproval(session: Session, toolName: string, toolInput: Record<string, unknown>): 'registry' | 'session' | 'headless' | 'prompt' {
+  /** Tools that are controlled by permission mode rather than per-tool approval. */
+  private static readonly FILE_TOOLS = new Set(['Read', 'Write', 'Edit', 'Glob', 'Grep', 'NotebookEdit'])
+
+  /** Permission modes that auto-approve file-editing tools. */
+  private static readonly EDIT_MODES = new Set(['acceptEdits', 'bypassPermissions', 'dangerouslySkipPermissions'])
+
+  resolveAutoApproval(session: Session, toolName: string, toolInput: Record<string, unknown>): 'registry' | 'session' | 'headless' | 'permissionMode' | 'prompt' {
+    // File tools are governed by permission mode, not per-tool approval.
+    // The PreToolUse hook intercepts them before Claude's native permission
+    // logic runs, so we must enforce permission mode here.
+    if (PromptRouter.FILE_TOOLS.has(toolName) && PromptRouter.EDIT_MODES.has(session.permissionMode ?? '')) {
+      return 'permissionMode'
+    }
     if (this.deps.approvalManager.checkAutoApproval(session.groupDir ?? session.workingDir, toolName, toolInput)) {
       return 'registry'
     }

--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -3262,6 +3262,49 @@ describe('SessionManager', () => {
     })
   })
 
+  describe('resolveAutoApproval() via permissionMode', () => {
+    it('auto-approves file tools when permissionMode is acceptEdits', async () => {
+      const s = sm.create('perm-edits', '/tmp', { permissionMode: 'acceptEdits' })
+
+      for (const tool of ['Write', 'Edit', 'Read', 'Glob', 'Grep', 'NotebookEdit']) {
+        const result = await sm.requestToolApproval(s.id, tool, { file_path: '/tmp/x' })
+        expect(result).toEqual({ allow: true, always: false })
+      }
+      expect(s.pendingToolApprovals.size).toBe(0)
+    })
+
+    it('auto-approves file tools when permissionMode is bypassPermissions', async () => {
+      const s = sm.create('perm-bypass', '/tmp', { permissionMode: 'bypassPermissions' })
+
+      const result = await sm.requestToolApproval(s.id, 'Write', { file_path: '/tmp/x' })
+      expect(result).toEqual({ allow: true, always: false })
+    })
+
+    it('does not auto-approve file tools when permissionMode is default', async () => {
+      const s = sm.create('perm-default', '/tmp', { permissionMode: 'default' })
+      const ws = fakeWs()
+      sm.join(s.id, ws)
+
+      const promise = sm.requestToolApproval(s.id, 'Write', { file_path: '/tmp/x' })
+      expect(s.pendingToolApprovals.size).toBe(1)
+
+      s.pendingToolApprovals.values().next().value!.resolve({ allow: false, always: false })
+      await promise
+    })
+
+    it('does not auto-approve non-file tools via permissionMode', async () => {
+      const s = sm.create('perm-bash', '/tmp', { permissionMode: 'acceptEdits' })
+      const ws = fakeWs()
+      sm.join(s.id, ws)
+
+      const promise = sm.requestToolApproval(s.id, 'Bash', { command: 'ls' })
+      expect(s.pendingToolApprovals.size).toBe(1)
+
+      s.pendingToolApprovals.values().next().value!.resolve({ allow: false, always: false })
+      await promise
+    })
+  })
+
   describe('createWorktree() with targetBranch', () => {
     afterEach(() => {
       mockExecFile.mockReset()


### PR DESCRIPTION
## Summary

- **Bug**: File tools (Write, Edit, Read, Glob, Grep, NotebookEdit) always prompted for approval even with "Auto accept edits" permission mode, because the PreToolUse hook intercepted them before Claude's native permission logic could auto-approve — and they were intentionally excluded from both the approval registry and `--allowedTools`
- **Fix**: Added permission-mode-aware auto-approval as the first check in `resolveAutoApproval()`, so file tools are auto-approved when the session's permission mode permits it (`acceptEdits`, `bypassPermissions`, `dangerouslySkipPermissions`)
- Added 4 tests covering the new behavior (all file tools approved, bypass mode, default mode still prompts, non-file tools unaffected)

## Test plan

- [x] All 1355 tests pass (4 new)
- [ ] Create session with "Auto accept edits" → verify Write/Edit no longer prompt
- [ ] Create session with "Ask permissions" → verify Write/Edit still prompt
- [ ] Verify Bash commands still prompt in acceptEdits mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)