### PR TITLE
feat: automated PR code review via webhooks

### DIFF
--- a/docs/PR-REVIEW-WEBHOOK.md
+++ b/docs/PR-REVIEW-WEBHOOK.md
@@ -1,0 +1,219 @@
+# PR Review Webhook
+
+Automated pull request code review via GitHub webhooks. When a PR is opened, updated, reopened, or marked ready for review, Codekin spawns a Claude session that reviews the changes and posts findings directly to GitHub. When a PR is closed or merged, Codekin cleans up active sessions and manages the review cache.
+
+## Overview
+
+GitHub sends `pull_request` webhook events to Codekin. The handler filters by action, deduplicates, manages concurrency, creates an isolated workspace, and spawns a Claude session with the PR context and a review prompt.
+
+## Architecture
+
+### Event Flow
+
+1. GitHub sends `pull_request` event (actions: `opened`, `synchronize`, `reopened`, `ready_for_review`, `closed`)
+   _(For `closed` events, steps 2–11 are skipped — see [Closed/Merged Flow](#closedmerged-flow) below)_
+2. `webhook-handler.ts` validates signature, filters by action/draft/allowlist
+3. Dedup check (`webhook-dedup.ts`) — rejects already-processed events
+4. Supersede any active session for the same PR (new push kills old review)
+5. Concurrency cap check (configurable, default 3, set to 10 via `~/.codekin/webhook-config.json`)
+6. Record in dedup only after passing all gates (not before — so rejected events can be retried)
+7. Create isolated workspace via `webhook-workspace.ts` (bare mirror + worktree)
+8. Fetch PR context in parallel: diff, changed files, commits, existing review comments, existing reviews, prior review cache, existing Codekin summary comment
+9. Resolve review prompt: repo-level `.codekin/pr-review-prompt.md` > global `~/.codekin/pr-review-prompt.md` > built-in default
+10. Spawn Claude session with model `sonnet` and restricted `allowedTools` (includes `Write` for cache persistence). Cache directory added via `--add-dir` so Claude can write to it inside the sandbox.
+11. Send assembled prompt (PR metadata + diff + existing reviews + prior cache context + comment update/create instructions + cache-writing instructions)
+
+### Closed/Merged Flow
+
+When a PR is closed (`closed` action), the handler runs synchronously — no workspace or Claude session is needed:
+
+1. Record the event in the event ring buffer for observability
+2. Kill any active review sessions for the PR via `supersedePrSessions`
+3. If **merged**: move cache file to `~/.codekin/pr-cache/{owner}/{repo}/archived/pr-{number}.json`
+4. If **closed** (not merged): delete the cache file
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `server/webhook-handler.ts` | Core dispatcher — `handlePullRequestEvent()` and `processPullRequestAsync()` |
+| `server/webhook-pr-github.ts` | GitHub data fetching — diff, files, commits, review comments, reviews, existing Codekin comment |
+| `server/webhook-pr-prompt.ts` | 3-tier prompt resolution and assembly, cache/comment instructions |
+| `server/webhook-pr-cache.ts` | Per-PR context cache — `loadPrCache()`, `getCachePath()`, `ensureCacheDir()`, `archivePrCache()`, `deletePrCache()`, `PrCacheData` interface |
+| `server/webhook-workspace.ts` | Bare mirror cloning + worktree creation with git auth |
+| `server/webhook-dedup.ts` | Idempotency — split into `isDuplicate()` (check) and `recordProcessed()` (record) |
+| `server/webhook-types.ts` | `PullRequestPayload` (includes `merged` field), `PullRequestContext`, `WebhookEventStatus` types |
+| `server/webhook-config.ts` | Config loading from file + env vars |
+
+### Session Lifecycle
+
+- **Model**: Sonnet (configured in handler, not Opus — cost/speed tradeoff for reviews)
+- **allowedTools**: `Bash(gh:*)`, `Write`, context7 MCP tools, `WebFetch`, `WebSearch` (plus pre-approved file ops from `acceptEdits` mode)
+- **addDirs**: The PR cache directory (`~/.codekin/pr-cache/{owner}/{repo}/`) is passed via `addDirs` through session creation to `ClaudeProcess`, which adds it via `--add-dir` so Claude can write cache files inside the sandbox.
+- **No auto-restore**: Webhook sessions are one-shot. They are NOT restored on server restart (unlike user sessions). This prevents finished reviews from consuming concurrency slots.
+- **Superseding**: When a new push arrives for the same PR, any active review session is marked `superseded` and deleted before the new one starts. Race condition guards check superseded status before workspace creation and session creation.
+
+### Git Authentication
+
+Workspace creation uses `gh repo clone` (handles auth internally), but subsequent `git fetch` commands need explicit credential configuration. Solved with per-process environment variables:
+
+```typescript
+const GIT_AUTH_ENV = {
+  ...process.env,
+  GIT_CONFIG_COUNT: '1',
+  GIT_CONFIG_KEY_0: 'credential.https://github.com.helper',
+  GIT_CONFIG_VALUE_0: '!/usr/bin/gh auth git-credential',
+}
+```
+
+Applied to bare mirror fetch and workspace fetch commands. Does NOT use `gh auth setup-git` (breaks other operations) or SSH (changes Codekin's design).
+
+## Configuration
+
+### Environment Variables
+
+Set in `~/.config/codekin/env` (loaded by systemd service, or source manually):
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `GITHUB_WEBHOOK_ENABLED` | Yes | Set to `true` to enable |
+| `GITHUB_WEBHOOK_SECRET` | Yes | Shared secret for signature verification |
+
+### Config File
+
+`~/.codekin/webhook-config.json`:
+
+```json
+{
+  "maxConcurrentSessions": 10
+}
+```
+
+### Review Prompt
+
+3-tier resolution:
+1. **Repo-level**: `.codekin/pr-review-prompt.md` in the PR's repository
+2. **Global**: `~/.codekin/pr-review-prompt.md`
+3. **Built-in default**: Hardcoded fallback
+
+The global prompt (`~/.codekin/pr-review-prompt.md`) is configured with:
+- Expert council pattern (2-4 reviewers selected by tech stack)
+- Mandatory Codex cross-review step before posting
+- Practical impact filter — findings must pass "would this actually cause a problem?"
+- Signal over noise — no manufactured issues, no academic observations, no premature optimizations
+- Security and scalability as first-class concerns alongside correctness
+- Existing review comment awareness — no duplicate findings
+- Never approve, only COMMENT or REQUEST_CHANGES
+
+## PR Context Cache
+
+Subsequent reviews of the same PR reuse prior context instead of starting from scratch.
+
+### How It Works
+
+Cache location: `~/.codekin/pr-cache/{owner}/{repo}/pr-{number}.json`
+
+```json
+{
+  "prNumber": 42,
+  "repo": "owner/repo",
+  "lastReviewedSha": "abc1234",
+  "timestamp": "2026-04-03T12:00:00.000Z",
+  "priorReviewSummary": "PR adds SSO authentication...",
+  "codebaseContext": "Auth module at src/auth/, uses JWT tokens...",
+  "reviewFindings": "Found null check issue in auth.ts line 42..."
+}
+```
+
+**What gets re-fetched every time:** diff, files, commits, GitHub comments/reviews (cheap, change between pushes).
+
+**What gets cached:** Claude's prior review summary, codebase familiarity notes, and specific findings.
+
+### Cache Lifecycle
+
+1. On first review: no cache exists, prompt has no "Prior Review Context" section.
+2. At end of review: Claude writes the cache JSON via the `Write` tool (instructed in the prompt).
+3. On subsequent reviews (`synchronize`/`reopened`): cache is loaded and included as a "Prior Review Context" section in the prompt, with a note that the current diff and comments are fresh.
+4. Claude uses prior context for faster, more informed review while still reviewing the full current diff.
+5. On PR **merged**: cache file is moved to `archived/` subdirectory (preserves review history).
+6. On PR **closed** (not merged): cache file is deleted (no value in keeping abandoned PR context).
+
+### Resilience
+
+- Missing cache: silently skipped (first review, or Claude failed to write it).
+- Malformed/incomplete JSON: logged as warning, treated as no cache.
+- Stale cache after force-push: `lastReviewedSha` won't match, but cache is supplementary — the fresh diff is authoritative.
+- Concurrent reviews: last writer wins (acceptable since it's the most recent review).
+
+## Update Existing Summary Comment
+
+Instead of posting a new summary comment for every review, Codekin finds and updates its existing comment. Inline code comments are still posted fresh.
+
+### Marker
+
+Every Codekin review summary comment starts with a hidden HTML marker:
+
+```html
+<!-- codekin-review -->
+```
+
+GitHub preserves HTML comments in issue comment bodies, so the marker is invisible to readers but detectable via API.
+
+### How It Works
+
+1. Before the review session starts, `fetchExistingReviewComment()` searches the PR's issue comments (via `gh api /repos/{repo}/issues/{prNumber}/comments --paginate`) for the marker.
+2. If found: the comment ID is passed to Claude with PATCH instructions to update it.
+3. If not found: Claude receives POST instructions to create a new comment.
+4. Both paths include the marker requirement so future reviews can find the comment.
+
+### Shell Escaping
+
+To avoid shell escaping issues with review body content, Claude is instructed to write the comment body to a file within the workspace directory (`${workspacePath}/review-body.md`) and use `gh api ... -F body=@${workspacePath}/review-body.md` rather than passing the body inline via `-f body='...'`. The workspace path is used instead of `/tmp` because the Claude sandbox blocks writes to `/tmp`.
+
+## Dedup Fix
+
+The original `isDuplicate()` was check-and-record in one call. This meant events rejected by the concurrency cap were still recorded as "seen," making redelivery impossible. Now split into:
+
+- `isDuplicate(deliveryId, idempotencyKey)` — check only, no side effects
+- `recordProcessed(deliveryId, idempotencyKey)` — called after the event passes all gates
+
+## Testing
+
+- `server/webhook-handler.test.ts` — 57 tests including PR events, superseding, cache/comment integration, closed/merged handling
+- `server/webhook-pr-github.test.ts` — 22 tests for all fetch functions (diff, files, commits, review comments, reviews, existing review comment detection)
+- `server/webhook-pr-prompt.test.ts` — 26 tests including prompt resolution, prior context rendering, cache-writing instructions, comment update/create instructions
+- `server/webhook-pr-cache.test.ts` — 15 tests for cache loading, path generation, validation, error handling, archive, and delete
+- `server/webhook-dedup.test.ts` — 26 tests for dedup check/record split, TTL eviction, max entries, disk persistence
+
+Run: `npm test`
+
+## Operational Notes
+
+### Starting the Server
+
+```bash
+cd ~/repos/codekin
+npm run build
+set -a; source ~/.config/codekin/env; set +a
+stdbuf -oL -eL node server/dist/ws-server.js > /tmp/codekin.log 2>&1 &
+```
+
+### Clearing Dedup
+
+Stop the server first (it flushes on shutdown), then:
+
+```bash
+echo '{"byDeliveryId":{},"byIdempotencyKey":{}}' > ~/.codekin/webhook-dedup.json
+```
+
+### Monitoring
+
+```bash
+tail -f /tmp/codekin.log | grep webhook
+```
+
+## Known Limitations
+
+- **Codekin permission delegation**: The Claude CLI rejects tools not in `--allowedTools` before any hook fires. Codekin can't show approval prompts for these tools. Workaround: add needed tools to `allowedTools` at spawn time.
+- **MCP tools in webhook sessions**: context7 tools must be in `allowedTools` to work. Added explicitly.
+- **Codex cross-review**: Requires `codex` CLI installed. Uses input redirection (`< file`) not pipes (Codekin's bash doesn't support pipes).

--- a/server/webhook-dedup.ts
+++ b/server/webhook-dedup.ts
@@ -26,6 +26,20 @@ export function computeIdempotencyKey(
   return crypto.createHash('sha256').update(parts.join('|')).digest('hex')
 }
 
+/**
+ * Computes the idempotency key for a pull_request webhook event.
+ * sha256(repo + 'pull_request' + pr_number + action + head_sha)
+ */
+export function computePrIdempotencyKey(
+  repo: string,
+  prNumber: number,
+  action: string,
+  headSha: string,
+): string {
+  const parts = [repo, 'pull_request', String(prNumber), action, headSha]
+  return crypto.createHash('sha256').update(parts.join('|')).digest('hex')
+}
+
 export class WebhookDedup {
   // Two lookup maps for the same data — either key can match
   private byDeliveryId = new Map<string, DedupEntry>()
@@ -61,6 +75,21 @@ export class WebhookDedup {
     this.enforceMaxEntries()
 
     return false
+  }
+
+  /**
+   * Record an event as processed without the isDuplicate check.
+   * Used when the event has already passed dedup but we want to mark
+   * its idempotency key as seen (e.g. after async processing starts).
+   */
+  recordProcessed(deliveryId: string, idempotencyKey: string): void {
+    const entry: DedupEntry = {
+      processedAt: new Date().toISOString(),
+      eventId: deliveryId || idempotencyKey.slice(0, 12),
+    }
+    if (deliveryId) this.byDeliveryId.set(deliveryId, entry)
+    this.byIdempotencyKey.set(idempotencyKey, entry)
+    this.enforceMaxEntries()
   }
 
   private evictExpired(): void {

--- a/server/webhook-handler.test.ts
+++ b/server/webhook-handler.test.ts
@@ -12,10 +12,12 @@ vi.mock('./webhook-dedup.js', () => {
     isDuplicate = mockIsDuplicate
     shutdown = mockDedupShutdown
     flushToDisk = vi.fn()
+    recordProcessed = vi.fn()
   }
   return {
     WebhookDedup: MockWebhookDedup,
     computeIdempotencyKey: vi.fn(() => 'mock-idempotency-key'),
+    computePrIdempotencyKey: vi.fn(() => 'mock-pr-idempotency-key'),
   }
 })
 
@@ -30,6 +32,26 @@ vi.mock('./webhook-github.js', () => ({
 
 vi.mock('./webhook-prompt.js', () => ({
   buildPrompt: vi.fn(() => 'test prompt'),
+}))
+
+vi.mock('./webhook-pr-github.js', () => ({
+  fetchPrDiff: vi.fn(async () => ({ diff: 'diff content', truncated: false })),
+  fetchPrFiles: vi.fn(async () => 'file1.ts'),
+  fetchPrCommits: vi.fn(async () => 'commit 1'),
+  fetchPrReviewComments: vi.fn(async () => ''),
+  fetchPrReviews: vi.fn(async () => ''),
+  fetchExistingReviewComment: vi.fn(async () => undefined),
+}))
+
+vi.mock('./webhook-pr-prompt.js', () => ({
+  buildPrReviewPrompt: vi.fn(() => 'test pr review prompt'),
+}))
+
+vi.mock('./webhook-pr-cache.js', () => ({
+  loadPrCache: vi.fn(async () => null),
+  ensureCacheDir: vi.fn(async () => {}),
+  archivePrCache: vi.fn(async () => {}),
+  deletePrCache: vi.fn(async () => {}),
 }))
 
 vi.mock('./webhook-workspace.js', () => ({
@@ -65,6 +87,9 @@ function fakeSessionManager() {
     broadcast: vi.fn(),
     sendInput: vi.fn(),
     onSessionExit: vi.fn((cb: ExitCallback) => { exitCallbacks.push(cb) }),
+    onSessionResult: vi.fn(() => () => {}),
+    stopClaude: vi.fn(),
+    delete: vi.fn(),
     _exitCallbacks: exitCallbacks,
   } as unknown as ReturnType<typeof fakeSessionManager>
 }

--- a/server/webhook-handler.ts
+++ b/server/webhook-handler.ts
@@ -1,9 +1,9 @@
 /**
- * GitHub webhook handler for automated CI failure triage.
+ * GitHub webhook handler for automated CI failure triage and PR code review.
  *
- * Processes incoming `workflow_run` webhook events and, for completed+failed
- * runs, spawns a Claude session that receives a structured prompt with logs,
- * job info, annotations, and commit context.
+ * Processes incoming webhook events:
+ *   - `workflow_run` (completed+failed) → spawns Claude session for CI diagnosis
+ *   - `pull_request` (opened/synchronize/reopened/ready_for_review) → spawns Claude session for code review
  *
  * Event lifecycle / state machine:
  *   received → (filtered/duplicate/capped)
@@ -21,10 +21,13 @@ import { randomUUID } from 'crypto'
 import type { SessionManager } from './session-manager.js'
 import { verifyHmacSignature } from './crypto-utils.js'
 import type { WsServerMessage } from './types.js'
-import type { WebhookConfig, WebhookEvent, WebhookEventStatus, WorkflowRunPayload, FailureContext } from './webhook-types.js'
+import type { WebhookConfig, WebhookEvent, WebhookEventStatus, WorkflowRunPayload, FailureContext, PullRequestPayload, PullRequestContext } from './webhook-types.js'
 import type { FullWebhookConfig } from './webhook-config.js'
-import { WebhookDedup, computeIdempotencyKey } from './webhook-dedup.js'
+import { WebhookDedup, computeIdempotencyKey, computePrIdempotencyKey } from './webhook-dedup.js'
 import { checkGhHealth, fetchFailedLogs, fetchJobs, fetchAnnotations, fetchCommitMessage, fetchPRTitle } from './webhook-github.js'
+import { fetchPrDiff, fetchPrFiles, fetchPrCommits, fetchPrReviewComments, fetchPrReviews, fetchExistingReviewComment } from './webhook-pr-github.js'
+import { buildPrReviewPrompt } from './webhook-pr-prompt.js'
+import { loadPrCache, ensureCacheDir, archivePrCache, deletePrCache } from './webhook-pr-cache.js'
 import { buildPrompt } from './webhook-prompt.js'
 import { createWorkspace, cleanupWorkspace } from './webhook-workspace.js'
 import { WebhookHandlerBase } from './webhook-handler-base.js'
@@ -32,6 +35,9 @@ import { REPOS_ROOT } from './config.js'
 
 /** How long an event can stay in 'processing' before the watchdog marks it as error. */
 const PROCESSING_TIMEOUT_MS = 5 * 60 * 1000
+
+/** Supported pull_request actions for code review. */
+const PR_REVIEW_ACTIONS = ['opened', 'synchronize', 'reopened', 'ready_for_review'] as const
 
 export class WebhookHandler extends WebhookHandlerBase<WebhookEvent, WebhookEventStatus> {
   private config: FullWebhookConfig
@@ -64,6 +70,34 @@ export class WebhookHandler extends WebhookHandlerBase<WebhookEvent, WebhookEven
         cleanupWorkspace(sessionId)
       }
     })
+
+    // Auto-kill PR review sessions after Claude completes its turn so they don't
+    // sit idle waiting for more input and consume memory indefinitely.
+    sessions.onSessionResult((sessionId, isError) => {
+      if (isError) return
+
+      const event = this.getEvents().find(
+        e => e.sessionId === sessionId && (e.status === 'session_created' || e.status === 'processing'),
+      )
+      if (!event) return
+
+      this.updateEventStatus(event.id, 'completed')
+      console.log(`[webhook] Session ${sessionId} completed review, scheduling cleanup`)
+
+      this.sessions.stopClaude(sessionId) // suppress auto-restart
+      setTimeout(() => {
+        this.sessions.delete(sessionId)
+      }, 2000)
+    })
+  }
+
+  /**
+   * Check if we are at the session cap (for reuse across event types).
+   */
+  private isAtSessionCap(): boolean {
+    const activeWebhookSessions = this.sessions.list().filter(s => s.source === 'webhook' && s.active).length
+    const processingEvents = this.countByStatus('processing')
+    return (activeWebhookSessions + processingEvents) >= this.config.maxConcurrentSessions
   }
 
   /**
@@ -131,23 +165,37 @@ export class WebhookHandler extends WebhookHandlerBase<WebhookEvent, WebhookEven
       return { statusCode: 401, body: { error: 'Invalid signature' } }
     }
 
-    // --- Parse payload ---
-    let payload: WorkflowRunPayload
+    // --- Parse payload (generic parse, dispatch by event type) ---
+    let payload: unknown
     try {
-      payload = JSON.parse(rawBody.toString('utf-8')) as WorkflowRunPayload
+      payload = JSON.parse(rawBody.toString('utf-8'))
     } catch {
       return { statusCode: 400, body: { error: 'Malformed JSON payload' } }
     }
 
-    // --- Event type filter (Phase 1: workflow_run only) ---
-    if (headers.event !== 'workflow_run') {
-      return {
-        statusCode: 200,
-        body: { accepted: false, eventId, status: 'filtered', filterReason: `Event type '${headers.event}' not supported (Phase 1: workflow_run only)` },
-      }
+    // --- Event type dispatch ---
+    switch (headers.event) {
+      case 'workflow_run':
+        return this.handleWorkflowRunEvent(payload as WorkflowRunPayload, eventId, headers)
+      case 'pull_request':
+        return this.handlePullRequestEvent(payload as PullRequestPayload, eventId, headers)
+      default:
+        return {
+          statusCode: 200,
+          body: { accepted: false, eventId, status: 'filtered', filterReason: `Event type '${headers.event}' not supported` },
+        }
     }
+  }
 
-    // --- Action + conclusion filter ---
+  // ---------------------------------------------------------------------------
+  // workflow_run handling (existing logic, extracted into its own method)
+  // ---------------------------------------------------------------------------
+
+  private async handleWorkflowRunEvent(
+    payload: WorkflowRunPayload,
+    eventId: string,
+    headers: { event: string; delivery: string; signature: string },
+  ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
     const wr = payload.workflow_run
     if (!wr) {
       return { statusCode: 400, body: { error: 'Missing workflow_run in payload' } }
@@ -211,13 +259,7 @@ export class WebhookHandler extends WebhookHandlerBase<WebhookEvent, WebhookEven
     }
 
     // --- Session cap check ---
-    // Count both active webhook sessions AND events still in 'processing' state
-    // (session not yet created) to prevent concurrent webhooks from bypassing the
-    // cap during the async setup window (gh API calls, workspace cloning, etc.).
-    const activeWebhookSessions = this.sessions.list().filter(s => s.source === 'webhook' && s.active).length
-    const processingEvents = this.countByStatus('processing')
-    const effectiveConcurrency = activeWebhookSessions + processingEvents
-    if (effectiveConcurrency >= this.config.maxConcurrentSessions) {
+    if (this.isAtSessionCap()) {
       this.recordEvent({
         id: eventId,
         idempotencyKey,
@@ -257,6 +299,7 @@ export class WebhookHandler extends WebhookHandlerBase<WebhookEvent, WebhookEven
       sessionId,
     }
     this.recordEvent(webhookEvent)
+    this.dedup.recordProcessed(eventId, idempotencyKey)
 
     // Process asynchronously — don't block the 202 response
     this.processWebhookAsync(payload, webhookEvent, sessionId).catch(err => {
@@ -388,6 +431,259 @@ export class WebhookHandler extends WebhookHandlerBase<WebhookEvent, WebhookEven
         this.sessions.broadcast(session, msg)
       }
     }
+  }
+
+  // ---------------------------------------------------------------------------
+  // pull_request handling (PR code review)
+  // ---------------------------------------------------------------------------
+
+  private async handlePullRequestEvent(
+    payload: PullRequestPayload,
+    eventId: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _headers: { event: string; delivery: string; signature: string },
+  ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+    const pr = payload.pull_request
+    if (!pr) {
+      return { statusCode: 400, body: { error: 'Missing pull_request in payload' } }
+    }
+
+    // --- Closed/merged handling (cleanup, no review) ---
+    if (payload.action === 'closed') {
+      return this.handlePrClosed(payload, eventId)
+    }
+
+    // --- Action filter ---
+    if (!(PR_REVIEW_ACTIONS as readonly string[]).includes(payload.action)) {
+      return {
+        statusCode: 200,
+        body: {
+          accepted: false,
+          eventId,
+          status: 'filtered',
+          filterReason: `PR action '${payload.action}' not supported (only ${PR_REVIEW_ACTIONS.join(', ')})`,
+        },
+      }
+    }
+
+    // --- Draft filter ---
+    if (pr.draft) {
+      return {
+        statusCode: 200,
+        body: { accepted: false, eventId, status: 'filtered', filterReason: 'PR is a draft' },
+      }
+    }
+
+    // --- Actor allowlist ---
+    const actorLower = (payload.sender?.login ?? '').toLowerCase()
+    if (this.config.actorAllowlist.length > 0 && !this.config.actorAllowlist.some(a => a.toLowerCase() === actorLower)) {
+      return {
+        statusCode: 200,
+        body: { accepted: false, eventId, status: 'filtered', filterReason: `Actor '${payload.sender?.login}' not in allowlist` },
+      }
+    }
+
+    // --- Deduplication ---
+    const headSha = pr.head?.sha ?? ''
+    const idempotencyKey = computePrIdempotencyKey(
+      payload.repository.full_name,
+      pr.number,
+      payload.action,
+      headSha,
+    )
+
+    if (this.dedup.isDuplicate(eventId, idempotencyKey)) {
+      return {
+        statusCode: 200,
+        body: { accepted: false, eventId, status: 'duplicate' },
+      }
+    }
+
+    // --- Session cap ---
+    if (this.isAtSessionCap()) {
+      return {
+        statusCode: 429,
+        body: { error: 'Max concurrent webhook sessions reached', max: this.config.maxConcurrentSessions },
+      }
+    }
+
+    // --- Pre-allocate session ID and respond 202 ---
+    const sessionId = randomUUID()
+    const repo = payload.repository.full_name
+
+    const webhookEvent: WebhookEvent = {
+      id: eventId,
+      idempotencyKey,
+      receivedAt: new Date().toISOString(),
+      event: 'pull_request',
+      action: payload.action,
+      repo,
+      branch: pr.head?.ref ?? 'unknown',
+      workflow: `PR #${pr.number}`,
+      runId: pr.number,
+      runAttempt: 1,
+      conclusion: 'pending',
+      status: 'processing',
+      sessionId,
+    }
+    this.recordEvent(webhookEvent)
+    this.dedup.recordProcessed(eventId, idempotencyKey)
+
+    // Process asynchronously
+    this.processPrReviewAsync(payload, webhookEvent, sessionId).catch(err => {
+      console.error('[webhook] PR review async processing error:', err)
+      this.updateEventStatus(eventId, 'error', String(err))
+    })
+
+    return {
+      statusCode: 202,
+      body: { accepted: true, eventId, status: 'processing', sessionId },
+    }
+  }
+
+  /**
+   * Handle PR closed/merged — archive or delete the review cache and kill any
+   * active review sessions for this PR.
+   */
+  private async handlePrClosed(
+    payload: PullRequestPayload,
+    eventId: string,
+  ): Promise<{ statusCode: number; body: Record<string, unknown> }> {
+    const pr = payload.pull_request
+    const repo = payload.repository.full_name
+    const merged = pr.merged ?? false
+
+    console.log(`[webhook] PR #${pr.number} ${merged ? 'merged' : 'closed'} in ${repo}`)
+
+    // Archive (merged) or delete (closed without merge) the cache
+    try {
+      if (merged) {
+        archivePrCache(repo, pr.number)
+      } else {
+        deletePrCache(repo, pr.number)
+      }
+    } catch (err) {
+      console.warn(`[webhook] Failed to clean up PR cache for ${repo}#${pr.number}:`, err)
+    }
+
+    // Kill any active review sessions for this PR
+    const prLabel = `PR #${pr.number}`
+    const activeEvents = this.getEvents().filter(
+      e => e.repo === repo && e.workflow === prLabel && (e.status === 'processing' || e.status === 'session_created'),
+    )
+    for (const event of activeEvents) {
+      if (event.sessionId) {
+        this.sessions.stopClaude(event.sessionId)
+        setTimeout(() => this.sessions.delete(event.sessionId!), 1000)
+      }
+      this.updateEventStatus(event.id, 'completed')
+    }
+
+    return {
+      statusCode: 200,
+      body: { accepted: true, eventId, status: 'completed', action: merged ? 'archived' : 'deleted' },
+    }
+  }
+
+  /**
+   * Async background processing for PR review: fetch PR context, create workspace,
+   * create session, send review prompt.
+   */
+  private async processPrReviewAsync(
+    payload: PullRequestPayload,
+    event: WebhookEvent,
+    sessionId: string,
+  ): Promise<void> {
+    const pr = payload.pull_request
+    const repo = payload.repository.full_name
+    const repoName = payload.repository.name
+    const prNumber = pr.number
+    const headSha = pr.head?.sha ?? ''
+    const baseRef = pr.base?.ref ?? 'main'
+
+    console.log(`[webhook] Processing PR review: ${repo}#${prNumber} (${pr.title})`)
+
+    // --- Ensure cache dir ---
+    ensureCacheDir(repo, prNumber)
+
+    // --- Load prior review cache ---
+    const priorCache = loadPrCache(repo, prNumber)
+
+    // --- Fetch PR context (all calls degrade gracefully) ---
+    const [diffResult, files, commits, reviewComments, reviews, existingComment] = await Promise.all([
+      fetchPrDiff(repo, prNumber),
+      fetchPrFiles(repo, prNumber),
+      fetchPrCommits(repo, prNumber),
+      fetchPrReviewComments(repo, prNumber),
+      fetchPrReviews(repo, prNumber),
+      fetchExistingReviewComment(repo, prNumber),
+    ])
+
+    const prContext: PullRequestContext = {
+      repo,
+      repoName,
+      prNumber,
+      prTitle: pr.title,
+      prBody: pr.body ?? '',
+      prUrl: pr.html_url ?? '',
+      author: pr.user?.login ?? 'unknown',
+      headBranch: pr.head?.ref ?? 'unknown',
+      baseBranch: baseRef,
+      headSha,
+      baseSha: pr.base?.sha ?? '',
+      beforeSha: payload.before,
+      action: payload.action as PullRequestContext['action'],
+      changedFiles: pr.changed_files ?? 0,
+      additions: pr.additions ?? 0,
+      deletions: pr.deletions ?? 0,
+      diff: diffResult.diff,
+      fileList: files,
+      commitMessages: commits,
+      reviewComments,
+      reviews,
+      existingComment: existingComment != null ? String(existingComment) : null,
+      priorCache: priorCache ?? null,
+    }
+
+    // --- Create workspace ---
+    let workspacePath: string
+    const headRepo = pr.head?.repo?.clone_url ?? payload.repository.clone_url
+    try {
+      workspacePath = await createWorkspace(
+        sessionId,
+        repo,
+        headRepo,
+        pr.head?.ref ?? baseRef,
+        headSha,
+      )
+    } catch (err) {
+      console.error(`[webhook] Failed to create workspace for PR ${repo}#${prNumber}:`, err)
+      this.updateEventStatus(event.id, 'error', `Workspace creation failed: ${err}`)
+      return
+    }
+
+    // --- Create session ---
+    const groupDir = `${REPOS_ROOT}/${repoName}`
+    const sessionName = `review/${repoName}/PR-${prNumber}`
+    this.sessions.create(sessionName, workspacePath, {
+      source: 'webhook',
+      id: sessionId,
+      groupDir,
+      allowedTools: ['Bash(git:*)', 'Bash(gh:*)'],
+    })
+
+    console.log(`[webhook] PR review session created: ${sessionName} (${sessionId})`)
+    this.updateEventStatus(event.id, 'session_created')
+
+    // Broadcast
+    const updatedEvent = this.getEvent(event.id)
+    if (updatedEvent) this.broadcastWebhookEvent(updatedEvent)
+
+    // --- Build and send prompt ---
+    const prompt = buildPrReviewPrompt(prContext, workspacePath)
+    this.sessions.sendInput(sessionId, prompt)
+
+    console.log(`[webhook] PR review prompt sent to session ${sessionId}`)
   }
 
   getConfig(): WebhookConfig {

--- a/server/webhook-pr-cache.test.ts
+++ b/server/webhook-pr-cache.test.ts
@@ -1,0 +1,193 @@
+/** Tests for PR context cache — verifies load/path helpers and graceful degradation. */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { homedir } from 'os'
+import { join } from 'path'
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => ''),
+    mkdirSync: vi.fn(),
+    renameSync: vi.fn(),
+    unlinkSync: vi.fn(),
+  }
+})
+
+import { loadPrCache, getCachePath, ensureCacheDir, archivePrCache, deletePrCache } from './webhook-pr-cache.js'
+import { existsSync, readFileSync, mkdirSync, renameSync, unlinkSync } from 'fs'
+
+function validCacheJson() {
+  return JSON.stringify({
+    prNumber: 42,
+    repo: 'owner/repo',
+    lastReviewedSha: 'abc1234',
+    timestamp: '2026-04-03T12:00:00.000Z',
+    priorReviewSummary: 'Reviewed auth changes',
+    codebaseContext: 'Auth module at src/auth/',
+    reviewFindings: 'Found null check issue in auth.ts',
+  })
+}
+
+describe('getCachePath', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns correct path for owner/repo PR #42', () => {
+    const path = getCachePath('owner/repo', 42)
+    expect(path).toBe(join(homedir(), '.codekin', 'pr-cache', 'owner', 'repo', 'pr-42.json'))
+  })
+
+  it('does not create directories (pure function)', () => {
+    getCachePath('owner/repo', 42)
+    expect(mkdirSync).not.toHaveBeenCalled()
+  })
+
+  it('handles org/name repos correctly', () => {
+    const path = getCachePath('my-org/my-project', 7)
+    expect(path).toBe(join(homedir(), '.codekin', 'pr-cache', 'my-org', 'my-project', 'pr-7.json'))
+  })
+})
+
+describe('ensureCacheDir', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns the same path as getCachePath', () => {
+    const path = ensureCacheDir('owner/repo', 42)
+    expect(path).toBe(getCachePath('owner/repo', 42))
+  })
+
+  it('creates parent directories', () => {
+    ensureCacheDir('owner/repo', 42)
+    expect(mkdirSync).toHaveBeenCalledWith(
+      join(homedir(), '.codekin', 'pr-cache', 'owner', 'repo'),
+      { recursive: true },
+    )
+  })
+})
+
+describe('loadPrCache', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns undefined when file does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    const result = loadPrCache('owner/repo', 42)
+    expect(result).toBeUndefined()
+  })
+
+  it('returns parsed data when valid JSON exists', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(validCacheJson())
+    const result = loadPrCache('owner/repo', 42)
+    expect(result).toBeDefined()
+    expect(result!.prNumber).toBe(42)
+    expect(result!.repo).toBe('owner/repo')
+    expect(result!.lastReviewedSha).toBe('abc1234')
+    expect(result!.priorReviewSummary).toBe('Reviewed auth changes')
+    expect(result!.codebaseContext).toBe('Auth module at src/auth/')
+    expect(result!.reviewFindings).toBe('Found null check issue in auth.ts')
+  })
+
+  it('returns undefined on malformed JSON', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue('not valid json {{{')
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = loadPrCache('owner/repo', 42)
+    expect(result).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('returns undefined on missing required fields', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(JSON.stringify({
+      prNumber: 42,
+      repo: 'owner/repo',
+      // missing other required fields
+    }))
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = loadPrCache('owner/repo', 42)
+    expect(result).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('reads from the correct path', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    vi.mocked(readFileSync).mockReturnValue(validCacheJson())
+    loadPrCache('my-org/project', 99)
+    expect(readFileSync).toHaveBeenCalledWith(
+      join(homedir(), '.codekin', 'pr-cache', 'my-org', 'project', 'pr-99.json'),
+      'utf-8',
+    )
+  })
+})
+
+describe('archivePrCache', () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    vi.mocked(renameSync).mockClear()
+    vi.mocked(mkdirSync).mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('moves cache file to archived directory', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    archivePrCache('owner/repo', 42)
+    expect(mkdirSync).toHaveBeenCalledWith(
+      join(homedir(), '.codekin', 'pr-cache', 'owner', 'repo', 'archived'),
+      { recursive: true },
+    )
+    expect(renameSync).toHaveBeenCalledWith(
+      join(homedir(), '.codekin', 'pr-cache', 'owner', 'repo', 'pr-42.json'),
+      join(homedir(), '.codekin', 'pr-cache', 'owner', 'repo', 'archived', 'pr-42.json'),
+    )
+  })
+
+  it('creates archived directory if missing', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    archivePrCache('owner/repo', 42)
+    expect(mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('archived'),
+      { recursive: true },
+    )
+  })
+
+  it('is a no-op when cache file does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    archivePrCache('owner/repo', 42)
+    expect(renameSync).not.toHaveBeenCalled()
+  })
+})
+
+describe('deletePrCache', () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    vi.mocked(unlinkSync).mockClear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('removes the cache file', () => {
+    vi.mocked(existsSync).mockReturnValue(true)
+    deletePrCache('owner/repo', 42)
+    expect(unlinkSync).toHaveBeenCalledWith(
+      join(homedir(), '.codekin', 'pr-cache', 'owner', 'repo', 'pr-42.json'),
+    )
+  })
+
+  it('is a no-op when cache file does not exist', () => {
+    vi.mocked(existsSync).mockReturnValue(false)
+    deletePrCache('owner/repo', 42)
+    expect(unlinkSync).not.toHaveBeenCalled()
+  })
+})

--- a/server/webhook-pr-cache.ts
+++ b/server/webhook-pr-cache.ts
@@ -1,0 +1,130 @@
+/**
+ * Per-PR context cache for webhook reviews.
+ *
+ * Stores Claude's prior review findings and codebase familiarity notes
+ * so subsequent reviews of the same PR can build on prior context.
+ *
+ * Cache location: ~/.codekin/pr-cache/{owner}/{repo}/pr-{number}.json
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+
+/** Structured finding from a PR review. */
+export interface PrFinding {
+  severity: 'critical' | 'must-fix' | 'suggestion' | 'minor' | 'nitpick'
+  file: string
+  line: number | null
+  description: string
+  status: 'new' | 'open' | 'fixed'
+}
+
+/** Shape of the cached PR review context. */
+export interface PrCacheData {
+  prNumber: number
+  repo: string
+  lastReviewedSha: string
+  timestamp: string
+  priorReviewSummary: string
+  codebaseContext: string
+  reviewFindings: string
+  // Structured review data (added 2026-04-07)
+  verdict?: 'approve' | 'request_changes' | 'comment'
+  structuredFindings?: PrFinding[]
+  // PR metadata snapshot
+  author?: string
+  prTitle?: string
+  changedFiles?: number
+  additions?: number
+  deletions?: number
+}
+
+const REQUIRED_FIELDS: (keyof PrCacheData)[] = [
+  'prNumber', 'repo', 'lastReviewedSha', 'timestamp',
+  'priorReviewSummary', 'codebaseContext', 'reviewFindings',
+]
+
+/**
+ * Return the absolute path for a PR's cache file (pure, no side effects).
+ */
+export function getCachePath(repo: string, prNumber: number): string {
+  const [owner, name] = repo.split('/')
+  return join(homedir(), '.codekin', 'pr-cache', owner, name, `pr-${prNumber}.json`)
+}
+
+/**
+ * Ensure the cache directory exists for a given repo, then return the cache file path.
+ * Use this when the caller intends to write (or instruct Claude to write) the cache file.
+ */
+export function ensureCacheDir(repo: string, prNumber: number): string {
+  const [owner, name] = repo.split('/')
+  const dir = join(homedir(), '.codekin', 'pr-cache', owner, name)
+  mkdirSync(dir, { recursive: true })
+  return join(dir, `pr-${prNumber}.json`)
+}
+
+/**
+ * Load cached review context for a PR.
+ * Returns undefined if the cache doesn't exist, is malformed, or is missing required fields.
+ */
+export function loadPrCache(repo: string, prNumber: number): PrCacheData | undefined {
+  const [owner, name] = repo.split('/')
+  const cachePath = join(homedir(), '.codekin', 'pr-cache', owner, name, `pr-${prNumber}.json`)
+
+  if (!existsSync(cachePath)) return undefined
+
+  try {
+    const raw = readFileSync(cachePath, 'utf-8')
+    const data = JSON.parse(raw) as Record<string, unknown>
+
+    // Validate required fields
+    for (const field of REQUIRED_FIELDS) {
+      if (data[field] === undefined || data[field] === null) {
+        console.warn(`[pr-cache] Cache for ${repo} PR #${prNumber} missing field '${field}', ignoring`)
+        return undefined
+      }
+    }
+
+    return data as unknown as PrCacheData
+  } catch (err) {
+    console.warn(`[pr-cache] Failed to load cache for ${repo} PR #${prNumber}:`, err)
+    return undefined
+  }
+}
+
+/**
+ * Archive a PR's cache file (move to archived/ subdirectory).
+ * Used when a PR is merged. No-op if cache doesn't exist.
+ */
+export function archivePrCache(repo: string, prNumber: number): void {
+  const source = getCachePath(repo, prNumber)
+  if (!existsSync(source)) return
+
+  try {
+    const [owner, name] = repo.split('/')
+    const archivedDir = join(homedir(), '.codekin', 'pr-cache', owner, name, 'archived')
+    mkdirSync(archivedDir, { recursive: true })
+    const dest = join(archivedDir, `pr-${prNumber}.json`)
+    renameSync(source, dest)
+    console.log(`[pr-cache] Archived cache for ${repo} PR #${prNumber}`)
+  } catch (err) {
+    console.warn(`[pr-cache] Failed to archive cache for ${repo} PR #${prNumber}:`, err)
+  }
+}
+
+/**
+ * Delete a PR's cache file.
+ * Used when a PR is closed without merging. No-op if cache doesn't exist.
+ */
+export function deletePrCache(repo: string, prNumber: number): void {
+  const path = getCachePath(repo, prNumber)
+  if (!existsSync(path)) return
+
+  try {
+    unlinkSync(path)
+    console.log(`[pr-cache] Deleted cache for ${repo} PR #${prNumber}`)
+  } catch (err) {
+    console.warn(`[pr-cache] Failed to delete cache for ${repo} PR #${prNumber}:`, err)
+  }
+}

--- a/server/webhook-pr-github.test.ts
+++ b/server/webhook-pr-github.test.ts
@@ -1,0 +1,213 @@
+/** Tests for PR-specific GitHub API helpers — verifies diff/files/commits fetching and graceful degradation. */
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { fetchPrDiff, fetchPrFiles, fetchPrCommits, fetchPrReviewComments, fetchPrReviews, fetchExistingReviewComment, REVIEW_COMMENT_MARKER, _setGhRunner, _resetGhRunner } from './webhook-pr-github.js'
+
+describe('fetchPrDiff', () => {
+  afterEach(() => {
+    _resetGhRunner()
+  })
+
+  it('returns the diff for a PR', async () => {
+    _setGhRunner(async () => 'diff --git a/file.ts\n+added line\n-removed line')
+    const result = await fetchPrDiff('owner/repo', 42)
+    expect(result.diff).toContain('+added line')
+    expect(result.diff).toContain('-removed line')
+    expect(result.truncated).toBe(false)
+  })
+
+  it('truncates diffs larger than 100KB', async () => {
+    const largeDiff = 'x'.repeat(150_000)
+    _setGhRunner(async () => largeDiff)
+    const result = await fetchPrDiff('owner/repo', 42)
+    expect(result.truncated).toBe(true)
+    expect(result.diff.length).toBeLessThan(largeDiff.length)
+    expect(result.diff).toContain('diff truncated')
+  })
+
+  it('returns empty string on error', async () => {
+    _setGhRunner(async () => { throw new Error('network error') })
+    const result = await fetchPrDiff('owner/repo', 42)
+    expect(result.diff).toBe('')
+    expect(result.truncated).toBe(false)
+  })
+
+  it('passes correct API path and Accept header', async () => {
+    let capturedArgs: string[] = []
+    _setGhRunner(async (args) => { capturedArgs = args; return 'some diff' })
+    await fetchPrDiff('owner/repo', 7)
+    expect(capturedArgs).toContain('/repos/owner/repo/pulls/7')
+    expect(capturedArgs).toContain('Accept: application/vnd.github.diff')
+  })
+})
+
+describe('fetchPrFiles', () => {
+  afterEach(() => {
+    _resetGhRunner()
+  })
+
+  it('returns formatted file list', async () => {
+    _setGhRunner(async () => JSON.stringify([
+      { filename: 'src/index.ts', status: 'modified', additions: 10, deletions: 3 },
+      { filename: 'README.md', status: 'added', additions: 5, deletions: 0 },
+    ]))
+    const result = await fetchPrFiles('owner/repo', 42)
+    expect(result).toContain('src/index.ts (modified, +10/-3)')
+    expect(result).toContain('README.md (added, +5/-0)')
+  })
+
+  it('returns empty string for empty file list', async () => {
+    _setGhRunner(async () => '[]')
+    const result = await fetchPrFiles('owner/repo', 42)
+    expect(result).toBe('')
+  })
+
+  it('returns empty string on error', async () => {
+    _setGhRunner(async () => { throw new Error('api error') })
+    const result = await fetchPrFiles('owner/repo', 42)
+    expect(result).toBe('')
+  })
+})
+
+describe('fetchPrCommits', () => {
+  afterEach(() => {
+    _resetGhRunner()
+  })
+
+  it('returns formatted commit list', async () => {
+    _setGhRunner(async () => JSON.stringify([
+      { sha: 'abc1234567890', commit: { message: 'fix: resolve auth bug\n\nMore details here' } },
+      { sha: 'def5678901234', commit: { message: 'test: add coverage' } },
+    ]))
+    const result = await fetchPrCommits('owner/repo', 42)
+    expect(result).toContain('- abc1234: fix: resolve auth bug')
+    expect(result).toContain('- def5678: test: add coverage')
+    // Multi-line commit message should only show first line
+    expect(result).not.toContain('More details here')
+  })
+
+  it('returns empty string for empty commits', async () => {
+    _setGhRunner(async () => '[]')
+    const result = await fetchPrCommits('owner/repo', 42)
+    expect(result).toBe('')
+  })
+
+  it('returns empty string on error', async () => {
+    _setGhRunner(async () => { throw new Error('api error') })
+    const result = await fetchPrCommits('owner/repo', 42)
+    expect(result).toBe('')
+  })
+})
+
+describe('fetchPrReviewComments', () => {
+  afterEach(() => {
+    _resetGhRunner()
+  })
+
+  it('returns formatted inline comments', async () => {
+    _setGhRunner(async () => JSON.stringify([
+      { path: 'src/auth.ts', line: 10, body: 'Fix the null check here', user: { login: 'reviewer1' } },
+      { path: 'src/auth.ts', line: null, body: 'General comment on file', user: { login: 'reviewer2' } },
+    ]))
+    const result = await fetchPrReviewComments('owner/repo', 42)
+    expect(result).toContain('reviewer1 on src/auth.ts:10: Fix the null check here')
+    expect(result).toContain('reviewer2 on src/auth.ts: General comment on file')
+  })
+
+  it('returns empty string for no comments', async () => {
+    _setGhRunner(async () => '[]')
+    const result = await fetchPrReviewComments('owner/repo', 42)
+    expect(result).toBe('')
+  })
+
+  it('returns empty string on error', async () => {
+    _setGhRunner(async () => { throw new Error('api error') })
+    const result = await fetchPrReviewComments('owner/repo', 42)
+    expect(result).toBe('')
+  })
+})
+
+describe('fetchPrReviews', () => {
+  afterEach(() => {
+    _resetGhRunner()
+  })
+
+  it('returns formatted review summaries', async () => {
+    _setGhRunner(async () => JSON.stringify([
+      { state: 'COMMENTED', body: 'Looks good overall', user: { login: 'reviewer1' } },
+      { state: 'CHANGES_REQUESTED', body: 'Needs fixes', user: { login: 'reviewer2' } },
+    ]))
+    const result = await fetchPrReviews('owner/repo', 42)
+    expect(result).toContain('reviewer1 (COMMENTED): Looks good overall')
+    expect(result).toContain('reviewer2 (CHANGES_REQUESTED): Needs fixes')
+  })
+
+  it('filters out PENDING reviews', async () => {
+    _setGhRunner(async () => JSON.stringify([
+      { state: 'PENDING', body: 'Draft', user: { login: 'reviewer1' } },
+      { state: 'APPROVED', body: null, user: { login: 'reviewer2' } },
+    ]))
+    const result = await fetchPrReviews('owner/repo', 42)
+    expect(result).not.toContain('PENDING')
+    expect(result).toContain('reviewer2 (APPROVED): (no summary)')
+  })
+
+  it('returns empty string for no reviews', async () => {
+    _setGhRunner(async () => '[]')
+    const result = await fetchPrReviews('owner/repo', 42)
+    expect(result).toBe('')
+  })
+
+  it('returns empty string on error', async () => {
+    _setGhRunner(async () => { throw new Error('api error') })
+    const result = await fetchPrReviews('owner/repo', 42)
+    expect(result).toBe('')
+  })
+})
+
+describe('fetchExistingReviewComment', () => {
+  afterEach(() => {
+    _resetGhRunner()
+  })
+
+  it('returns comment ID when marker is found', async () => {
+    _setGhRunner(async () => JSON.stringify([
+      { id: 100, body: 'Some other comment' },
+      { id: 200, body: `${REVIEW_COMMENT_MARKER}\n## Review Summary\nLooks good` },
+    ]))
+    const result = await fetchExistingReviewComment('owner/repo', 42)
+    expect(result).toBe(200)
+  })
+
+  it('returns undefined when no marker found', async () => {
+    _setGhRunner(async () => JSON.stringify([
+      { id: 100, body: 'Regular comment' },
+      { id: 200, body: 'Another comment' },
+    ]))
+    const result = await fetchExistingReviewComment('owner/repo', 42)
+    expect(result).toBeUndefined()
+  })
+
+  it('returns the most recent matching comment', async () => {
+    _setGhRunner(async () => JSON.stringify([
+      { id: 100, body: `${REVIEW_COMMENT_MARKER}\nOld review` },
+      { id: 200, body: 'Unrelated comment' },
+      { id: 300, body: `${REVIEW_COMMENT_MARKER}\nNew review` },
+    ]))
+    const result = await fetchExistingReviewComment('owner/repo', 42)
+    expect(result).toBe(300)
+  })
+
+  it('returns undefined on API error', async () => {
+    _setGhRunner(async () => { throw new Error('api error') })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = await fetchExistingReviewComment('owner/repo', 42)
+    expect(result).toBeUndefined()
+    expect(warnSpy).toHaveBeenCalled()
+  })
+
+  it('returns undefined for empty comment list', async () => {
+    _setGhRunner(async () => '[]')
+    const result = await fetchExistingReviewComment('owner/repo', 42)
+    expect(result).toBeUndefined()
+  })
+})

--- a/server/webhook-pr-github.ts
+++ b/server/webhook-pr-github.ts
@@ -1,0 +1,237 @@
+/**
+ * GitHub API helpers for pull request webhook processing.
+ *
+ * All functions delegate to the `gh` CLI and degrade gracefully — errors are
+ * logged as warnings and an empty result is returned so callers can proceed
+ * with partial data.
+ */
+
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+
+const execFileAsync = promisify(execFile)
+const GH_TIMEOUT_MS = 30_000
+
+/** Maximum diff size in bytes before truncation (~100KB). */
+const MAX_DIFF_BYTES = 100_000
+
+type GhRunner = (args: string[]) => Promise<string>
+
+let ghRunner: GhRunner = async (args) => {
+  const { stdout } = await execFileAsync('gh', args, { timeout: GH_TIMEOUT_MS })
+  return stdout
+}
+
+/** @internal Test-only: override the gh CLI runner */
+export function _setGhRunner(runner: GhRunner): void {
+  ghRunner = runner
+}
+
+/** @internal Test-only: reset to default gh CLI runner */
+export function _resetGhRunner(): void {
+  ghRunner = async (args) => {
+    const { stdout } = await execFileAsync('gh', args, { timeout: GH_TIMEOUT_MS })
+    return stdout
+  }
+}
+
+/**
+ * Fetch the unified diff for a pull request.
+ * Truncates to ~100KB with a note if larger.
+ *
+ * @param repo     - GitHub repo in `owner/name` format.
+ * @param prNumber - Pull request number.
+ * @returns The diff text, or empty string on error.
+ */
+export async function fetchPrDiff(repo: string, prNumber: number): Promise<{ diff: string; truncated: boolean }> {
+  try {
+    const output = await ghRunner([
+      'api',
+      `/repos/${repo}/pulls/${prNumber}`,
+      '-H', 'Accept: application/vnd.github.diff',
+    ])
+
+    if (output.length > MAX_DIFF_BYTES) {
+      const truncated = output.slice(0, MAX_DIFF_BYTES)
+      // Cut at last newline to avoid splitting a line
+      const lastNewline = truncated.lastIndexOf('\n')
+      return {
+        diff: (lastNewline > 0 ? truncated.slice(0, lastNewline) : truncated) +
+          `\n\n... (diff truncated — full diff is ${Math.round(output.length / 1024)}KB, showing first ~${Math.round(MAX_DIFF_BYTES / 1024)}KB)`,
+        truncated: true,
+      }
+    }
+
+    return { diff: output, truncated: false }
+  } catch (err) {
+    console.warn(`fetchPrDiff: failed for ${repo} PR #${prNumber}:`, err)
+    return { diff: '', truncated: false }
+  }
+}
+
+/**
+ * Fetch the list of changed files for a pull request with stats.
+ *
+ * @param repo     - GitHub repo in `owner/name` format.
+ * @param prNumber - Pull request number.
+ * @returns Formatted file list, or empty string on error.
+ */
+export async function fetchPrFiles(repo: string, prNumber: number): Promise<string> {
+  try {
+    const raw = await ghRunner([
+      'api',
+      `/repos/${repo}/pulls/${prNumber}/files`,
+      '--paginate',
+    ])
+    const files = JSON.parse(raw) as Array<{
+      filename: string
+      status: string
+      additions: number
+      deletions: number
+    }>
+
+    if (!Array.isArray(files) || files.length === 0) return ''
+
+    return files
+      .map(f => `${f.filename} (${f.status}, +${f.additions}/-${f.deletions})`)
+      .join('\n')
+  } catch (err) {
+    console.warn(`fetchPrFiles: failed for ${repo} PR #${prNumber}:`, err)
+    return ''
+  }
+}
+
+/**
+ * Fetch commit messages for a pull request.
+ *
+ * @param repo     - GitHub repo in `owner/name` format.
+ * @param prNumber - Pull request number.
+ * @returns Formatted commit list, or empty string on error.
+ */
+/**
+ * Fetch existing review comments (inline code comments) for a pull request.
+ *
+ * @param repo     - GitHub repo in `owner/name` format.
+ * @param prNumber - Pull request number.
+ * @returns Formatted comment list, or empty string on error.
+ */
+export async function fetchPrReviewComments(repo: string, prNumber: number): Promise<string> {
+  try {
+    const raw = await ghRunner([
+      'api',
+      `/repos/${repo}/pulls/${prNumber}/comments`,
+      '--paginate',
+    ])
+    const comments = JSON.parse(raw) as Array<{
+      path: string
+      line: number | null
+      body: string
+      user: { login: string }
+    }>
+
+    if (!Array.isArray(comments) || comments.length === 0) return ''
+
+    return comments
+      .map(c => {
+        const location = c.line ? `${c.path}:${c.line}` : c.path
+        return `- ${c.user.login} on ${location}: ${c.body}`
+      })
+      .join('\n')
+  } catch (err) {
+    console.warn(`fetchPrReviewComments: failed for ${repo} PR #${prNumber}:`, err)
+    return ''
+  }
+}
+
+/**
+ * Fetch review summaries (approve/request changes/comment) for a pull request.
+ *
+ * @param repo     - GitHub repo in `owner/name` format.
+ * @param prNumber - Pull request number.
+ * @returns Formatted review list, or empty string on error.
+ */
+export async function fetchPrReviews(repo: string, prNumber: number): Promise<string> {
+  try {
+    const raw = await ghRunner([
+      'api',
+      `/repos/${repo}/pulls/${prNumber}/reviews`,
+      '--paginate',
+    ])
+    const reviews = JSON.parse(raw) as Array<{
+      state: string
+      body: string | null
+      user: { login: string }
+    }>
+
+    if (!Array.isArray(reviews) || reviews.length === 0) return ''
+
+    return reviews
+      .filter(r => r.state !== 'PENDING')
+      .map(r => `- ${r.user.login} (${r.state}): ${r.body || '(no summary)'}`)
+      .join('\n')
+  } catch (err) {
+    console.warn(`fetchPrReviews: failed for ${repo} PR #${prNumber}:`, err)
+    return ''
+  }
+}
+
+/** HTML marker embedded in Codekin review comments for identification. */
+export const REVIEW_COMMENT_MARKER = '<!-- codekin-review -->'
+
+/**
+ * Find an existing Codekin review summary comment on a PR.
+ * Searches issue comments (top-level conversation comments) for the marker.
+ *
+ * @param repo     - GitHub repo in `owner/name` format.
+ * @param prNumber - Pull request number.
+ * @returns The comment ID if found, or undefined.
+ */
+export async function fetchExistingReviewComment(repo: string, prNumber: number): Promise<number | undefined> {
+  try {
+    const raw = await ghRunner([
+      'api',
+      `/repos/${repo}/issues/${prNumber}/comments`,
+      '--paginate',
+    ])
+    const comments = JSON.parse(raw) as Array<{
+      id: number
+      body: string
+    }>
+
+    if (!Array.isArray(comments) || comments.length === 0) return undefined
+
+    // Search in reverse to find the most recent matching comment
+    for (let i = comments.length - 1; i >= 0; i--) {
+      if (comments[i].body.includes(REVIEW_COMMENT_MARKER)) {
+        return comments[i].id
+      }
+    }
+    return undefined
+  } catch (err) {
+    console.warn(`fetchExistingReviewComment: failed for ${repo} PR #${prNumber}:`, err)
+    return undefined
+  }
+}
+
+export async function fetchPrCommits(repo: string, prNumber: number): Promise<string> {
+  try {
+    const raw = await ghRunner([
+      'api',
+      `/repos/${repo}/pulls/${prNumber}/commits`,
+      '--paginate',
+    ])
+    const commits = JSON.parse(raw) as Array<{
+      sha: string
+      commit: { message: string }
+    }>
+
+    if (!Array.isArray(commits) || commits.length === 0) return ''
+
+    return commits
+      .map(c => `- ${c.sha.slice(0, 7)}: ${c.commit.message.split('\n')[0]}`)
+      .join('\n')
+  } catch (err) {
+    console.warn(`fetchPrCommits: failed for ${repo} PR #${prNumber}:`, err)
+    return ''
+  }
+}

--- a/server/webhook-pr-prompt.test.ts
+++ b/server/webhook-pr-prompt.test.ts
@@ -1,0 +1,306 @@
+/** Tests for buildPrReviewPrompt — verifies PR context rendering and custom prompt resolution. */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    existsSync: vi.fn(() => false),
+    readFileSync: vi.fn(() => ''),
+  }
+})
+
+import { buildPrReviewPrompt } from './webhook-pr-prompt.js'
+import { REVIEW_COMMENT_MARKER } from './webhook-pr-github.js'
+import { existsSync, readFileSync } from 'fs'
+import type { PullRequestContext } from './webhook-types.js'
+import type { PrCacheData } from './webhook-pr-cache.js'
+
+function makeContext(overrides: Partial<PullRequestContext> = {}): PullRequestContext {
+  return {
+    repo: 'owner/repo',
+    prNumber: 42,
+    prTitle: 'Fix authentication bug',
+    prBody: 'This PR fixes the login flow when using SSO.',
+    prUrl: 'https://github.com/owner/repo/pull/42',
+    author: 'octocat',
+    headBranch: 'fix-auth',
+    baseBranch: 'main',
+    headSha: 'abc1234567890',
+    baseSha: 'def5678901234',
+    action: 'opened',
+    changedFiles: 3,
+    additions: 25,
+    deletions: 10,
+    diff: 'diff --git a/src/auth.ts\n+fixed line\n-broken line',
+    fileList: 'src/auth.ts (modified, +20/-8)\nsrc/auth.test.ts (modified, +5/-2)',
+    commitMessages: '- abc1234: fix: resolve auth bug',
+    reviewComments: '',
+    reviews: '',
+    ...overrides,
+  }
+}
+
+describe('buildPrReviewPrompt', () => {
+  beforeEach(() => {
+    vi.mocked(existsSync).mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('full context produces all sections', () => {
+    const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+
+    expect(prompt).toContain('A pull request needs code review')
+    expect(prompt).toContain('**Repository**: owner/repo')
+    expect(prompt).toContain('**PR**: #42 — Fix authentication bug')
+    expect(prompt).toContain('**Author**: octocat')
+    expect(prompt).toContain('**Branch**: fix-auth → main')
+    expect(prompt).toContain('3 files changed, +25/-10')
+    expect(prompt).toContain('**Head**: abc1234')
+    expect(prompt).toContain('## PR Description')
+    expect(prompt).toContain('fixes the login flow')
+    expect(prompt).toContain('## Changed Files')
+    expect(prompt).toContain('src/auth.ts (modified, +20/-8)')
+    expect(prompt).toContain('## Commits')
+    expect(prompt).toContain('abc1234: fix: resolve auth bug')
+    expect(prompt).toContain('## Diff')
+    expect(prompt).toContain('+fixed line')
+    expect(prompt).toContain('## Instructions')
+  })
+
+  it('opened action produces comprehensive review instructions', () => {
+    const prompt = buildPrReviewPrompt(makeContext({ action: 'opened' }), '/tmp/workspace')
+    expect(prompt).toContain('comprehensive code review')
+  })
+
+  it('reopened action mentions fresh review', () => {
+    const prompt = buildPrReviewPrompt(makeContext({ action: 'reopened' }), '/tmp/workspace')
+    expect(prompt).toContain('reopened')
+    expect(prompt).toContain('fresh comprehensive code review')
+  })
+
+  it('synchronize action mentions previous head', () => {
+    const prompt = buildPrReviewPrompt(
+      makeContext({ action: 'synchronize', beforeSha: 'old1234567890' }),
+      '/tmp/workspace',
+    )
+    expect(prompt).toContain('updated with new commits')
+    expect(prompt).toContain('old1234')
+    expect(prompt).toContain('abc1234')
+  })
+
+  it('synchronize without beforeSha falls back to comprehensive review', () => {
+    const prompt = buildPrReviewPrompt(
+      makeContext({ action: 'synchronize', beforeSha: undefined }),
+      '/tmp/workspace',
+    )
+    expect(prompt).toContain('comprehensive code review')
+  })
+
+  it('missing PR body omits description section', () => {
+    const prompt = buildPrReviewPrompt(makeContext({ prBody: '' }), '/tmp/workspace')
+    expect(prompt).not.toContain('## PR Description')
+  })
+
+  it('empty diff shows "No diff available"', () => {
+    const prompt = buildPrReviewPrompt(makeContext({ diff: '' }), '/tmp/workspace')
+    expect(prompt).toContain('No diff available')
+  })
+
+  it('empty file list omits changed files section', () => {
+    const prompt = buildPrReviewPrompt(makeContext({ fileList: '' }), '/tmp/workspace')
+    expect(prompt).not.toContain('## Changed Files')
+  })
+
+  it('empty commit messages omits commits section', () => {
+    const prompt = buildPrReviewPrompt(makeContext({ commitMessages: '' }), '/tmp/workspace')
+    expect(prompt).not.toContain('## Commits')
+  })
+
+  it('includes existing review comments when present', () => {
+    const prompt = buildPrReviewPrompt(makeContext({
+      reviewComments: '- reviewer1 on src/auth.ts:10: Fix the null check here',
+      reviews: '- reviewer1 (COMMENTED): Needs a few fixes',
+    }), '/tmp/workspace')
+    expect(prompt).toContain('## Existing Reviews')
+    expect(prompt).toContain('### Review Summaries')
+    expect(prompt).toContain('reviewer1 (COMMENTED)')
+    expect(prompt).toContain('### Inline Comments')
+    expect(prompt).toContain('Fix the null check here')
+  })
+
+  it('omits existing reviews section when no comments exist', () => {
+    const prompt = buildPrReviewPrompt(makeContext({ reviewComments: '', reviews: '' }), '/tmp/workspace')
+    expect(prompt).not.toContain('## Existing Reviews')
+  })
+
+  describe('custom prompt resolution', () => {
+    it('uses repo-level custom prompt when available', () => {
+      vi.mocked(existsSync).mockImplementation((p: Parameters<typeof existsSync>[0]) =>
+        String(p).includes('/tmp/workspace/.codekin/pr-review-prompt.md'),
+      )
+      vi.mocked(readFileSync).mockReturnValue('Custom repo review instructions here')
+
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).toContain('Custom repo review instructions here')
+      // Should NOT contain default instructions
+      expect(prompt).not.toContain('comprehensive code review')
+    })
+
+    it('uses global custom prompt when repo-level not found', () => {
+      vi.mocked(existsSync).mockImplementation((p: Parameters<typeof existsSync>[0]) =>
+        String(p).includes('.codekin/pr-review-prompt.md') && !String(p).includes('/tmp/workspace'),
+      )
+      vi.mocked(readFileSync).mockReturnValue('Global custom instructions')
+
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).toContain('Global custom instructions')
+    })
+
+    it('falls back to default when no custom prompt exists', () => {
+      vi.mocked(existsSync).mockReturnValue(false)
+
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).toContain('comprehensive code review')
+      expect(prompt).toContain('Code correctness')
+    })
+
+    it('repo-level takes precedence over global', () => {
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(readFileSync).mockImplementation((p: Parameters<typeof readFileSync>[0]) => {
+        if (String(p).includes('/tmp/workspace')) return 'Repo prompt wins'
+        return 'Global prompt loses'
+      })
+
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).toContain('Repo prompt wins')
+      expect(prompt).not.toContain('Global prompt loses')
+    })
+
+    it('skips empty custom prompt file and falls back', () => {
+      vi.mocked(existsSync).mockReturnValue(true)
+      vi.mocked(readFileSync).mockReturnValue('   \n  ')
+
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      // Should fall back to default since file was whitespace-only
+      expect(prompt).toContain('comprehensive code review')
+    })
+  })
+
+  describe('prior review context (cache)', () => {
+    const mockCache: PrCacheData = {
+      prNumber: 42,
+      repo: 'owner/repo',
+      lastReviewedSha: 'prev123',
+      timestamp: '2026-04-02T10:00:00.000Z',
+      priorReviewSummary: 'PR adds SSO authentication support',
+      codebaseContext: 'Auth module at src/auth/, uses JWT tokens',
+      reviewFindings: 'Found null check issue in auth.ts line 42',
+    }
+
+    it('includes prior context section when cache provided', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace', { priorCache: mockCache })
+      expect(prompt).toContain('## Prior Review Context')
+      expect(prompt).toContain('prev123')
+      expect(prompt).toContain('2026-04-02T10:00:00.000Z')
+    })
+
+    it('includes all cache fields in prior context', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace', { priorCache: mockCache })
+      expect(prompt).toContain('### Codebase Familiarity')
+      expect(prompt).toContain('Auth module at src/auth/, uses JWT tokens')
+      expect(prompt).toContain('### Previous Review Findings')
+      expect(prompt).toContain('Found null check issue in auth.ts line 42')
+      expect(prompt).toContain('### Previous Review Summary')
+      expect(prompt).toContain('PR adds SSO authentication support')
+    })
+
+    it('omits prior context section when no cache', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).not.toContain('## Prior Review Context')
+    })
+
+    it('includes note about fresh diff', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace', { priorCache: mockCache })
+      expect(prompt).toContain('diff and comments below are fresh')
+    })
+  })
+
+  describe('cache-writing instructions', () => {
+    it('includes cache-writing instructions with correct path', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace', {
+        cachePath: '/home/user/.codekin/pr-cache/owner/repo/pr-42.json',
+      })
+      expect(prompt).toContain('## Post-Review: Save Context')
+      expect(prompt).toContain('/home/user/.codekin/pr-cache/owner/repo/pr-42.json')
+      expect(prompt).toContain('Write tool')
+    })
+
+    it('omits cache-writing instructions when no cachePath', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).not.toContain('## Post-Review: Save Context')
+    })
+  })
+
+  describe('intermediate file path overrides', () => {
+    it('includes PR-specific draft and codex review paths', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).toContain('pr-42-draft-review.md')
+      expect(prompt).toContain('pr-42-codex-review.md')
+      expect(prompt).toContain('/tmp/workspace/pr-42-draft-review.md')
+    })
+
+    it('warns against writing to git-tracked directories', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).toContain('Do NOT write review files to the `docs/` directory')
+    })
+
+    it('includes overridden codex command with correct paths', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).toContain('codex exec - --skip-git-repo-check -o /tmp/workspace/pr-42-codex-review.md < /tmp/workspace/pr-42-draft-review.md')
+    })
+  })
+
+  describe('comment posting instructions', () => {
+    it('includes update instructions when existingCommentId provided', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace', {
+        existingCommentId: 12345,
+      })
+      expect(prompt).toContain('## Posting Your Review Summary')
+      expect(prompt).toContain('comment ID: 12345')
+      expect(prompt).toContain('Update it instead of creating a new comment')
+      expect(prompt).toContain('PATCH')
+      expect(prompt).toContain('-F body=@/tmp/workspace/pr-42-review-body.md')
+      expect(prompt).toContain(`issues/comments/12345`)
+    })
+
+    it('includes create instructions when no existing comment', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).toContain('## Posting Your Review Summary')
+      expect(prompt).toContain('new comment')
+      expect(prompt).toContain('-F body=@/tmp/workspace/pr-42-review-body.md')
+      expect(prompt).toContain(`issues/${42}/comments`)
+    })
+
+    it('uses a PR-specific review body path to avoid collisions', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).toContain('/tmp/workspace/pr-42-review-body.md')
+      expect(prompt).not.toContain('/tmp/workspace/review-body.md')
+    })
+
+    it('always includes marker requirement in update instructions', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace', {
+        existingCommentId: 12345,
+      })
+      expect(prompt).toContain(REVIEW_COMMENT_MARKER)
+    })
+
+    it('always includes marker requirement in create instructions', () => {
+      const prompt = buildPrReviewPrompt(makeContext(), '/tmp/workspace')
+      expect(prompt).toContain(REVIEW_COMMENT_MARKER)
+    })
+  })
+})

--- a/server/webhook-pr-prompt.ts
+++ b/server/webhook-pr-prompt.ts
@@ -1,0 +1,277 @@
+/**
+ * Builds the structured prompt sent to Claude for pull request code review.
+ *
+ * Supports a 3-tier custom prompt resolution for the review instructions:
+ *   1. Repo-level: {workspacePath}/.codekin/pr-review-prompt.md
+ *   2. Global:     ~/.codekin/pr-review-prompt.md
+ *   3. Built-in default (hardcoded below)
+ *
+ * The PR metadata and diff context are always prepended — custom prompts
+ * only replace the review instructions section.
+ */
+
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import type { PullRequestContext } from './webhook-types.js'
+import type { PrCacheData } from './webhook-pr-cache.js'
+import { REVIEW_COMMENT_MARKER } from './webhook-pr-github.js'
+
+/** Options for prompt assembly — cache context and comment management. */
+export interface PrPromptOptions {
+  priorCache?: PrCacheData
+  cachePath?: string
+  existingCommentId?: number
+}
+
+const CUSTOM_PROMPT_FILENAME = 'pr-review-prompt.md'
+
+/**
+ * Attempt to load a custom review prompt from disk.
+ * Returns the file contents if found, or undefined.
+ */
+function loadCustomPrompt(workspacePath: string): string | undefined {
+  // 1. Repo-level
+  const repoPromptPath = join(workspacePath, '.codekin', CUSTOM_PROMPT_FILENAME)
+  if (existsSync(repoPromptPath)) {
+    try {
+      const content = readFileSync(repoPromptPath, 'utf-8').trim()
+      if (content) {
+        console.log(`[pr-prompt] Using repo-level custom prompt: ${repoPromptPath}`)
+        return content
+      }
+    } catch (err) {
+      console.warn(`[pr-prompt] Failed to read repo-level prompt:`, err)
+    }
+  }
+
+  // 2. Global
+  const globalPromptPath = join(homedir(), '.codekin', CUSTOM_PROMPT_FILENAME)
+  if (existsSync(globalPromptPath)) {
+    try {
+      const content = readFileSync(globalPromptPath, 'utf-8').trim()
+      if (content) {
+        console.log(`[pr-prompt] Using global custom prompt: ${globalPromptPath}`)
+        return content
+      }
+    } catch (err) {
+      console.warn(`[pr-prompt] Failed to read global prompt:`, err)
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Build the default review instructions (used when no custom prompt is found).
+ */
+function buildDefaultInstructions(ctx: PullRequestContext): string {
+  const lines: string[] = []
+
+  if (ctx.action === 'synchronize' && ctx.beforeSha) {
+    lines.push(`This PR has been updated with new commits. The previous head was \`${ctx.beforeSha.slice(0, 7)}\`, the new head is \`${ctx.headSha.slice(0, 7)}\`. Review the full PR diff but pay particular attention to changes since the previous head.`)
+  } else if (ctx.action === 'reopened') {
+    lines.push('This PR has been reopened. Provide a fresh comprehensive code review.')
+  } else {
+    lines.push('Provide a comprehensive code review of this pull request.')
+  }
+
+  lines.push('')
+  lines.push('Focus on:')
+  lines.push('1. Code correctness and logic errors')
+  lines.push('2. Security vulnerabilities (injection, auth issues, data exposure)')
+  lines.push('3. Performance implications')
+  lines.push('4. Code style, readability, and maintainability')
+  lines.push('5. Test coverage for new or changed code')
+  lines.push('')
+  lines.push('Produce a structured review report with:')
+  lines.push('- **Summary**: 1-2 sentence overview of the PR')
+  lines.push('- **Findings**: Grouped by severity (Critical / Warning / Suggestion / Nitpick)')
+  lines.push('  - For each finding: file path, line number(s), description, and suggested fix')
+  lines.push('- **Overall Assessment**: Approve / Request Changes / Comment')
+
+  return lines.join('\n')
+}
+
+/**
+ * Builds the full prompt for PR review, combining PR context with review instructions.
+ *
+ * @param ctx           - Pull request context with metadata and diff.
+ * @param workspacePath - Path to the cloned workspace (for repo-level prompt lookup).
+ * @param options       - Optional cache context and comment management settings.
+ */
+export function buildPrReviewPrompt(ctx: PullRequestContext, workspacePath: string, options?: PrPromptOptions): string {
+  const lines: string[] = []
+  const reviewBodyPath = `${workspacePath}/pr-${ctx.prNumber}-review-body.md`
+
+  // --- PR metadata (always included) ---
+  lines.push('A pull request needs code review.')
+  lines.push('')
+  lines.push('## PR Details')
+  lines.push(`- **Repository**: ${ctx.repo}`)
+  lines.push(`- **PR**: #${ctx.prNumber} — ${ctx.prTitle}`)
+  lines.push(`- **Author**: ${ctx.author}`)
+  lines.push(`- **Branch**: ${ctx.headBranch} → ${ctx.baseBranch}`)
+  lines.push(`- **Stats**: ${ctx.changedFiles} files changed, +${ctx.additions}/-${ctx.deletions}`)
+
+  const shortHead = ctx.headSha.slice(0, 7)
+  lines.push(`- **Head**: ${shortHead}`)
+
+  if (ctx.prUrl) {
+    lines.push(`- **URL**: ${ctx.prUrl}`)
+  }
+
+  // PR description
+  if (ctx.prBody) {
+    lines.push('')
+    lines.push('## PR Description')
+    lines.push(ctx.prBody)
+  }
+
+  // Changed files
+  if (ctx.fileList) {
+    lines.push('')
+    lines.push('## Changed Files')
+    lines.push(ctx.fileList)
+  }
+
+  // Commit messages
+  if (ctx.commitMessages) {
+    lines.push('')
+    lines.push('## Commits')
+    lines.push(ctx.commitMessages)
+  }
+
+  // Existing review comments
+  if (ctx.reviews || ctx.reviewComments) {
+    lines.push('')
+    lines.push('## Existing Reviews')
+    if (ctx.reviews) {
+      lines.push('### Review Summaries')
+      lines.push(ctx.reviews)
+    }
+    if (ctx.reviewComments) {
+      lines.push('### Inline Comments')
+      lines.push(ctx.reviewComments)
+    }
+  }
+
+  // Prior review context (from cache)
+  if (options?.priorCache) {
+    const cache = options.priorCache
+    lines.push('')
+    lines.push('## Prior Review Context')
+    lines.push(`(from review at commit ${cache.lastReviewedSha} on ${cache.timestamp})`)
+    lines.push('')
+    lines.push('### Codebase Familiarity')
+    lines.push(cache.codebaseContext)
+    lines.push('')
+    lines.push('### Previous Review Findings')
+    lines.push(cache.reviewFindings)
+    lines.push('')
+    lines.push('### Previous Review Summary')
+    lines.push(cache.priorReviewSummary)
+    lines.push('')
+    lines.push('Note: The above is from a previous review. The diff and comments below are fresh. Review the full current diff but leverage your prior context for faster, more informed review.')
+  }
+
+  // Diff
+  lines.push('')
+  lines.push('## Diff')
+  if (ctx.diff) {
+    lines.push('```diff')
+    lines.push(ctx.diff)
+    lines.push('```')
+  } else {
+    lines.push('No diff available.')
+  }
+
+  // --- Review instructions (custom or default) ---
+  lines.push('')
+  lines.push('## Instructions')
+
+  const customPrompt = loadCustomPrompt(workspacePath)
+  if (customPrompt) {
+    lines.push(customPrompt)
+  } else {
+    lines.push(buildDefaultInstructions(ctx))
+  }
+
+  // Override any hardcoded intermediate review file paths from custom prompts
+  // so concurrent reviews don't collide or write into tracked repo files.
+  lines.push('')
+  lines.push('## File Paths for This Review')
+  lines.push('When writing intermediate files during the review process, use these paths:')
+  lines.push(`- Draft review: \`${workspacePath}/pr-${ctx.prNumber}-draft-review.md\``)
+  lines.push(`- Codex cross-review output: \`${workspacePath}/pr-${ctx.prNumber}-codex-review.md\``)
+  lines.push(`- Codex command: \`codex exec - --skip-git-repo-check -o ${workspacePath}/pr-${ctx.prNumber}-codex-review.md < ${workspacePath}/pr-${ctx.prNumber}-draft-review.md\``)
+  lines.push('These paths override any file paths mentioned in the review instructions above.')
+  lines.push('Do NOT write review files to the `docs/` directory or any other git-tracked location.')
+
+  // --- Comment posting instructions ---
+  lines.push('')
+  if (options?.existingCommentId) {
+    lines.push('## Posting Your Review Summary')
+    lines.push(`An existing Codekin review comment was found on this PR (comment ID: ${options.existingCommentId}).`)
+    lines.push('Update it instead of creating a new comment. Use a temporary file for the body to avoid shell escaping issues:')
+    lines.push('')
+    lines.push(`1. Write your review summary to \`${reviewBodyPath}\``)
+    lines.push(`2. Ensure the file starts with \`${REVIEW_COMMENT_MARKER}\` on its own line`)
+    lines.push(`3. Run: \`gh api repos/${ctx.repo}/issues/comments/${options.existingCommentId} -X PATCH -F body=@${reviewBodyPath}\``)
+    lines.push('')
+    lines.push(`IMPORTANT: Always include \`${REVIEW_COMMENT_MARKER}\` at the very beginning of the comment body.`)
+  } else {
+    lines.push('## Posting Your Review Summary')
+    lines.push('Post your review summary as a new comment on the PR. Use a temporary file for the body to avoid shell escaping issues:')
+    lines.push('')
+    lines.push(`1. Write your review summary to \`${reviewBodyPath}\``)
+    lines.push(`2. Ensure the file starts with \`${REVIEW_COMMENT_MARKER}\` on its own line`)
+    lines.push(`3. Run: \`gh api repos/${ctx.repo}/issues/${ctx.prNumber}/comments -F body=@${reviewBodyPath}\``)
+    lines.push('')
+    lines.push(`IMPORTANT: Always include \`${REVIEW_COMMENT_MARKER}\` at the very beginning of the comment body. This marker allows future reviews to update this comment instead of creating a new one.`)
+  }
+
+  // --- Cache-writing instructions ---
+  if (options?.cachePath) {
+    lines.push('')
+    lines.push('## Post-Review: Save Context')
+    lines.push('After completing your review, write a JSON file to preserve your context for future reviews of this PR.')
+    lines.push('')
+    lines.push(`Path: ${options.cachePath}`)
+    lines.push('')
+    lines.push('The file must be valid JSON with this exact structure:')
+    lines.push('```json')
+    lines.push('{')
+    lines.push(`  "prNumber": ${ctx.prNumber},`)
+    lines.push(`  "repo": "${ctx.repo}",`)
+    lines.push(`  "lastReviewedSha": "${ctx.headSha}",`)
+    lines.push('  "timestamp": "<current ISO timestamp>",')
+    lines.push('  "priorReviewSummary": "<1-3 sentence summary of your review findings>",')
+    lines.push('  "codebaseContext": "<key architectural observations, module structure, patterns you noticed>",')
+    lines.push('  "reviewFindings": "<specific issues found, their locations, and whether they were fixed>",')
+    lines.push('  "verdict": "<approve | request_changes | comment>",')
+    lines.push('  "structuredFindings": [')
+    lines.push('    {')
+    lines.push('      "severity": "<critical | must-fix | suggestion | minor | nitpick>",')
+    lines.push('      "file": "<path/to/file.ts>",')
+    lines.push('      "line": <line number or null>,')
+    lines.push('      "description": "<short description of the finding>",')
+    lines.push('      "status": "<new | open | fixed>"')
+    lines.push('    }')
+    lines.push('  ],')
+    lines.push(`  "author": ${JSON.stringify(ctx.author)},`)
+    lines.push(`  "prTitle": ${JSON.stringify(ctx.prTitle)},`)
+    lines.push(`  "changedFiles": ${ctx.changedFiles},`)
+    lines.push(`  "additions": ${ctx.additions},`)
+    lines.push(`  "deletions": ${ctx.deletions}`)
+    lines.push('}')
+    lines.push('```')
+    lines.push('')
+    lines.push('IMPORTANT: The `structuredFindings` array must include every finding from your review.')
+    lines.push('Use an empty array `[]` if there are no findings. The `verdict` must be exactly one of: approve, request_changes, comment.')
+    lines.push('')
+    lines.push('Use the Write tool to save this file. This helps future reviews of this PR be more efficient.')
+  }
+
+  return lines.join('\n')
+}

--- a/server/webhook-types.ts
+++ b/server/webhook-types.ts
@@ -7,6 +7,7 @@ export type WebhookEventStatus =
   | 'session_created'
   | 'completed'
   | 'error'
+  | 'superseded'
 
 export interface WebhookEvent {
   id: string                    // X-GitHub-Delivery ID
@@ -24,6 +25,11 @@ export interface WebhookEvent {
   sessionId?: string            // if a session was created
   error?: string                // if processing failed
   filterReason?: string         // if filtered out, why
+  // PR-specific fields (populated when event is pull_request)
+  prNumber?: number              // PR number
+  prTitle?: string               // PR title
+  headSha?: string               // head commit SHA
+  baseBranch?: string            // target branch
 }
 
 // --- GitHub payload subset (workflow_run) ---
@@ -108,4 +114,67 @@ export interface WebhookConfig {
   maxConcurrentSessions: number
   logLinesToInclude: number
   actorAllowlist: string[]
+}
+
+// --- GitHub payload subset (pull_request) ---
+export interface PullRequestPayload {
+  action: string
+  number: number
+  before?: string                 // previous head SHA (on synchronize)
+  after?: string                  // new head SHA (on synchronize)
+  pull_request: {
+    number: number
+    title: string
+    body: string | null
+    state: string                 // "open" | "closed"
+    draft: boolean
+    merged: boolean
+    user: { login: string }
+    head: {
+      ref: string
+      sha: string
+      repo: { clone_url: string } | null
+    }
+    base: {
+      ref: string
+      sha: string
+    }
+    html_url: string
+    changed_files: number
+    additions: number
+    deletions: number
+  }
+  repository: {
+    full_name: string
+    name: string
+    clone_url: string
+  }
+  sender: { login: string }
+}
+
+// --- PR review context collected from gh CLI ---
+export interface PullRequestContext {
+  repo: string                    // owner/repo
+  repoName: string
+  prNumber: number
+  prTitle: string
+  prBody: string
+  prUrl: string
+  author: string
+  headBranch: string
+  baseBranch: string
+  headSha: string
+  baseSha: string
+  beforeSha?: string              // previous head SHA (on synchronize)
+  action: 'opened' | 'synchronize' | 'reopened' | 'ready_for_review'
+  changedFiles: number
+  additions: number
+  deletions: number
+  diff: string                    // fetched via gh, potentially truncated
+  fileList: string                // formatted list of changed files
+  commitMessages: string          // formatted commit messages
+  reviewComments: string          // existing inline review comments
+  reviews: string                 // existing review summaries
+  existingComment: string | null
+  priorCache: import('./webhook-pr-cache.js').PrCacheData | null
 }


### PR DESCRIPTION
## Summary

Cherry-picked and adapted from PR #319 (external fork contribution by @benjamin-talic).

- Extends the webhook handler to process `pull_request` events (opened, synchronize, reopened, ready_for_review) alongside existing `workflow_run` CI failure triage
- Spawns Claude sessions that fetch PR diff, changed files, commits, and existing review comments to perform automated code review
- Includes file-based per-PR context cache (`~/.codekin/pr-cache/`) for persistent review state across updates
- Auto-kills review sessions after completion to prevent idle memory consumption
- Archives/deletes cache and kills sessions when PRs are merged/closed
- Deduplicates PR events by repo + PR number + action + head SHA

## Changed files

**New files:**
- `server/webhook-pr-github.ts` — fetch PR data via gh CLI
- `server/webhook-pr-prompt.ts` — build structured review prompt with 3-tier custom prompt resolution
- `server/webhook-pr-cache.ts` — file-based per-PR context cache
- `server/webhook-pr-*.test.ts` — comprehensive test coverage
- `docs/PR-REVIEW-WEBHOOK.md` — setup and configuration docs

**Modified files:**
- `server/webhook-handler.ts` — refactored to dispatch by event type, added PR handling
- `server/webhook-dedup.ts` — added PR idempotency key + `recordProcessed()`
- `server/webhook-types.ts` — added `PullRequestPayload`, `PullRequestContext`, PR fields on `WebhookEvent`
- `server/webhook-handler.test.ts` — updated mocks for new dependencies

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (1422 tests across 51 files)
- [x] `npm run lint` passes (0 errors)
- [ ] Manual: configure webhook secret and test with a real PR event
- [ ] Manual: verify existing `workflow_run` handling is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)