### PR TITLE
feat: add OpenCode as alternative AI provider

### DIFF
--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -19,6 +19,7 @@ import { randomUUID } from 'crypto'
 import type { ClaudeEvent, ClaudeSystemInit, ClaudeControlRequest, ClaudeResultEvent, ClaudeStreamEvent, TaskItem, PromptQuestion, PermissionMode } from './types.js'
 import { SCREENSHOTS_DIR, CLAUDE_BINARY } from './config.js'
 import { redactSecrets } from './crypto-utils.js'
+import { CLAUDE_CAPABILITIES, type CodingProcess, type CodingProvider, type ProviderCapabilities } from './coding-process.js'
 
 /** Options for constructing a ClaudeProcess. Replaces positional constructor parameters. */
 export interface ClaudeProcessOptions {
@@ -36,6 +37,8 @@ export interface ClaudeProcessOptions {
   resume?: boolean
   /** Additional tools to pre-approve via --allowedTools. */
   allowedTools?: string[]
+  /** Extra directories to grant Claude access to via --add-dir. */
+  addDirs?: string[]
 }
 
 /** Accumulated state for an in-progress extended thinking block. */
@@ -77,7 +80,10 @@ const TOOL_DEBUG = process.env.NODE_ENV !== 'production'
  * Wraps a Claude CLI child process. Parses stream-json NDJSON output from
  * stdout and emits structured events consumed by SessionManager.
  */
-export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> {
+export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements CodingProcess {
+  readonly provider: CodingProvider = 'claude'
+  readonly capabilities: ProviderCapabilities = CLAUDE_CAPABILITIES
+
   private proc: ChildProcess | null = null
   private rl: Interface | null = null
   private sessionId: string
@@ -126,6 +132,7 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> {
   private model?: string
   private permissionMode?: PermissionMode
   private allowedTools?: string[]
+  private addDirs?: string[]
 
   constructor(workingDir: string, opts?: Partial<ClaudeProcessOptions>)
   /** @deprecated Use the options-object form: `new ClaudeProcess(workingDir, { sessionId, ... })` */
@@ -142,6 +149,7 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> {
       this.permissionMode = o.permissionMode
       this.resume = !!(o.resume && o.sessionId)
       this.allowedTools = o.allowedTools
+      this.addDirs = o.addDirs
     } else {
       this.sessionId = sessionIdOrOpts || randomUUID()
       this.extraEnv = extraEnv || {}
@@ -201,6 +209,7 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> {
         : ['--permission-mode', this.permissionMode || 'acceptEdits']),
       '--allowedTools', ['Bash(git:*)', ...(this.allowedTools || [])].join(','),
       '--add-dir', SCREENSHOTS_DIR,
+      ...(this.addDirs || []).flatMap(d => ['--add-dir', d]),
       '--include-partial-messages',
       '--verbose',
       ...(this.resume ? ['--resume', this.sessionId] : ['--session-id', this.sessionId]),
@@ -773,6 +782,11 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> {
   }
 
   isAlive(): boolean {
+    return this.alive
+  }
+
+  isReady(): boolean {
+    // Claude CLI stdin is always buffered — ready as soon as alive
     return this.alive
   }
 

--- a/server/coding-process.test.ts
+++ b/server/coding-process.test.ts
@@ -1,0 +1,84 @@
+/** Tests for the CodingProcess abstraction layer and provider dispatch. */
+import { describe, it, expect } from 'vitest'
+import { CLAUDE_CAPABILITIES, OPENCODE_CAPABILITIES } from './coding-process.js'
+import type { CodingProvider } from './coding-process.js'
+
+describe('CodingProvider type', () => {
+  it('accepts claude and opencode as valid values', () => {
+    const providers: CodingProvider[] = ['claude', 'opencode']
+    expect(providers).toHaveLength(2)
+    expect(providers).toContain('claude')
+    expect(providers).toContain('opencode')
+  })
+})
+
+describe('ProviderCapabilities', () => {
+  it('CLAUDE_CAPABILITIES has expected defaults', () => {
+    expect(CLAUDE_CAPABILITIES).toEqual({
+      streaming: true,
+      multiTurn: true,
+      permissionControl: true,
+      toolEvents: true,
+      thinkingDisplay: true,
+      multiProvider: false,
+      planMode: true,
+    })
+  })
+
+  it('OPENCODE_CAPABILITIES has expected defaults', () => {
+    expect(OPENCODE_CAPABILITIES).toEqual({
+      streaming: true,
+      multiTurn: true,
+      permissionControl: true,
+      toolEvents: true,
+      thinkingDisplay: true,
+      multiProvider: true,
+      planMode: true,
+    })
+  })
+
+  it('Claude is single-provider, OpenCode is multi-provider', () => {
+    expect(CLAUDE_CAPABILITIES.multiProvider).toBe(false)
+    expect(OPENCODE_CAPABILITIES.multiProvider).toBe(true)
+  })
+})
+
+describe('CodingProcess interface', () => {
+  it('can be satisfied by a mock object with required methods', () => {
+    // Verify the interface shape is correct by creating a mock that satisfies it
+    const mock = {
+      provider: 'claude' as CodingProvider,
+      capabilities: CLAUDE_CAPABILITIES,
+      start: () => {},
+      stop: () => {},
+      sendMessage: () => {},
+      sendRaw: () => {},
+      sendControlResponse: () => {},
+      isAlive: () => true,
+      getSessionId: () => 'test-id',
+      waitForExit: () => Promise.resolve(),
+      // EventEmitter methods
+      on: () => mock,
+      once: () => mock,
+      emit: () => true,
+      removeAllListeners: () => mock,
+      addListener: () => mock,
+      removeListener: () => mock,
+      off: () => mock,
+      listeners: () => [],
+      rawListeners: () => [],
+      listenerCount: () => 0,
+      prependListener: () => mock,
+      prependOnceListener: () => mock,
+      eventNames: () => [],
+      setMaxListeners: () => mock,
+      getMaxListeners: () => 10,
+    } satisfies Record<string, unknown>
+
+    // Type check: this would fail at compile time if interface is wrong
+    expect(mock.provider).toBe('claude')
+    expect(mock.capabilities).toBe(CLAUDE_CAPABILITIES)
+    expect(mock.isAlive()).toBe(true)
+    expect(mock.getSessionId()).toBe('test-id')
+  })
+})

--- a/server/coding-process.ts
+++ b/server/coding-process.ts
@@ -1,0 +1,115 @@
+/**
+ * Abstract interface for AI coding assistant processes.
+ *
+ * Both ClaudeProcess (Claude Code CLI via stdin/stdout NDJSON) and
+ * OpenCodeProcess (OpenCode server via HTTP/SSE) implement this interface,
+ * allowing SessionManager to work with either provider transparently.
+ *
+ * The event interface mirrors ClaudeProcessEvents — all providers emit the
+ * same set of typed events so the session layer and frontend need no
+ * provider-specific branching for event handling.
+ */
+
+import type { EventEmitter } from 'events'
+import type { ClaudeProcessEvents } from './claude-process.js'
+
+/**
+ * Supported AI coding assistant providers.
+ * - 'claude': Claude Code CLI (subprocess, NDJSON on stdin/stdout)
+ * - 'opencode': OpenCode server (HTTP REST + SSE)
+ */
+export type CodingProvider = 'claude' | 'opencode'
+
+/**
+ * Capabilities that differ between providers. SessionManager and frontend
+ * use this to gate features that aren't universally available.
+ */
+export interface ProviderCapabilities {
+  /** Provider supports bidirectional streaming (true for both Claude and OpenCode). */
+  streaming: boolean
+  /** Provider supports multi-turn conversations within a single process. */
+  multiTurn: boolean
+  /** Provider supports programmatic permission control. */
+  permissionControl: boolean
+  /** Provider emits tool_active/tool_done events for real-time tool indicators. */
+  toolEvents: boolean
+  /** Provider emits thinking/reasoning deltas. */
+  thinkingDisplay: boolean
+  /** Provider supports multiple LLM backends (not just Anthropic). */
+  multiProvider: boolean
+  /** Provider supports plan mode (read-only agent). */
+  planMode: boolean
+}
+
+/**
+ * Minimum process interface consumed by SessionManager.
+ *
+ * Any provider process must:
+ * 1. Emit typed events from ClaudeProcessEvents
+ * 2. Accept user messages via sendMessage()
+ * 3. Support lifecycle management (start/stop/isAlive)
+ * 4. Respond to permission requests via sendControlResponse()
+ *
+ * ClaudeProcess already satisfies this (it extends EventEmitter<ClaudeProcessEvents>).
+ * OpenCodeProcess implements it via HTTP/SSE under the hood.
+ */
+export interface CodingProcess extends EventEmitter<ClaudeProcessEvents> {
+  /** Start the underlying process or connection. */
+  start(): void
+
+  /** Gracefully stop the process (SIGTERM then SIGKILL, or HTTP disconnect). */
+  stop(): void
+
+  /** Send a user message to the AI assistant. */
+  sendMessage(content: string): void
+
+  /** Write raw protocol data (used for control_response in Claude, no-op in OpenCode). */
+  sendRaw(data: string): void
+
+  /**
+   * Respond to a permission/control request.
+   * Claude: writes control_response JSON to stdin.
+   * OpenCode: POSTs to /permission/:requestId/reply.
+   */
+  sendControlResponse(requestId: string, behavior: 'allow' | 'deny', updatedInput?: Record<string, unknown>, message?: string): void
+
+  /** Whether the process is currently running and accepting input. */
+  isAlive(): boolean
+
+  /** Whether the process is fully initialized and ready to accept messages immediately. */
+  isReady(): boolean
+
+  /** The provider's internal session ID (used for resume). */
+  getSessionId(): string
+
+  /** Returns a promise that resolves when the process exits. */
+  waitForExit(timeoutMs?: number): Promise<void>
+
+  /** Which provider this process belongs to. */
+  readonly provider: CodingProvider
+
+  /** Provider capability flags. */
+  readonly capabilities: ProviderCapabilities
+}
+
+/** Default capabilities for the Claude Code CLI provider. */
+export const CLAUDE_CAPABILITIES: ProviderCapabilities = {
+  streaming: true,
+  multiTurn: true,
+  permissionControl: true,
+  toolEvents: true,
+  thinkingDisplay: true,
+  multiProvider: false,
+  planMode: true,
+}
+
+/** Default capabilities for the OpenCode provider. */
+export const OPENCODE_CAPABILITIES: ProviderCapabilities = {
+  streaming: true,
+  multiTurn: true,
+  permissionControl: true,
+  toolEvents: true,
+  thinkingDisplay: true,
+  multiProvider: true,
+  planMode: true,
+}

--- a/server/opencode-process.test.ts
+++ b/server/opencode-process.test.ts
@@ -1,0 +1,549 @@
+/** Tests for OpenCodeProcess — verifies SSE event mapping, lifecycle, and provider interface compliance. */
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+
+// Mock fetch globally for HTTP calls
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+// Mock child_process.spawn for the server process
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  return {
+    ...actual,
+    spawn: vi.fn(() => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const EventEmitter = require('events').EventEmitter
+      const proc = Object.assign(new EventEmitter(), {
+        stdin: { write: vi.fn(), end: vi.fn() },
+        stdout: Object.assign(new EventEmitter(), { on: vi.fn() }),
+        stderr: Object.assign(new EventEmitter(), { on: vi.fn() }),
+        kill: vi.fn(),
+        killed: false,
+      })
+      return proc
+    }),
+  }
+})
+
+import { OpenCodeProcess, stopOpenCodeServer } from './opencode-process.js'
+import { OPENCODE_CAPABILITIES } from './coding-process.js'
+
+describe('OpenCodeProcess', () => {
+  let ocp: OpenCodeProcess
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    ocp = new OpenCodeProcess('/tmp/test-repo', {
+      sessionId: 'test-session-id',
+      model: 'anthropic/claude-sonnet-4',
+    })
+  })
+
+  afterEach(() => {
+    ocp.stop()
+    stopOpenCodeServer()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Interface compliance
+  // ---------------------------------------------------------------------------
+
+  describe('provider interface', () => {
+    it('reports provider as opencode', () => {
+      expect(ocp.provider).toBe('opencode')
+    })
+
+    it('has opencode capabilities', () => {
+      expect(ocp.capabilities).toBe(OPENCODE_CAPABILITIES)
+      expect(ocp.capabilities.multiProvider).toBe(true)
+    })
+
+    it('starts as not alive', () => {
+      expect(ocp.isAlive()).toBe(false)
+    })
+
+    it('returns codekin session ID when no opencode session exists', () => {
+      expect(ocp.getSessionId()).toBe('test-session-id')
+    })
+
+    it('returns opencode session ID when available (for resume)', () => {
+      const ocp2 = new OpenCodeProcess('/tmp/test-repo', {
+        sessionId: 'codekin-id',
+        opencodeSessionId: 'opencode-abc-123',
+      })
+      expect(ocp2.getSessionId()).toBe('opencode-abc-123')
+      ocp2.stop()
+    })
+
+    it('generates a session ID if not provided', () => {
+      const ocp2 = new OpenCodeProcess('/tmp/test-repo')
+      expect(ocp2.getSessionId()).toBeTruthy()
+      expect(ocp2.getSessionId()).toHaveLength(36) // UUID format
+      ocp2.stop()
+    })
+
+    it('accepts opencodeSessionId for resume via constructor', () => {
+      const ocp2 = new OpenCodeProcess('/tmp/test-repo', {
+        opencodeSessionId: 'oc-resume-id',
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((ocp2 as any).opencodeSessionId).toBe('oc-resume-id')
+      ocp2.stop()
+    })
+
+    it('sendRaw is a no-op', () => {
+      // Should not throw
+      ocp.sendRaw('anything')
+    })
+
+    it('waitForExit resolves immediately when not alive', async () => {
+      await expect(ocp.waitForExit()).resolves.toBeUndefined()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // SSE event mapping
+  // ---------------------------------------------------------------------------
+
+  // Access the private handleSSEEvent method for testing event mapping
+  const callHandleSSE = (ocp: OpenCodeProcess, event: Record<string, unknown>) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(ocp as any).handleSSEEvent(event)
+  }
+
+  // Set the opencodeSessionId so session filtering works
+  const setSessionId = (ocp: OpenCodeProcess, id: string) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(ocp as any).opencodeSessionId = id
+  }
+
+  describe('SSE event mapping', () => {
+
+    it('maps text delta events to text events', () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'oc-session-1',
+          field: 'text',
+          delta: 'Hello',
+        },
+      })
+      expect(textHandler).toHaveBeenCalledWith('Hello')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'oc-session-1',
+          field: 'text',
+          delta: ' world',
+        },
+      })
+      expect(textHandler).toHaveBeenCalledWith(' world')
+      expect(textHandler).toHaveBeenCalledTimes(2)
+    })
+
+    it('ignores non-text delta events', () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'oc-session-1',
+          field: 'reasoning',
+          delta: 'some reasoning',
+        },
+      })
+      expect(textHandler).not.toHaveBeenCalled()
+    })
+
+    it('ignores delta events from other sessions', () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.delta',
+        properties: {
+          sessionID: 'other-session',
+          field: 'text',
+          delta: 'Hello',
+        },
+      })
+      expect(textHandler).not.toHaveBeenCalled()
+    })
+
+    it('ignores text part updates (content arrives via deltas)', () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          part: { type: 'text', content: 'Hello' },
+        },
+      })
+      expect(textHandler).not.toHaveBeenCalled()
+    })
+
+    it('maps reasoning parts to thinking events', () => {
+      const thinkingHandler = vi.fn()
+      ocp.on('thinking', thinkingHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          part: { type: 'reasoning', text: 'Let me think about this carefully and consider all the options.' },
+        },
+      })
+      expect(thinkingHandler).toHaveBeenCalledTimes(1)
+      expect(thinkingHandler.mock.calls[0][0]).toBeTruthy()
+    })
+
+    it('ignores short reasoning content', () => {
+      const thinkingHandler = vi.fn()
+      ocp.on('thinking', thinkingHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          part: { type: 'reasoning', text: 'Short' },
+        },
+      })
+      expect(thinkingHandler).not.toHaveBeenCalled()
+    })
+
+    it('maps running tool parts to tool_active events', () => {
+      const toolActiveHandler = vi.fn()
+      ocp.on('tool_active', toolActiveHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          part: {
+            type: 'tool',
+            tool: 'bash',
+            state: { status: 'running', input: { command: 'ls -la' } },
+          },
+        },
+      })
+      expect(toolActiveHandler).toHaveBeenCalledWith('bash', '$ ls -la')
+    })
+
+    it('maps completed tool parts to tool_done and tool_output events', () => {
+      const toolDoneHandler = vi.fn()
+      const toolOutputHandler = vi.fn()
+      ocp.on('tool_done', toolDoneHandler)
+      ocp.on('tool_output', toolOutputHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          part: {
+            type: 'tool',
+            tool: 'read',
+            state: { status: 'completed', output: 'file contents here' },
+          },
+        },
+      })
+      expect(toolDoneHandler).toHaveBeenCalledWith('read', 'file contents here')
+      expect(toolOutputHandler).toHaveBeenCalledWith('file contents here', false)
+    })
+
+    it('maps error tool parts to tool_done and error tool_output', () => {
+      const toolDoneHandler = vi.fn()
+      const toolOutputHandler = vi.fn()
+      ocp.on('tool_done', toolDoneHandler)
+      ocp.on('tool_output', toolOutputHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          part: {
+            type: 'tool',
+            tool: 'bash',
+            state: { status: 'error', error: 'command not found' },
+          },
+        },
+      })
+      expect(toolDoneHandler).toHaveBeenCalledWith('bash', 'Error: command not found')
+      expect(toolOutputHandler).toHaveBeenCalledWith('command not found', true)
+    })
+
+    it('maps session.status idle to result event', () => {
+      const resultHandler = vi.fn()
+      ocp.on('result', resultHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'session.status',
+        properties: {
+          sessionID: 'oc-session-1',
+          status: { type: 'idle' },
+        },
+      })
+      expect(resultHandler).toHaveBeenCalledWith('', false)
+    })
+
+    it('maps session.error to error event', () => {
+      const errorHandler = vi.fn()
+      ocp.on('error', errorHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'session.error',
+        properties: { sessionID: 'oc-session-1', error: { message: 'Rate limit exceeded' } },
+      })
+      expect(errorHandler).toHaveBeenCalledWith('Rate limit exceeded')
+    })
+
+    it('filters session.error from other sessions', () => {
+      const errorHandler = vi.fn()
+      ocp.on('error', errorHandler)
+      setSessionId(ocp, 'my-session')
+
+      callHandleSSE(ocp, {
+        type: 'session.error',
+        properties: { sessionID: 'other-session', error: { message: 'Should be ignored' } },
+      })
+      expect(errorHandler).not.toHaveBeenCalled()
+    })
+
+    it('maps permission.asked to control_request event', () => {
+      const controlHandler = vi.fn()
+      ocp.on('control_request', controlHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'permission.asked',
+        properties: {
+          sessionID: 'oc-session-1',
+          id: 'perm-123',
+          permission: 'external_directory',
+          patterns: ['/tmp/*'],
+          metadata: { filepath: '/tmp', parentDir: '/tmp' },
+          tool: { messageID: 'msg-1', callID: 'call-1' },
+        },
+      })
+      expect(controlHandler).toHaveBeenCalledWith('perm-123', 'external_directory', {
+        permission: 'external_directory',
+        filepath: '/tmp',
+        parentDir: '/tmp',
+        patterns: ['/tmp/*'],
+      })
+    })
+
+    it('filters permission.asked from other sessions', () => {
+      const controlHandler = vi.fn()
+      ocp.on('control_request', controlHandler)
+      setSessionId(ocp, 'my-session')
+
+      callHandleSSE(ocp, {
+        type: 'permission.asked',
+        properties: {
+          sessionID: 'other-session',
+          id: 'perm-456',
+          permission: 'external_directory',
+          patterns: ['/tmp/*'],
+        },
+      })
+      expect(controlHandler).not.toHaveBeenCalled()
+    })
+
+    it('filters events from other sessions', () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'my-session')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'other-session',
+          part: { type: 'text', content: 'Should be ignored' },
+        },
+      })
+      expect(textHandler).not.toHaveBeenCalled()
+    })
+
+    it('truncates long tool output', () => {
+      const toolOutputHandler = vi.fn()
+      ocp.on('tool_output', toolOutputHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      const longOutput = 'x'.repeat(3000)
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          part: {
+            type: 'tool',
+            tool: 'read',
+            state: { status: 'completed', output: longOutput },
+          },
+        },
+      })
+
+      const emitted = toolOutputHandler.mock.calls[0][0] as string
+      expect(emitted.length).toBeLessThan(longOutput.length)
+      expect(emitted).toContain('truncated')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
+  describe('lifecycle', () => {
+    it('stop() sets alive to false and emits exit', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).alive = true
+      expect(ocp.isAlive()).toBe(true)
+
+      const exitHandler = vi.fn()
+      ocp.on('exit', exitHandler)
+      ocp.stop()
+
+      expect(ocp.isAlive()).toBe(false)
+      expect(exitHandler).toHaveBeenCalledWith(0, null)
+    })
+
+    it('waitForExit resolves after stop', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).alive = true
+
+      const exitPromise = ocp.waitForExit(5000)
+      ocp.stop()
+      await expect(exitPromise).resolves.toBeUndefined()
+    })
+
+    it('sendMessage emits error when not connected', () => {
+      const errorHandler = vi.fn()
+      ocp.on('error', errorHandler)
+
+      ocp.sendMessage('hello')
+      expect(errorHandler).toHaveBeenCalledWith('OpenCode process is not connected')
+    })
+
+    it('sendControlResponse calls replyToPermission', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const replyFn = vi.spyOn(ocp as any, 'replyToPermission').mockResolvedValue(undefined)
+      ocp.sendControlResponse('req-1', 'allow')
+      expect(replyFn).toHaveBeenCalledWith('req-1', 'once')
+    })
+
+    it('sendControlResponse maps deny to reject', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const replyFn = vi.spyOn(ocp as any, 'replyToPermission').mockResolvedValue(undefined)
+      ocp.sendControlResponse('req-2', 'deny')
+      expect(replyFn).toHaveBeenCalledWith('req-2', 'reject')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Tool input summarization
+  // ---------------------------------------------------------------------------
+
+  describe('summarizeToolInput', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const summarize = (tool: string, input: Record<string, unknown>) => (ocp as any).summarizeToolInput(tool, input)
+
+    it('summarizes bash commands', () => {
+      expect(summarize('bash', { command: 'npm install' })).toBe('$ npm install')
+    })
+
+    it('summarizes read/view with file path', () => {
+      expect(summarize('read', { file_path: '/src/index.ts' })).toBe('/src/index.ts')
+      expect(summarize('view', { filePath: '/src/main.ts' })).toBe('/src/main.ts')
+    })
+
+    it('summarizes edit/write with file path', () => {
+      expect(summarize('edit', { file_path: '/README.md' })).toBe('/README.md')
+    })
+
+    it('summarizes glob/grep with pattern', () => {
+      expect(summarize('glob', { pattern: '**/*.ts' })).toBe('**/*.ts')
+      expect(summarize('grep', { pattern: 'TODO' })).toBe('TODO')
+    })
+
+    it('returns empty string for unknown tools', () => {
+      expect(summarize('unknown_tool', {})).toBe('')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Task/Todo support
+  // ---------------------------------------------------------------------------
+
+  describe('task tracking', () => {
+    it('emits todo_update for TodoWrite tool calls', () => {
+      const todoHandler = vi.fn()
+      ocp.on('todo_update', todoHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          part: {
+            type: 'tool',
+            tool: 'TodoWrite',
+            state: {
+              status: 'running',
+              input: {
+                todos: [
+                  { content: 'Fix bug', status: 'in_progress', activeForm: 'Fixing bug' },
+                  { content: 'Write tests', status: 'pending', activeForm: 'Writing tests' },
+                ],
+              },
+            },
+          },
+        },
+      })
+
+      expect(todoHandler).toHaveBeenCalledTimes(1)
+      const tasks = todoHandler.mock.calls[0][0]
+      expect(tasks).toHaveLength(2)
+      expect(tasks[0].subject).toBe('Fix bug')
+      expect(tasks[0].status).toBe('in_progress')
+      expect(tasks[1].subject).toBe('Write tests')
+      expect(tasks[1].status).toBe('pending')
+    })
+
+    it('does not emit todo_update for non-task tools', () => {
+      const todoHandler = vi.fn()
+      ocp.on('todo_update', todoHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          part: {
+            type: 'tool',
+            tool: 'bash',
+            state: { status: 'running', input: { command: 'ls' } },
+          },
+        },
+      })
+
+      expect(todoHandler).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -1,0 +1,792 @@
+/**
+ * Manages an OpenCode server session via HTTP REST + SSE.
+ *
+ * OpenCode (github.com/anomalyco/opencode) uses a client/server architecture:
+ * - `opencode serve` runs a long-lived HTTP server
+ * - Sessions are created/managed via REST API
+ * - Real-time events stream via SSE (Server-Sent Events)
+ *
+ * This class wraps that model behind the same CodingProcess interface that
+ * ClaudeProcess implements, so SessionManager works identically for both.
+ *
+ * Key differences from ClaudeProcess:
+ * - No child process per session — one shared OpenCode server
+ * - Messages sent via HTTP POST, not stdin
+ * - Events received via SSE, not stdout NDJSON
+ * - Permissions handled via POST /permission/:id/reply, not control_response on stdin
+ */
+
+import { EventEmitter } from 'events'
+import { spawn, type ChildProcess } from 'child_process'
+import { randomUUID } from 'crypto'
+import type { ClaudeProcessEvents } from './claude-process.js'
+import { OPENCODE_CAPABILITIES, type CodingProcess, type CodingProvider, type ProviderCapabilities } from './coding-process.js'
+import type { PermissionMode, TaskItem } from './types.js'
+
+// ---------------------------------------------------------------------------
+// OpenCode SSE event types (subset — only what we need to map)
+// ---------------------------------------------------------------------------
+
+/** A part within an OpenCode message (text, reasoning, tool, step markers). */
+interface OpenCodeMessagePart {
+  type: 'text' | 'reasoning' | 'tool' | 'step-start' | 'step-finish'
+  /** Text/reasoning content (field name is 'text', not 'content'). */
+  text?: string
+  /** Tool name (only for type='tool'). */
+  tool?: string
+  /** Tool state — an object, not a string. Contains status, input, output, time, etc. */
+  state?: {
+    status: 'pending' | 'running' | 'completed' | 'error'
+    input?: Record<string, unknown>
+    output?: string
+    error?: string
+    time?: { start?: number; end?: number }
+    metadata?: Record<string, unknown>
+    title?: string
+  }
+  time?: { start?: number; end?: number }
+  metadata?: Record<string, unknown>
+}
+
+/** Shape of an SSE event from OpenCode's GET /event endpoint. */
+interface OpenCodeSSEEvent {
+  type: string
+  properties: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// OpenCode server manager (singleton — one server for all sessions)
+// ---------------------------------------------------------------------------
+
+interface OpenCodeServerState {
+  process: ChildProcess | null
+  port: number
+  password: string
+  ready: boolean
+  startPromise: Promise<void> | null
+}
+
+const serverState: OpenCodeServerState = {
+  process: null,
+  port: 0,
+  password: '',
+  ready: false,
+  startPromise: null,
+}
+
+/**
+ * Ensure the OpenCode server is running. Starts it if not already running.
+ * Returns the base URL for API calls.
+ */
+async function ensureOpenCodeServer(workingDir: string): Promise<string> {
+  if (serverState.ready && serverState.process && !serverState.process.killed) {
+    return `http://localhost:${serverState.port}`
+  }
+
+  if (serverState.startPromise) {
+    await serverState.startPromise
+    return `http://localhost:${serverState.port}`
+  }
+
+  serverState.startPromise = startOpenCodeServer(workingDir)
+  try {
+    await serverState.startPromise
+  } finally {
+    serverState.startPromise = null
+  }
+  return `http://localhost:${serverState.port}`
+}
+
+async function startOpenCodeServer(workingDir: string): Promise<void> {
+  // Pick a port in the ephemeral range
+  serverState.port = 14096 + Math.floor(Math.random() * 1000)
+  serverState.password = randomUUID()
+
+  const env: Record<string, string> = {
+    ...Object.fromEntries(
+      Object.entries(process.env).filter(
+        (entry): entry is [string, string] => entry[1] != null
+      )
+    ),
+    OPENCODE_SERVER_PASSWORD: serverState.password,
+  }
+
+  const proc = spawn('opencode', ['serve', '--port', String(serverState.port)], {
+    cwd: workingDir,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env,
+  })
+  serverState.process = proc
+
+  proc.on('close', () => {
+    serverState.ready = false
+    serverState.process = null
+  })
+
+  // Wait for server to become ready (poll health endpoint)
+  const baseUrl = `http://localhost:${serverState.port}`
+  const maxAttempts = 30
+  for (let i = 0; i < maxAttempts; i++) {
+    await new Promise(r => setTimeout(r, 1000))
+    try {
+      const res = await fetch(`${baseUrl}/health`, {
+        headers: authHeaders(),
+        signal: AbortSignal.timeout(2000),
+      })
+      if (res.ok) {
+        serverState.ready = true
+        console.log(`[opencode-server] Ready on port ${serverState.port}`)
+        return
+      }
+    } catch {
+      // Server not ready yet
+    }
+  }
+
+  // Kill orphaned process that never became healthy
+  if (serverState.process) {
+    serverState.process.kill('SIGTERM')
+    serverState.process = null
+  }
+  throw new Error(`OpenCode server failed to start within ${maxAttempts}s`)
+}
+
+/** Build auth headers for OpenCode API calls. */
+function authHeaders(): Record<string, string> {
+  if (!serverState.password) return {}
+  const encoded = Buffer.from(`opencode:${serverState.password}`).toString('base64')
+  return { Authorization: `Basic ${encoded}` }
+}
+
+/** OpenCode model info returned from /config/providers. */
+export interface OpenCodeModelInfo {
+  id: string
+  name: string
+  providerID: string
+  providerName: string
+}
+
+/**
+ * Fetch the list of configured models from the running OpenCode server.
+ * Returns an empty array if the server is not running.
+ */
+export async function fetchOpenCodeModels(workingDir: string): Promise<{
+  models: OpenCodeModelInfo[]
+  defaults: Record<string, string>
+}> {
+  try {
+    const baseUrl = await ensureOpenCodeServer(workingDir)
+    const res = await fetch(`${baseUrl}/config/providers`, {
+      headers: {
+        ...authHeaders(),
+        'x-opencode-directory': workingDir,
+      },
+      signal: AbortSignal.timeout(15000),
+    })
+    if (!res.ok) return { models: [], defaults: {} }
+    const data = await res.json() as {
+      providers: Array<{
+        id: string
+        name: string
+        models: Record<string, { id: string; name: string }>
+      }>
+      default?: Record<string, string>
+    }
+    const models: OpenCodeModelInfo[] = []
+    for (const p of data.providers) {
+      for (const m of Object.values(p.models)) {
+        models.push({ id: m.id, name: m.name, providerID: p.id, providerName: p.name })
+      }
+    }
+    return { models, defaults: data.default ?? {} }
+  } catch {
+    return { models: [], defaults: {} }
+  }
+}
+
+/** Stop the shared OpenCode server. */
+export function stopOpenCodeServer(): void {
+  if (serverState.process) {
+    serverState.process.kill('SIGTERM')
+    serverState.process = null
+    serverState.ready = false
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface OpenCodeProcessOptions {
+  /** Absolute path to the project directory. */
+  workingDir: string
+  /** Codekin session ID (used for internal tracking). */
+  sessionId?: string
+  /** OpenCode's own session ID (used for resume — returned by getSessionId()). */
+  opencodeSessionId?: string
+  /** Model in provider/model format (e.g. 'anthropic/claude-sonnet-4'). */
+  model?: string
+  /** Additional environment variables (CODEKIN_SESSION_ID, etc.). */
+  extraEnv?: Record<string, string>
+  /** Permission mode — mapped to OpenCode's permission config. */
+  permissionMode?: PermissionMode
+}
+
+// ---------------------------------------------------------------------------
+// OpenCodeProcess
+// ---------------------------------------------------------------------------
+
+export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implements CodingProcess {
+  readonly provider: CodingProvider = 'opencode'
+  readonly capabilities: ProviderCapabilities = OPENCODE_CAPABILITIES
+
+  private sessionId: string
+  private opencodeSessionId: string | null = null
+  private workingDir: string
+  private model?: string
+  private alive = false
+  private abortController: AbortController | null = null
+  private startupTimer: ReturnType<typeof setTimeout> | null = null
+  private permissionMode?: PermissionMode
+  private tasks = new Map<string, TaskItem>()
+  private turnComplete = false
+  private taskSeq = 0
+
+  constructor(workingDir: string, opts?: Partial<OpenCodeProcessOptions>) {
+    super()
+    this.workingDir = workingDir
+    this.sessionId = opts?.sessionId || randomUUID()
+    this.opencodeSessionId = opts?.opencodeSessionId || null
+    this.model = opts?.model
+    this.permissionMode = opts?.permissionMode
+  }
+
+  /** Connect to the OpenCode server, create a session, and subscribe to SSE events. */
+  start(): void {
+    if (this.alive) return
+
+    this.alive = true
+
+    // Startup timeout
+    this.startupTimer = setTimeout(() => {
+      this.startupTimer = null
+      if (this.alive) {
+        this.emit('error', 'OpenCode process failed to initialize within 60 seconds')
+        this.stop()
+      }
+    }, 60_000)
+
+    void this.initialize().catch((err) => {
+      this.emit('error', `OpenCode initialization failed: ${err instanceof Error ? err.message : String(err)}`)
+      this.stop()
+    })
+  }
+
+  private async initialize(): Promise<void> {
+    const baseUrl = await ensureOpenCodeServer(this.workingDir)
+
+    // Create or resume a session — must happen BEFORE SSE subscription
+    // so that this.opencodeSessionId is set and the session ID filter
+    // guards in handleSSEEvent() are active (prevents cross-session leakage).
+    if (this.opencodeSessionId) {
+      // Resume existing session — just reconnect to SSE
+    } else {
+      const createRes = await fetch(`${baseUrl}/session`, {
+        method: 'POST',
+        headers: {
+          ...authHeaders(),
+          'Content-Type': 'application/json',
+          'x-opencode-directory': this.workingDir,
+        },
+        body: JSON.stringify({
+          title: `Codekin session ${this.sessionId.slice(0, 8)}`,
+        }),
+      })
+
+      if (!createRes.ok) {
+        throw new Error(`Failed to create OpenCode session: ${createRes.status} ${await createRes.text()}`)
+      }
+
+      const data = await createRes.json() as { id: string }
+      this.opencodeSessionId = data.id
+    }
+
+    // Subscribe to SSE events AFTER opencodeSessionId is set so session
+    // filtering is active from the first event received.
+    this.subscribeToEvents(baseUrl)
+
+    // Clear startup timer and emit init
+    if (this.startupTimer) {
+      clearTimeout(this.startupTimer)
+      this.startupTimer = null
+    }
+
+    // Model is stored as "providerID/modelID" — show everything after the first slash
+    const modelName = this.model?.includes('/') ? this.model.slice(this.model.indexOf('/') + 1) : (this.model || 'opencode (default)')
+    this.emit('system_init', modelName)
+  }
+
+  /** Subscribe to the OpenCode SSE event stream and map events to CodingProcess events. */
+  private subscribeToEvents(baseUrl: string): void {
+    this.abortController = new AbortController()
+    let reconnectDelay = 1000
+    const MAX_RECONNECT_DELAY = 30_000
+    const MAX_RECONNECT_ATTEMPTS = 20
+
+    let reconnectAttempts = 0
+
+    const connectSSE = () => {
+      if (!this.alive) return
+
+      void fetch(`${baseUrl}/event`, {
+        headers: {
+          ...authHeaders(),
+          Accept: 'text/event-stream',
+          'x-opencode-directory': this.workingDir,
+        },
+        signal: this.abortController!.signal,
+      }).then(async (res) => {
+        if (!res.ok || !res.body) {
+          if (this.alive) {
+            reconnectAttempts++
+            if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
+              this.emit('error', `SSE reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts (last status: ${res.status})`)
+              return
+            }
+            console.warn(`[opencode-sse] Non-2xx ${res.status}, reconnecting in ${reconnectDelay / 1000}s (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`)
+            setTimeout(connectSSE, reconnectDelay)
+            reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY)
+          }
+          return
+        }
+
+        // Reset backoff on successful connection
+        reconnectDelay = 1000
+        reconnectAttempts = 0
+
+        const reader = res.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+
+        while (this.alive) {
+          const { done, value } = await reader.read()
+          if (done) break
+
+          buffer += decoder.decode(value, { stream: true })
+          const lines = buffer.split('\n')
+          buffer = lines.pop() || ''
+
+          let currentData = ''
+          for (const line of lines) {
+            if (line.startsWith('data: ')) {
+              currentData += line.slice(6)
+            } else if (line === '' && currentData) {
+              try {
+                const event = JSON.parse(currentData) as OpenCodeSSEEvent
+                this.handleSSEEvent(event)
+              } catch {
+                // Ignore unparseable SSE data
+              }
+              currentData = ''
+            }
+          }
+        }
+
+        // Clean EOF — reconnect if still alive (server restart, proxy timeout, etc.)
+        if (this.alive) {
+          reconnectAttempts++
+          if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
+            this.emit('error', `SSE reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts`)
+            return
+          }
+          console.warn(`[opencode-sse] Stream closed cleanly, reconnecting in ${reconnectDelay / 1000}s (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`)
+          setTimeout(connectSSE, reconnectDelay)
+          reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY)
+        }
+      }).catch((err) => {
+        if (err instanceof Error && err.name === 'AbortError') return
+        if (this.alive) {
+          reconnectAttempts++
+          if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
+            this.emit('error', `SSE reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts`)
+            return
+          }
+          console.warn(`[opencode-sse] Connection lost, reconnecting in ${reconnectDelay / 1000}s (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`, err)
+          setTimeout(connectSSE, reconnectDelay)
+          reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY)
+        }
+      })
+    }
+
+    connectSSE()
+  }
+
+  /**
+   * Check whether an SSE event belongs to this process's OpenCode session.
+   * Returns true if the event should be processed, false if it should be skipped.
+   * Rejects events when opencodeSessionId is not yet set (init window) to prevent
+   * cross-session leakage on the shared SSE stream.
+   */
+  private isOwnSession(properties: Record<string, unknown>): boolean {
+    const sessionID = properties.sessionID as string | undefined
+    // If we don't have our session ID yet, reject everything to prevent
+    // cross-session leakage during the initialization window.
+    if (!this.opencodeSessionId) return false
+    // If event has no session ID, accept (server-level event)
+    if (!sessionID) return true
+    return sessionID === this.opencodeSessionId
+  }
+
+  /** Map an OpenCode SSE event to CodingProcess events. */
+  private handleSSEEvent(event: OpenCodeSSEEvent): void {
+    const { type, properties } = event
+
+    switch (type) {
+      // Delta events carry the actual streaming text content
+      case 'message.part.delta': {
+        if (!this.isOwnSession(properties)) break
+        const field = properties.field as string | undefined
+        const delta = properties.delta as string | undefined
+        if (field === 'text' && delta) {
+          this.emit('text', delta)
+        }
+        break
+      }
+
+      case 'message.part.updated': {
+        const part = properties.part as OpenCodeMessagePart | undefined
+        if (!part) break
+
+        // Only process events for our session
+        if (!this.isOwnSession(properties)) break
+
+        switch (part.type) {
+          case 'text': {
+            // Text content arrives via message.part.delta events, not here.
+            break
+          }
+
+          case 'reasoning': {
+            // OpenCode uses 'text' field, not 'content'. Reasoning may be
+            // empty or encrypted (e.g. OpenAI models). Only emit if present.
+            const content = part.text || ''
+            if (content.length > 20) {
+              const match = content.match(/^(.+?[.!?\n])/)
+              const summary = match && match[1].length <= 120
+                ? match[1].replace(/\n/g, ' ').trim()
+                : content.slice(0, 80).trim()
+              this.emit('thinking', summary)
+            }
+            break
+          }
+
+          case 'tool': {
+            // Tool state is an object {status, input, output, time, ...}, not a string
+            const toolName = part.tool || 'unknown'
+            const status = part.state?.status
+            if (status === 'running') {
+              const inputStr = part.state?.input ? this.summarizeToolInput(toolName, part.state.input) : undefined
+              this.emit('tool_active', toolName, inputStr)
+              // Detect task/todo tool calls and emit todo_update
+              if (part.state?.input && this.handleTaskTool(toolName, part.state.input)) {
+                this.emit('todo_update', Array.from(this.tasks.values()))
+              }
+            } else if (status === 'completed') {
+              // Also check for task tools at completion (some providers only
+              // populate input at this stage, not during 'running')
+              if (part.state?.input && this.handleTaskTool(toolName, part.state.input)) {
+                this.emit('todo_update', Array.from(this.tasks.values()))
+              }
+              const output = part.state?.output
+              const summary = output ? output.slice(0, 200) : undefined
+              this.emit('tool_done', toolName, summary)
+              if (output) {
+                const truncated = output.length > 2000
+                  ? output.slice(0, 2000) + `\n… (truncated, ${output.length} chars total)`
+                  : output
+                this.emit('tool_output', truncated, false)
+              }
+            } else if (status === 'error') {
+              const errMsg = part.state?.error || 'unknown'
+              this.emit('tool_done', toolName, `Error: ${errMsg}`)
+              this.emit('tool_output', errMsg, true)
+            }
+            // 'pending' status — tool call parsed but not yet executing; no action needed
+            break
+          }
+
+          // step-start / step-finish are agentic iteration boundaries — no mapping needed
+        }
+        break
+      }
+
+      case 'session.status': {
+        if (!this.isOwnSession(properties)) break
+        // Status may be a string ('idle') or object ({ type: 'idle' }) depending on OpenCode version
+        const status = properties.status
+        const statusType = typeof status === 'string' ? status : (status as { type?: string } | undefined)?.type
+        if (statusType === 'idle') {
+          if (this.turnComplete) break
+          this.turnComplete = true
+          this.emit('result', '', false)
+        }
+        break
+      }
+
+      case 'session.error': {
+        if (!this.isOwnSession(properties)) break
+        const error = properties.error as { message?: string } | undefined
+        this.emit('error', error?.message || 'Unknown OpenCode error')
+        break
+      }
+
+      case 'permission.asked': {
+        if (!this.isOwnSession(properties)) break
+
+        const requestId = properties.id as string | undefined
+        if (!requestId) {
+          console.error('[opencode] permission.asked event missing required id field')
+          break
+        }
+        // Real format: properties.permission is the type (e.g. "external_directory"),
+        // properties.metadata has details (filepath, parentDir), properties.patterns
+        // has the glob patterns being requested. No direct tool name — use permission type.
+        const permissionType = properties.permission as string || 'unknown'
+        const metadata = properties.metadata as Record<string, unknown> || {}
+        const patterns = properties.patterns as string[] || []
+        const input: Record<string, unknown> = {
+          permission: permissionType,
+          ...metadata,
+          patterns,
+        }
+
+        // Auto-approve for headless sessions (webhook/workflow)
+        if (this.permissionMode === 'bypassPermissions' || this.permissionMode === 'dangerouslySkipPermissions') {
+          void this.replyToPermission(requestId, 'always')
+          return
+        }
+
+        // Emit as control_request for SessionManager to handle
+        this.emit('control_request', requestId, permissionType, input)
+        break
+      }
+
+      // message.completed signals that the model has finished its response
+      case 'message.completed': {
+        if (!this.isOwnSession(properties)) break
+        if (this.turnComplete) break
+        this.turnComplete = true
+        this.emit('result', '', false)
+        break
+      }
+
+      // session.updated may carry idle status in some OpenCode versions
+      case 'session.updated': {
+        if (!this.isOwnSession(properties)) break
+        const session = properties.session as Record<string, unknown> | undefined
+        const sessionStatus = session?.status
+        const sType = typeof sessionStatus === 'string' ? sessionStatus : (sessionStatus as { type?: string } | undefined)?.type
+        if (sType === 'idle') {
+          if (this.turnComplete) break
+          this.turnComplete = true
+          this.emit('result', '', false)
+        }
+        break
+      }
+
+      default:
+        // Log unhandled session-scoped events for debugging (skip noisy ones)
+        if (type !== 'heartbeat' && type !== 'server.connected' && type !== 'message.part.added') {
+          if (this.isOwnSession(properties)) {
+            console.log(`[opencode-sse] Unhandled event: ${type}`, JSON.stringify(properties).slice(0, 200))
+          }
+        }
+        break
+    }
+  }
+
+  /** Reply to an OpenCode permission request via HTTP. */
+  private async replyToPermission(requestId: string, type: 'once' | 'always' | 'reject'): Promise<void> {
+    try {
+      const baseUrl = `http://localhost:${serverState.port}`
+      const res = await fetch(`${baseUrl}/permission/${requestId}/reply`, {
+        method: 'POST',
+        headers: {
+          ...authHeaders(),
+          'Content-Type': 'application/json',
+          'x-opencode-directory': this.workingDir,
+        },
+        body: JSON.stringify({ type }),
+      })
+      if (!res.ok) {
+        console.error(`[opencode] Permission reply failed: HTTP ${res.status} for ${requestId}`)
+      }
+    } catch (err) {
+      console.error(`[opencode] Failed to reply to permission ${requestId}:`, err)
+    }
+  }
+
+  /** Generate a short summary for tool input (mirrors ClaudeProcess.summarizeToolInput). */
+  private summarizeToolInput(toolName: string, input: Record<string, unknown>): string {
+    switch (toolName) {
+      case 'bash': return `$ ${String(input.command || '').split('\n')[0]}`
+      case 'read':
+      case 'view': return String(input.file_path || input.filePath || '')
+      case 'write':
+      case 'edit':
+      case 'multiedit': return String(input.file_path || input.filePath || '')
+      case 'glob': return String(input.pattern || '')
+      case 'grep': return String(input.pattern || '')
+      case 'task': return String(input.description || '')
+      default: return ''
+    }
+  }
+
+  /**
+   * Detect TodoWrite/TaskCreate/TaskUpdate tool calls and emit todo_update events.
+   * Mirrors the task-tracking logic in ClaudeProcess.handleTaskTool().
+   */
+  private handleTaskTool(toolName: string, input: Record<string, unknown>): boolean {
+    // Normalize tool name — OpenCode may report as 'todowrite', 'TodoWrite', 'todo_write', etc.
+    const normalized = toolName.toLowerCase().replace(/_/g, '')
+    if (normalized === 'todowrite') {
+      const todos = input.todos as Array<Record<string, unknown>> | undefined
+      if (!Array.isArray(todos)) return false
+      this.tasks.clear()
+      this.taskSeq = 0
+      for (const item of todos) {
+        const id = String(item.id || ++this.taskSeq)
+        const status = item.status as string
+        if (status !== 'pending' && status !== 'in_progress' && status !== 'completed') continue
+        this.tasks.set(id, {
+          id,
+          subject: String(item.content || item.subject || ''),
+          status,
+          activeForm: item.activeForm ? String(item.activeForm) : undefined,
+        })
+      }
+      return true
+    }
+    if (normalized === 'taskcreate') {
+      const id = String(++this.taskSeq)
+      this.tasks.set(id, {
+        id,
+        subject: String(input.subject || ''),
+        status: 'pending',
+        activeForm: input.activeForm ? String(input.activeForm) : undefined,
+      })
+      return true
+    }
+    if (normalized === 'taskupdate') {
+      const id = String(input.taskId || '')
+      const task = this.tasks.get(id)
+      if (!task) return false
+      const status = input.status as string | undefined
+      if (status === 'deleted') {
+        this.tasks.delete(id)
+        return true
+      }
+      if (status === 'pending' || status === 'in_progress' || status === 'completed') {
+        task.status = status
+      }
+      if (input.subject) task.subject = String(input.subject)
+      if (input.activeForm !== undefined) task.activeForm = input.activeForm ? String(input.activeForm) : undefined
+      return true
+    }
+    return false
+  }
+
+  /** Send a user message to the OpenCode session. */
+  sendMessage(content: string): void {
+    if (!this.alive || !this.opencodeSessionId) {
+      this.emit('error', 'OpenCode process is not connected')
+      return
+    }
+
+    this.turnComplete = false // reset completion latch for new turn
+
+    const baseUrl = `http://localhost:${serverState.port}`
+    // Build request body with optional model override
+    const body: Record<string, unknown> = {
+      parts: [{ type: 'text', text: content }],
+    }
+    // Model is stored as "providerID/modelID" — split only at first slash so
+    // OpenRouter-style IDs like "openrouter/meta-llama/llama-3.1-8b" stay intact.
+    if (this.model && this.model.includes('/')) {
+      const slashIdx = this.model.indexOf('/')
+      const providerID = this.model.slice(0, slashIdx)
+      const modelID = this.model.slice(slashIdx + 1)
+      body.model = { providerID, modelID }
+    }
+    // Use prompt_async for fire-and-forget (events come via SSE)
+    void fetch(`${baseUrl}/session/${this.opencodeSessionId}/prompt_async`, {
+      method: 'POST',
+      headers: {
+        ...authHeaders(),
+        'Content-Type': 'application/json',
+        'x-opencode-directory': this.workingDir,
+      },
+      body: JSON.stringify(body),
+    }).then((res) => {
+      if (!res.ok) {
+        this.emit('error', `Failed to send message: HTTP ${res.status}`)
+      }
+    }).catch((err) => {
+      this.emit('error', `Failed to send message: ${err instanceof Error ? err.message : String(err)}`)
+    })
+  }
+
+  /** No-op for OpenCode — raw protocol data is Claude-specific. */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  sendRaw(_: string): void {
+    // OpenCode uses HTTP endpoints, not raw stdin
+  }
+
+  /**
+   * Respond to a permission/control request.
+   * Maps Codekin's allow/deny to OpenCode's once/always/reject.
+   */
+  sendControlResponse(requestId: string, behavior: 'allow' | 'deny'): void {
+    const type = behavior === 'deny' ? 'reject' : 'once'
+    void this.replyToPermission(requestId, type)
+  }
+
+  /** Stop the OpenCode session and disconnect the SSE stream. */
+  stop(): void {
+    if (!this.alive) return
+    this.alive = false
+    if (this.startupTimer) {
+      clearTimeout(this.startupTimer)
+      this.startupTimer = null
+    }
+    if (this.abortController) {
+      this.abortController.abort()
+      this.abortController = null
+    }
+    // Emit exit event to match ClaudeProcess behavior
+    this.emit('exit', 0, null)
+  }
+
+  isAlive(): boolean {
+    return this.alive
+  }
+
+  isReady(): boolean {
+    return this.alive && this.opencodeSessionId !== null && serverState.port > 0
+  }
+
+  getSessionId(): string {
+    return this.opencodeSessionId ?? this.sessionId
+  }
+
+  waitForExit(timeoutMs = 10000): Promise<void> {
+    if (!this.alive) return Promise.resolve()
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, timeoutMs)
+      this.once('exit', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+  }
+}

--- a/server/prompt-router.ts
+++ b/server/prompt-router.ts
@@ -11,7 +11,7 @@
 
 import { randomUUID } from 'crypto'
 import { ApprovalManager } from './approval-manager.js'
-import type { ClaudeProcess } from './claude-process.js'
+import type { CodingProcess } from './coding-process.js'
 import type { PromptQuestion, Session, WsServerMessage } from './types.js'
 
 /** Dependencies injected by SessionManager so PromptRouter can interact with session state. */
@@ -117,7 +117,7 @@ export class PromptRouter {
 
   /** Handle a Claude process 'control_request' event. */
   onControlRequestEvent(
-    cp: ClaudeProcess,
+    cp: CodingProcess,
     session: Session,
     sessionId: string,
     requestId: string,

--- a/server/provider-dispatch.test.ts
+++ b/server/provider-dispatch.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for provider dispatch in session creation and persistence.
+ *
+ * Verifies that:
+ * 1. Sessions default to 'claude' provider when not specified
+ * 2. Sessions can be created with 'opencode' provider
+ * 3. Provider is persisted and restored correctly
+ * 4. WsClientMessage supports provider field
+ * 5. Workflow config supports provider field
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    existsSync: vi.fn((p: string) => String(p).includes('sessions.json') ? false : actual.existsSync(p)),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    renameSync: vi.fn(),
+    chmodSync: vi.fn(),
+    readFileSync: vi.fn(() => '[]'),
+  }
+})
+
+vi.mock('better-sqlite3', () => {
+  class MockDatabase {
+    pragma = vi.fn()
+    exec = vi.fn()
+    prepare = vi.fn(() => ({
+      run: vi.fn(() => ({ changes: 0 })),
+      get: vi.fn(),
+      all: vi.fn(() => []),
+    }))
+    close = vi.fn()
+  }
+  return { default: MockDatabase }
+})
+
+// Mock child_process for session naming
+const mockSpawn = vi.hoisted(() => vi.fn())
+const mockExecFile = vi.hoisted(() => vi.fn())
+const makeExecFileWrapper = vi.hoisted(() => (mockFn: ReturnType<typeof vi.fn>) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const wrapper = (...args: any[]) => mockFn(...args)
+  const sym = Symbol.for('nodejs.util.promisify.custom')
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ;(wrapper as any)[sym] = (...args: any[]) => {
+    return new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      mockFn(...args, (err: Error | null, stdout: string, stderr: string) => {
+        if (err) reject(err)
+        else resolve({ stdout, stderr })
+      })
+    })
+  }
+  return wrapper
+})
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawn: (...args: any[]) => mockSpawn(...args),
+    execFile: makeExecFileWrapper(mockExecFile),
+  }
+})
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  return {
+    ...actual,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    spawn: (...args: any[]) => mockSpawn(...args),
+    execFile: makeExecFileWrapper(mockExecFile),
+  }
+})
+
+import { SessionManager } from './session-manager.js'
+import type { PersistedSession } from './session-persistence.js'
+import type { ReviewRepoConfig } from './workflow-config.js'
+import type { WsClientMessage } from './types.js'
+
+describe('Provider dispatch', () => {
+  let sm: SessionManager
+
+  beforeEach(() => {
+    sm = new SessionManager()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Session creation
+  // ---------------------------------------------------------------------------
+
+  describe('session creation', () => {
+    it('defaults to claude provider when not specified', () => {
+      const session = sm.create('Test session', '/tmp/repo')
+      expect(session.provider).toBe('claude')
+    })
+
+    it('creates sessions with claude provider explicitly', () => {
+      const session = sm.create('Test session', '/tmp/repo', { provider: 'claude' })
+      expect(session.provider).toBe('claude')
+    })
+
+    it('creates sessions with opencode provider', () => {
+      const session = sm.create('Test session', '/tmp/repo', { provider: 'opencode' })
+      expect(session.provider).toBe('opencode')
+    })
+
+    it('preserves provider alongside other options', () => {
+      const session = sm.create('Test session', '/tmp/repo', {
+        provider: 'opencode',
+        model: 'openai/gpt-4o',
+        source: 'webhook',
+      })
+      expect(session.provider).toBe('opencode')
+      expect(session.model).toBe('openai/gpt-4o')
+      expect(session.source).toBe('webhook')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Session persistence
+  // ---------------------------------------------------------------------------
+
+  describe('session persistence', () => {
+    it('includes provider in persisted session data', () => {
+      const sessions = new Map()
+      sessions.set('test-1', {
+        id: 'test-1',
+        name: 'Test',
+        workingDir: '/tmp/repo',
+        created: new Date().toISOString(),
+        source: 'manual',
+        provider: 'opencode',
+        claudeProcess: null,
+        clients: new Set(),
+        outputHistory: [],
+        claudeSessionId: null,
+      })
+
+      // Verify the serialized shape includes provider field
+      const serialized = Array.from(sessions.values()).map((s) => ({
+        id: s.id,
+        name: s.name,
+        workingDir: s.workingDir,
+        provider: s.provider,
+        source: s.source,
+      }))
+      expect(serialized[0].provider).toBe('opencode')
+    })
+
+    it('PersistedSession type includes optional provider field', () => {
+      // Type check: verify the shape is correct
+      const persisted: PersistedSession = {
+        id: 'test-1',
+        name: 'Test',
+        workingDir: '/tmp/repo',
+        created: new Date().toISOString(),
+        provider: 'opencode',
+        claudeSessionId: null,
+        outputHistory: [],
+      }
+      expect(persisted.provider).toBe('opencode')
+    })
+
+    it('PersistedSession defaults provider to undefined (backwards compat)', () => {
+      const persisted: PersistedSession = {
+        id: 'test-1',
+        name: 'Test',
+        workingDir: '/tmp/repo',
+        created: new Date().toISOString(),
+        claudeSessionId: null,
+        outputHistory: [],
+      }
+      expect(persisted.provider).toBeUndefined()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // WsClientMessage
+  // ---------------------------------------------------------------------------
+
+  describe('WsClientMessage provider field', () => {
+    it('create_session accepts provider field', () => {
+      const msg: WsClientMessage = {
+        type: 'create_session',
+        name: 'Test',
+        workingDir: '/tmp/repo',
+        provider: 'opencode',
+      }
+      expect(msg.provider).toBe('opencode')
+    })
+
+    it('create_session works without provider (backwards compat)', () => {
+      const msg: WsClientMessage = {
+        type: 'create_session',
+        name: 'Test',
+        workingDir: '/tmp/repo',
+      }
+      expect(msg).toBeDefined()
+      // TypeScript allows this because provider is optional
+    })
+
+    it('create_session accepts all options together', () => {
+      const msg: WsClientMessage = {
+        type: 'create_session',
+        name: 'Test',
+        workingDir: '/tmp/repo',
+        model: 'openai/gpt-4o',
+        provider: 'opencode',
+        permissionMode: 'acceptEdits',
+        useWorktree: true,
+      }
+      expect(msg.provider).toBe('opencode')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Workflow config
+  // ---------------------------------------------------------------------------
+
+  describe('ReviewRepoConfig provider field', () => {
+    it('accepts provider field', () => {
+      const config: ReviewRepoConfig = {
+        id: 'repo-1',
+        name: 'My Repo',
+        repoPath: '/tmp/repo',
+        cronExpression: '0 9 * * 1-5',
+        enabled: true,
+        provider: 'opencode',
+      }
+      expect(config.provider).toBe('opencode')
+    })
+
+    it('defaults to undefined provider (backwards compat)', () => {
+      const config: ReviewRepoConfig = {
+        id: 'repo-1',
+        name: 'My Repo',
+        repoPath: '/tmp/repo',
+        cronExpression: '0 9 * * 1-5',
+        enabled: true,
+      }
+      expect(config.provider).toBeUndefined()
+    })
+  })
+})

--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -11,6 +11,8 @@
 import { existsSync } from 'fs'
 import path from 'path'
 import { ClaudeProcess } from './claude-process.js'
+import { OpenCodeProcess } from './opencode-process.js'
+import type { CodingProcess } from './coding-process.js'
 import { ApprovalManager } from './approval-manager.js'
 import type { PromptRouter } from './prompt-router.js'
 import type { Session, WsServerMessage } from './types.js'
@@ -33,7 +35,7 @@ export interface SessionLifecycleDeps {
   promptRouter: PromptRouter
   exitListeners: Array<(sessionId: string, code: number | null, signal: string | null, willRestart: boolean) => void>
   // Event handler callbacks that remain in SessionManager
-  onSystemInit(cp: ClaudeProcess, session: Session, model: string): void
+  onSystemInit(cp: CodingProcess, session: Session, model: string): void
   onTextEvent(session: Session, sessionId: string, text: string): void
   onThinkingEvent(session: Session, summary: string): void
   onToolOutputEvent(session: Session, content: string, isError: boolean): void
@@ -142,14 +144,26 @@ export class SessionLifecycle {
     const repoDir = session.groupDir ?? session.workingDir
     const registryPatterns = this.deps.approvalManager.getAllowedToolsForRepo(repoDir)
     const mergedAllowedTools = [...new Set([...(session.allowedTools || []), ...registryPatterns])]
-    const cp = new ClaudeProcess(session.workingDir, {
-      sessionId: session.claudeSessionId || undefined,
-      extraEnv,
-      model: session.model,
-      permissionMode: session.permissionMode,
-      resume,
-      allowedTools: mergedAllowedTools,
-    })
+    let cp: CodingProcess
+    if (session.provider === 'opencode') {
+      cp = new OpenCodeProcess(session.workingDir, {
+        sessionId: sessionId,
+        opencodeSessionId: session.claudeSessionId || undefined,
+        model: session.model,
+        extraEnv,
+        permissionMode: session.permissionMode,
+      })
+    } else {
+      cp = new ClaudeProcess(session.workingDir, {
+        sessionId: session.claudeSessionId || undefined,
+        extraEnv,
+        model: session.model,
+        permissionMode: session.permissionMode,
+        resume,
+        allowedTools: mergedAllowedTools,
+        addDirs: session.addDirs,
+      })
+    }
 
     this.wireClaudeEvents(cp, session, sessionId)
 
@@ -172,18 +186,20 @@ export class SessionLifecycle {
   waitForReady(sessionId: string, timeoutMs = 30_000): Promise<void> {
     const session = this.deps.getSession(sessionId)
     if (!session?.claudeProcess) return Promise.resolve()
-    // If the process already completed init in a prior turn, resolve immediately
-    if (session.claudeSessionId) return Promise.resolve()
+    // If the process is already fully initialized, resolve immediately.
+    // Uses isReady() which accounts for provider differences: Claude is ready
+    // as soon as alive (stdin buffered), OpenCode needs alive + opencodeSessionId.
+    if (session.claudeProcess.isReady()) return Promise.resolve()
 
     return new Promise<void>((resolve) => {
+      const done = () => { clearTimeout(timer); resolve() }
       const timer = setTimeout(() => {
         console.warn(`[waitForReady] Timed out waiting for system_init on ${sessionId} after ${timeoutMs}ms`)
+        session.claudeProcess?.removeListener('exit', done)
         resolve()
       }, timeoutMs)
-      session.claudeProcess!.once('system_init', () => {
-        clearTimeout(timer)
-        resolve()
-      })
+      session.claudeProcess!.once('system_init', done)
+      session.claudeProcess!.once('exit', done) // fail-fast if process dies during init
     })
   }
 
@@ -191,7 +207,7 @@ export class SessionLifecycle {
    * Attach all ClaudeProcess event listeners for a session.
    * Called by startClaude() to keep that method focused on process setup.
    */
-  wireClaudeEvents(cp: ClaudeProcess, session: Session, sessionId: string): void {
+  wireClaudeEvents(cp: CodingProcess, session: Session, sessionId: string): void {
     cp.on('system_init', (model) => this.deps.onSystemInit(cp, session, model))
     cp.on('text', (text) => this.deps.onTextEvent(session, sessionId, text))
     cp.on('thinking', (summary) => this.deps.onThinkingEvent(session, summary))
@@ -227,7 +243,7 @@ export class SessionLifecycle {
    * Uses evaluateRestart() for the restart decision, keeping this method focused
    * on state updates, listener notification, and message broadcasting.
    */
-  handleClaudeExit(exitedProcess: ClaudeProcess, session: Session, sessionId: string, code: number | null, signal: string | null): void {
+  handleClaudeExit(exitedProcess: CodingProcess, session: Session, sessionId: string, code: number | null, signal: string | null): void {
     // Guard: ignore exit events from stale processes that were replaced by a
     // new startClaude() call.  Without this, the old process's exit handler
     // would null out session.claudeProcess (which now points to the NEW
@@ -244,7 +260,12 @@ export class SessionLifecycle {
     // "Session ID is already in use" means another process holds the lock.
     // Retrying with the same session ID will fail every time, so treat this
     // as a non-restartable exit (same as stopped-by-user).
-    const sessionConflict = exitedProcess.hasSessionConflict()
+    // ClaudeProcess has diagnostic methods (hasSessionConflict, hadOutput, hasSpawnFailed)
+    // that OpenCodeProcess does not. Duck-type check via property existence.
+    const proc = exitedProcess as CodingProcess & Partial<Pick<ClaudeProcess, 'hasSessionConflict' | 'hadOutput' | 'hasSpawnFailed'>>
+    const sessionConflict = proc.hasSessionConflict ? proc.hasSessionConflict() : false
+    const producedOutput = proc.hadOutput ? proc.hadOutput() : true
+    const spawnFailed = proc.hasSpawnFailed ? proc.hasSpawnFailed() : false
 
     // If the process exited without ever producing stdout output, --resume
     // hung on a broken/stale session. Clear claudeSessionId so the next
@@ -252,11 +273,11 @@ export class SessionLifecycle {
     // broken resume — which would just hang again.
     // Exception: if spawn() itself failed (ENOENT/EACCES), the process never
     // started — the session data on disk is fine, so preserve the ID for retry.
-    if (!exitedProcess.hadOutput() && session.claudeSessionId && !exitedProcess.hasSpawnFailed()) {
+    if (!producedOutput && session.claudeSessionId && !spawnFailed) {
       console.warn(`[restart] Session ${sessionId} produced no output before exit — clearing claudeSessionId to force fresh session`)
       session.claudeSessionId = null
     }
-    if (exitedProcess.hasSpawnFailed()) {
+    if (spawnFailed) {
       console.warn(`[restart] Session ${sessionId} spawn failed (binary not found) — preserving claudeSessionId for retry`)
     }
 

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -26,7 +26,7 @@ import { homedir } from 'os'
 import path from 'path'
 import { promisify } from 'util'
 import type { WebSocket } from 'ws'
-import { ClaudeProcess } from './claude-process.js'
+import type { CodingProcess, CodingProvider } from './coding-process.js'
 import { PlanManager } from './plan-manager.js'
 import { SessionArchive } from './session-archive.js'
 import type { DiffFileStatus, DiffScope, Session, SessionInfo, TaskItem, WsServerMessage } from './types.js'
@@ -80,6 +80,10 @@ export interface CreateSessionOptions {
   permissionMode?: import('./types.js').PermissionMode
   /** Additional tools to pre-approve via --allowedTools (e.g. 'Bash(curl:*)', 'WebFetch'). */
   allowedTools?: string[]
+  /** Extra directories to grant Claude access to via --add-dir. */
+  addDirs?: string[]
+  /** AI provider to use for this session. Defaults to 'claude'. */
+  provider?: import('./coding-process.js').CodingProvider
 }
 
 
@@ -272,9 +276,11 @@ export class SessionManager {
       groupDir: options?.groupDir,
       created: new Date().toISOString(),
       source: options?.source ?? 'manual',
+      provider: options?.provider ?? 'claude',
       model: options?.model,
       permissionMode: options?.permissionMode,
       allowedTools: options?.allowedTools,
+      addDirs: options?.addDirs,
       claudeProcess: null,
       clients: new Set(),
       outputHistory: [],
@@ -885,7 +891,7 @@ export class SessionManager {
     })
   }
 
-  private onSystemInit(cp: ClaudeProcess, session: Session, model: string): void {
+  private onSystemInit(cp: CodingProcess, session: Session, model: string): void {
     session.claudeSessionId = cp.getSessionId()
     // Only show model message on first init or when model actually changes
     if (!session._lastReportedModel || session._lastReportedModel !== model) {
@@ -1111,9 +1117,27 @@ export class SessionManager {
             session.isProcessing = true
             this._globalBroadcast?.({ type: 'sessions_updated' })
           }
-          session.claudeProcess?.sendMessage(combined)
+          if (session.claudeProcess && !session.claudeProcess.isReady()) {
+            void this.waitForReady(sessionId).then(() => session.claudeProcess?.sendMessage(combined))
+          } else {
+            session.claudeProcess?.sendMessage(combined)
+          }
           return
         }
+      }
+
+      // Process just started — if not ready yet (OpenCode needs server init),
+      // queue the message via waitForReady.
+      if (session.claudeProcess && !session.claudeProcess.isReady()) {
+        session._lastUserInput = data
+        session._lastUserInputAt = Date.now()
+        session._apiRetryCount = 0
+        if (!session.isProcessing) {
+          session.isProcessing = true
+          this._globalBroadcast?.({ type: 'sessions_updated' })
+        }
+        void this.waitForReady(sessionId).then(() => session.claudeProcess?.sendMessage(data))
+        return
       }
     }
 
@@ -1150,6 +1174,30 @@ export class SessionManager {
    */
   requestToolApproval(sessionId: string, toolName: string, toolInput: Record<string, unknown>): Promise<{ allow: boolean; always: boolean; answer?: string }> {
     return this.promptRouter.requestToolApproval(sessionId, toolName, toolInput)
+  }
+
+  getSessionProvider(sessionId: string): string {
+    return this.sessions.get(sessionId)?.provider ?? 'claude'
+  }
+
+  /** Update the provider for a session and restart with the new provider process. */
+  setProvider(sessionId: string, provider: CodingProvider): boolean {
+    const session = this.sessions.get(sessionId)
+    if (!session) return false
+    if (session.provider === provider) return true
+    session.provider = provider
+    session.claudeSessionId = null
+    this.persistToDiskDebounced()
+    if (session.claudeProcess?.isAlive()) {
+      this.stopClaude(sessionId)
+      session._stoppedByUser = false
+      setTimeout(() => {
+        if (this.sessions.has(sessionId) && !session._stoppedByUser) {
+          this.startClaude(sessionId)
+        }
+      }, 500)
+    }
+    return true
   }
 
   /** Update the model for a session and restart Claude with the new model. */
@@ -1486,7 +1534,7 @@ export class SessionManager {
   restoreActiveSessions(): void {
     const toRestore: Session[] = []
     for (const session of this.sessions.values()) {
-      if (session._wasActiveBeforeRestart && session.claudeSessionId) {
+      if (session._wasActiveBeforeRestart && session.claudeSessionId && session.source !== 'webhook') {
         toRestore.push(session)
       }
     }

--- a/server/session-persistence.ts
+++ b/server/session-persistence.ts
@@ -24,6 +24,7 @@ export interface PersistedSession {
   worktreePath?: string
   created: string
   source?: 'manual' | 'webhook' | 'workflow' | 'stepflow' | 'orchestrator' | 'agent'
+  provider?: import('./coding-process.js').CodingProvider
   model?: string
   permissionMode?: string
   /** Additional tools to pre-approve via --allowedTools. */
@@ -51,6 +52,7 @@ export class SessionPersistence {
       worktreePath: s.worktreePath,
       created: s.created,
       source: s.source,
+    provider: s.provider,
       model: s.model,
       permissionMode: s.permissionMode,
       allowedTools: s.allowedTools,
@@ -112,6 +114,7 @@ export class SessionPersistence {
           worktreePath,
           created: s.created,
           source: s.source ?? 'manual',
+          provider: s.provider ?? 'claude',
           model: s.model,
           permissionMode: s.permissionMode as Session['permissionMode'],
           allowedTools: s.allowedTools,

--- a/server/types.ts
+++ b/server/types.ts
@@ -7,7 +7,7 @@
  */
 
 import type { WebSocket } from 'ws'
-import type { ClaudeProcess } from './claude-process.js'
+import type { CodingProcess, CodingProvider } from './coding-process.js'
 import type { PlanManager } from './plan-manager.js'
 
 /**
@@ -17,9 +17,13 @@ import type { PlanManager } from './plan-manager.js'
 export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions' | 'dangerouslySkipPermissions'
 
 /** Allow-list for server-side validation of client-supplied permission modes. */
+/** Allow-list for server-side validation of client-supplied provider names. */
+export const VALID_PROVIDERS = new Set<CodingProvider>(['claude', 'opencode'])
+
 export const VALID_PERMISSION_MODES = new Set<PermissionMode>(['default', 'acceptEdits', 'plan', 'bypassPermissions', 'dangerouslySkipPermissions'])
 
-/** Allow-list for server-side validation of client-supplied model IDs. */
+/** Allow-list for server-side validation of client-supplied model IDs.
+ *  Only Claude models — OpenCode sessions bypass this (models are dynamic). */
 export const VALID_MODELS = new Set([
   'claude-opus-4-6',
   'claude-sonnet-4-6',
@@ -41,8 +45,10 @@ export interface Session {
   worktreePath?: string
   created: string
   source: 'manual' | 'webhook' | 'workflow' | 'stepflow' | 'orchestrator' | 'agent'
-  /** The spawned Claude CLI process, or null if not running. */
-  claudeProcess: ClaudeProcess | null
+  /** Which AI coding assistant provider powers this session. Defaults to 'claude'. */
+  provider: CodingProvider
+  /** The spawned AI process (Claude CLI or OpenCode), or null if not running. */
+  claudeProcess: CodingProcess | null
   /** All browser clients currently viewing this session. */
   clients: Set<WebSocket>
   /** Rolling buffer of messages for replay when a new client joins. */
@@ -55,6 +61,8 @@ export interface Session {
   permissionMode?: PermissionMode
   /** Additional tools to pre-approve via --allowedTools (e.g. 'Bash(curl:*)', 'WebFetch'). */
   allowedTools?: string[]
+  /** Extra directories to grant Claude access to via --add-dir. */
+  addDirs?: string[]
   /** Number of auto-restarts since last cooldown reset. */
   restartCount: number
   lastRestartAt: number | null
@@ -117,6 +125,7 @@ export interface SessionInfo {
   connectedClients: number
   lastActivity: string
   source: 'manual' | 'webhook' | 'workflow' | 'stepflow' | 'orchestrator' | 'agent'
+  provider?: CodingProvider
 }
 
 // ---------------------------------------------------------------------------
@@ -280,11 +289,12 @@ export type WsServerMessage =
 /** Messages sent from browser clients to the server over WebSocket. */
 export type WsClientMessage =
   | { type: 'auth'; token: string }
-  | { type: 'create_session'; name: string; workingDir: string; model?: string; useWorktree?: boolean; permissionMode?: PermissionMode; allowedTools?: string[] }
+  | { type: 'create_session'; name: string; workingDir: string; model?: string; useWorktree?: boolean; permissionMode?: PermissionMode; allowedTools?: string[]; provider?: CodingProvider }
   | { type: 'join_session'; sessionId: string }
   | { type: 'leave_session' }
   | { type: 'start_claude'; options?: Record<string, unknown> }
   | { type: 'set_model'; model: string }
+  | { type: 'set_provider'; provider: CodingProvider }
   | { type: 'set_permission_mode'; permissionMode: PermissionMode }
   | { type: 'stop' }
   | { type: 'input'; data: string; displayText?: string }

--- a/server/ws-message-handler.test.ts
+++ b/server/ws-message-handler.test.ts
@@ -60,6 +60,8 @@ function createContext(): WsHandlerContext & { sent: WsServerMessage[] } {
       sendInput: vi.fn(),
       sendPromptResponse: vi.fn(),
       setModel: vi.fn().mockReturnValue(true),
+      getSessionProvider: vi.fn().mockReturnValue('claude'),
+      setProvider: vi.fn().mockReturnValue(true),
       setPermissionMode: vi.fn().mockReturnValue(true),
       addToHistory: vi.fn(),
       broadcast: vi.fn(),

--- a/server/ws-message-handler.ts
+++ b/server/ws-message-handler.ts
@@ -11,7 +11,7 @@ import { resolve as pathResolve } from 'path'
 import type { WebSocket } from 'ws'
 import { REPOS_ROOT } from './config.js'
 import type { SessionManager } from './session-manager.js'
-import { VALID_MODELS, VALID_PERMISSION_MODES } from './types.js'
+import { VALID_MODELS, VALID_PERMISSION_MODES, VALID_PROVIDERS } from './types.js'
 import type { WsClientMessage, WsServerMessage } from './types.js'
 
 /** Closure state passed to handleWsMessage from the ws.on('connection') scope. */
@@ -44,7 +44,11 @@ export function handleWsMessage(msg: WsClientMessage, ctx: WsHandlerContext): vo
         break
       }
 
-      const session = sessions.create(msg.name, msg.workingDir, { model: msg.model, permissionMode: msg.permissionMode, allowedTools: msg.allowedTools })
+      if (msg.provider && !VALID_PROVIDERS.has(msg.provider)) {
+        send({ type: 'error', message: `Invalid provider: ${msg.provider}` })
+        break
+      }
+      const session = sessions.create(msg.name, msg.workingDir, { model: msg.model, permissionMode: msg.permissionMode, allowedTools: msg.allowedTools, provider: msg.provider })
       session.clients.add(ws)
       clientSessions.set(ws, session.id)
 
@@ -172,11 +176,27 @@ export function handleWsMessage(msg: WsClientMessage, ctx: WsHandlerContext): vo
     case 'set_model': {
       const sessionId = clientSessions.get(ws)
       if (sessionId) {
-        if (!VALID_MODELS.has(msg.model)) {
+        // For OpenCode sessions, accept any model string (models are dynamic).
+        // For Claude sessions, validate against the static allowlist.
+        const sessionProvider = sessions.getSessionProvider(sessionId)
+        if (sessionProvider !== 'opencode' && !VALID_MODELS.has(msg.model)) {
           send({ type: 'error', message: `Invalid model: ${msg.model}` })
           break
         }
         sessions.setModel(sessionId, msg.model)
+      }
+      break
+    }
+
+    // Change the AI provider for the session. Stops old process and restarts with new provider.
+    case 'set_provider': {
+      const sessionId = clientSessions.get(ws)
+      if (sessionId) {
+        if (!VALID_PROVIDERS.has(msg.provider)) {
+          send({ type: 'error', message: `Invalid provider: ${msg.provider}` })
+          break
+        }
+        sessions.setProvider(sessionId, msg.provider)
       }
       break
     }

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -33,6 +33,7 @@ import { loadMdWorkflows } from './workflow-loader.js'
 import { createWorkflowRouter, syncSchedules } from './workflow-routes.js'
 import { CommitEventHandler } from './commit-event-handler.js'
 import { checkForUpdates, getUpdateNotification } from './version-check.js'
+import { stopOpenCodeServer } from './opencode-process.js'
 import { ensureHookConfig, syncCommitHooks } from './commit-event-hooks.js'
 import { createAuthRouter } from './auth-routes.js'
 import { createSessionRouter } from './session-routes.js'
@@ -598,6 +599,7 @@ async function gracefulShutdown(signal: string): Promise<void> {
   webhookHandler.shutdown()
   stepflowHandler.shutdown()
   await sessions.shutdown()
+  stopOpenCodeServer()
   wss.close()
   server.close()
   process.exit(0)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,9 @@ import { DiffPanel } from './components/DiffPanel'
 import { OrchestratorContent } from './components/OrchestratorContent'
 import { DocsBrowserContent } from './components/DocsBrowserContent'
 import { SessionContent } from './components/SessionContent'
-import type { PermissionMode } from './types'
+import type { PermissionMode, CodingProvider, ModelOption } from './types'
+import { CLAUDE_MODELS } from './types'
+import { fetchOpenCodeModels } from './lib/ccApi'
 
 export default function App() {
   const { settings, updateSettings } = useSettings()
@@ -108,6 +110,11 @@ export default function App() {
   /** Permission mode ref for session orchestration (read at session creation time). */
   const permissionModeRef = useRef<PermissionMode>(
     (localStorage.getItem('claude-permission-mode') as PermissionMode) || 'acceptEdits'
+  )
+
+  /** Provider ref for session orchestration (read at session creation time). */
+  const providerRef = useRef<CodingProvider>(
+    (localStorage.getItem('codekin-provider') as CodingProvider) || 'claude'
   )
 
   const inputBarRef = useRef<InputBarHandle>(null)
@@ -184,6 +191,45 @@ export default function App() {
     setPermissionMode(mode)
   }, [setPermissionMode])
 
+  // Provider is per-session; default for new sessions is persisted to localStorage
+  const [currentProvider] = useState<CodingProvider>(
+    (localStorage.getItem('codekin-provider') as CodingProvider) || 'claude'
+  )
+  // Dynamic model list for OpenCode (fetched from server on demand)
+  const [openCodeModels, setOpenCodeModels] = useState<ModelOption[]>([])
+  const openCodeModelsDirRef = useRef<string | undefined>(undefined)
+  // Derive the active session's provider (falls back to the default for new sessions)
+  const activeSessionProvider = sessions.find(s => s.id === activeSessionId)?.provider ?? currentProvider
+  const availableModels = activeSessionProvider === 'opencode' ? openCodeModels : CLAUDE_MODELS
+
+  // Fetch OpenCode models when switching to an OpenCode session
+  const currentModelRef = useRef(currentModel)
+  useEffect(() => { currentModelRef.current = currentModel }, [currentModel])
+
+  const activeOpenCodeWd = activeSessionProvider === 'opencode'
+    ? sessions.find(s => s.id === activeSessionId)?.workingDir
+    : undefined
+  useEffect(() => {
+    if (activeSessionProvider !== 'opencode' || !settings.token) return
+    const wdChanged = activeOpenCodeWd && activeOpenCodeWd !== openCodeModelsDirRef.current
+    if (!wdChanged && openCodeModels.length > 0) return
+    const activeWd = activeOpenCodeWd
+    fetchOpenCodeModels(settings.token, activeWd).then(result => {
+      const models: ModelOption[] = result.models.map(m => ({
+        id: `${m.providerID}/${m.id}`,
+        label: `${m.name} (${m.providerName})`,
+      }))
+      setOpenCodeModels(models)
+      openCodeModelsDirRef.current = activeWd
+      const currentIsOpenCode = currentModelRef.current && models.some(m => m.id === currentModelRef.current)
+      if (!currentIsOpenCode) {
+        const [defaultProvider, defaultModelId] = Object.entries(result.defaults)[0] ?? []
+        if (defaultProvider && defaultModelId) setModel(`${defaultProvider}/${defaultModelId}`)
+        else if (models.length > 0) setModel(models[0].id)
+      }
+    }).catch(() => { /* OpenCode server not available */ })
+  }, [activeSessionProvider, settings.token, openCodeModels.length, setModel, activeOpenCodeWd])
+
   // Reset file-change tracking when switching sessions
   useEffect(() => {
     setHasFileChanges(false) // eslint-disable-line react-hooks/set-state-in-effect -- sync with session change
@@ -212,6 +258,7 @@ export default function App() {
     pendingContextRef,
     useWorktreeRef,
     permissionModeRef,
+    providerRef,
   })
 
   // Derive active repo from the active session
@@ -621,6 +668,7 @@ export default function App() {
             onSessionInputChange={handleSessionInputChange}
             currentModel={currentModel}
             onModelChange={setModel}
+            availableModels={availableModels}
             hasUserMessages={messages.some(m => m.type === 'user')}
             useWorktree={useWorktree}
             onWorktreeChange={setUseWorktree}

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -14,7 +14,7 @@ import { SkillMenu, type SkillGroup } from './SkillMenu'
 import { SlashAutocomplete } from './SlashAutocomplete'
 import { DropZone } from './DropZone'
 import type { SlashCommand } from '../lib/slashCommands'
-import { PERMISSION_MODES, type PermissionMode } from '../types'
+import { PERMISSION_MODES, type PermissionMode, type ModelOption } from '../types'
 
 const PERMISSION_MODE_ICONS: Record<string, typeof IconShieldCheck> = {
   shield: IconShieldCheck,
@@ -23,14 +23,8 @@ const PERMISSION_MODE_ICONS: Record<string, typeof IconShieldCheck> = {
   warning: IconAlertTriangle,
 }
 
-const MODELS = [
-  { id: 'claude-opus-4-6', label: 'Opus 4.6' },
-  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
-  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
-]
-
-function shortModelLabel(modelId: string): string {
-  return MODELS.find(m => m.id === modelId)?.label ?? modelId.replace(/^claude-/, '')
+function shortModelLabel(modelId: string, models: ModelOption[]): string {
+  return models.find(m => m.id === modelId)?.label ?? modelId.replace(/^claude-/, '')
 }
 
 // ---------------------------------------------------------------------------
@@ -138,8 +132,8 @@ function PermissionModeDropdown({ currentMode, isOpen, menuRef, onToggle, onSele
 }
 
 /** Model selector dropdown. */
-function ModelDropdown({ currentModel, isOpen, menuRef, onToggle, onChange }: {
-  currentModel: string; isOpen: boolean
+function ModelDropdown({ currentModel, models, isOpen, menuRef, onToggle, onChange }: {
+  currentModel: string; models: ModelOption[]; isOpen: boolean
   menuRef: React.RefObject<HTMLDivElement | null>
   onToggle: () => void; onChange: (model: string) => void
 }) {
@@ -150,12 +144,12 @@ function ModelDropdown({ currentModel, isOpen, menuRef, onToggle, onChange }: {
         className="flex items-center gap-1 rounded-md px-2 py-1 text-[12px] font-medium text-neutral-4 hover:text-neutral-2 hover:bg-neutral-7 transition-colors"
         title="Change model"
       >
-        {shortModelLabel(currentModel)}
+        {shortModelLabel(currentModel, models)}
         <IconChevronDown size={12} stroke={2} />
       </button>
       {isOpen && (
         <div className="absolute bottom-full mb-1 right-0 z-50 min-w-[160px] rounded-lg border border-neutral-6 bg-neutral-8 shadow-lg py-1">
-          {MODELS.map(m => (
+          {models.map(m => (
             <button
               key={m.id}
               onClick={() => onChange(m.id)}
@@ -209,6 +203,8 @@ interface InputBarProps {
   currentModel?: string | null
   /** Called when the user selects a different model from the picker. */
   onModelChange?: (model: string) => void
+  /** Available models for the current provider. */
+  availableModels?: ModelOption[]
   /** Override the default placeholder text in the textarea. */
   placeholder?: string
   /** When true, disables drag-to-resize and uses auto-height instead. */
@@ -231,7 +227,7 @@ interface InputBarProps {
   variant?: InputBarVariant
 }
 
-export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function InputBar({ onSendInput, isWaiting, disabled, onEscape, pendingFiles, onAddFiles, onRemoveFile, skillGroups, slashCommands, initialValue = '', onValueChange, currentModel, onModelChange, placeholder, isMobile = false, showWorktreeToggle = false, useWorktree = false, onWorktreeChange, currentPermissionMode, onPermissionModeChange, onMoveToWorktree, worktreePath, variant = 'default' }, ref) {
+export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function InputBar({ onSendInput, isWaiting, disabled, onEscape, pendingFiles, onAddFiles, onRemoveFile, skillGroups, slashCommands, initialValue = '', onValueChange, currentModel, onModelChange, availableModels = [], placeholder, isMobile = false, showWorktreeToggle = false, useWorktree = false, onWorktreeChange, currentPermissionMode, onPermissionModeChange, onMoveToWorktree, worktreePath, variant = 'default' }, ref) {
   const isOrchestrator = variant === 'orchestrator'
   const [value, setValue] = useState(initialValue)
   const [skillMenuOpen, setSkillMenuOpen] = useState(false)
@@ -525,6 +521,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
               {currentModel && onModelChange && (
                 <ModelDropdown
                   currentModel={currentModel}
+                  models={availableModels}
                   isOpen={modelMenuOpen}
                   menuRef={modelMenuRef}
                   onToggle={() => { closeAllPopups('model'); setModelMenuOpen(!modelMenuOpen) }}
@@ -621,7 +618,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
                     {currentModel && onModelChange && (
                       <>
                         <div className="px-3 py-1.5 text-[12px] text-neutral-5 uppercase tracking-wider">Model</div>
-                        {MODELS.map(m => (
+                        {availableModels.map(m => (
                           <button
                             key={m.id}
                             onClick={() => { onModelChange(m.id); setMobileMenuOpen(false) }}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -105,7 +105,7 @@ interface Props {
   /** Rename a session in the sidebar tree. */
   onRenameSession: (id: string, name: string) => void
   /** Create a new session in the active repo. */
-  onNewSession: () => void
+  onNewSession: (provider?: import('../types').CodingProvider) => void
   /** Create a new session seeded with context from an archived session. */
   onNewSessionFromArchive: (workingDir: string, context: string) => void
   /** Open (or create) a session for a specific repo, optionally with a name. */

--- a/src/components/SessionContent.tsx
+++ b/src/components/SessionContent.tsx
@@ -48,6 +48,7 @@ export interface SessionContentProps {
   onSessionInputChange: (sessionId: string, value: string) => void
   currentModel: string | null
   onModelChange: (model: string) => void
+  availableModels?: import('../types').ModelOption[]
   hasUserMessages: boolean
   useWorktree: boolean
   onWorktreeChange: (v: boolean) => void
@@ -87,6 +88,7 @@ export function SessionContent({
   onSessionInputChange,
   currentModel,
   onModelChange,
+  availableModels,
   hasUserMessages,
   useWorktree,
   onWorktreeChange,
@@ -168,6 +170,7 @@ export function SessionContent({
         onValueChange={(v) => { onSessionInputChange(activeSessionId, v) }}
         currentModel={currentModel}
         onModelChange={onModelChange}
+        availableModels={availableModels}
         isMobile={isMobile}
         showWorktreeToggle={!hasUserMessages}
         useWorktree={useWorktree}

--- a/src/hooks/useChatSocket.ts
+++ b/src/hooks/useChatSocket.ts
@@ -430,8 +430,8 @@ export function useChatSocket({
     send({ type: 'join_session', sessionId })
   }, [send])
 
-  const createSession = useCallback((name: string, workingDir: string, useWorktree?: boolean, permissionMode?: PermissionMode) => {
-    send({ type: 'create_session', name, workingDir, useWorktree, permissionMode })
+  const createSession = useCallback((name: string, workingDir: string, useWorktree?: boolean, permissionMode?: PermissionMode, provider?: import('../types').CodingProvider) => {
+    send({ type: 'create_session', name, workingDir, useWorktree, permissionMode, provider })
   }, [send])
 
   const sendInput = useCallback((data: string, displayText?: string) => {

--- a/src/hooks/useSessionOrchestration.test.ts
+++ b/src/hooks/useSessionOrchestration.test.ts
@@ -147,7 +147,7 @@ describe('useSessionOrchestration', () => {
 
     expect(params.clearMessages).toHaveBeenCalled()
     expect(params.leaveSession).toHaveBeenCalled()
-    expect(params.wsCreateSession).toHaveBeenCalledWith('hub:myrepo', '/newrepo', true, 'plan')
+    expect(params.wsCreateSession).toHaveBeenCalledWith('hub:myrepo', '/newrepo', true, 'plan', undefined)
     unmount()
   })
 
@@ -280,7 +280,7 @@ describe('useSessionOrchestration', () => {
 
     expect(params.clearMessages).toHaveBeenCalled()
     expect(params.leaveSession).toHaveBeenCalled()
-    expect(params.wsCreateSession).toHaveBeenCalledWith('hub:repo1', '/repo', true, 'acceptEdits')
+    expect(params.wsCreateSession).toHaveBeenCalledWith('hub:repo1', '/repo', true, 'acceptEdits', undefined)
     unmount()
   })
 
@@ -298,7 +298,7 @@ describe('useSessionOrchestration', () => {
     expect(params.pendingContextRef.current).toBe('archived context')
     expect(params.clearMessages).toHaveBeenCalled()
     expect(params.leaveSession).toHaveBeenCalled()
-    expect(params.wsCreateSession).toHaveBeenCalledWith('hub:repo1', '/repo', false, 'default')
+    expect(params.wsCreateSession).toHaveBeenCalledWith('hub:repo1', '/repo', false, 'default', undefined)
     unmount()
   })
 })

--- a/src/hooks/useSessionOrchestration.ts
+++ b/src/hooks/useSessionOrchestration.ts
@@ -21,13 +21,14 @@ export interface UseSessionOrchestrationParams {
   joinSession: (sessionId: string) => void
   leaveSession: () => void
   clearMessages: () => void
-  wsCreateSession: (name: string, workingDir: string, useWorktree?: boolean, permissionMode?: PermissionMode) => void
+  wsCreateSession: (name: string, workingDir: string, useWorktree?: boolean, permissionMode?: PermissionMode, provider?: import('../types').CodingProvider) => void
   removeSession: (sessionId: string) => Promise<void>
   pendingContextRef: React.RefObject<string | null>
   /** Ref to the current worktree preference (read at session creation time). */
   useWorktreeRef: React.RefObject<boolean>
   /** Ref to the current permission mode preference (read at session creation time). */
   permissionModeRef: React.RefObject<PermissionMode>
+  providerRef?: React.RefObject<import('../types').CodingProvider>
 }
 
 export interface UseSessionOrchestrationReturn {
@@ -55,6 +56,7 @@ export function useSessionOrchestration({
   pendingContextRef,
   useWorktreeRef,
   permissionModeRef,
+  providerRef,
 }: UseSessionOrchestrationParams): UseSessionOrchestrationReturn {
   // Derive active session and grouping key
   const activeSession = activeSessionId ? sessions.find(s => s.id === activeSessionId) ?? null : null
@@ -71,8 +73,8 @@ export function useSessionOrchestration({
     }
     clearMessages()
     leaveSession()
-    wsCreateSession(`hub:${repo.id}`, repo.workingDir, useWorktreeRef.current, permissionModeRef.current)
-  }, [sessions, joinSession, wsCreateSession, leaveSession, clearMessages, useWorktreeRef, permissionModeRef])
+    wsCreateSession(`hub:${repo.id}`, repo.workingDir, useWorktreeRef.current, permissionModeRef.current, providerRef?.current)
+  }, [sessions, joinSession, wsCreateSession, leaveSession, clearMessages, useWorktreeRef, permissionModeRef, providerRef])
 
   const handleSelectSession = useCallback((sessionId: string) => {
     if (sessionId === activeSessionId) return
@@ -137,8 +139,8 @@ export function useSessionOrchestration({
     const repoId = repo?.id ?? workingDir.split('/').pop() ?? 'session'
     clearMessages()
     leaveSession()
-    wsCreateSession(`hub:${repoId}`, workingDir, useWorktreeRef.current, permissionModeRef.current)
-  }, [activeWorkingDir, repos, clearMessages, leaveSession, wsCreateSession, permissionModeRef, useWorktreeRef])
+    wsCreateSession(`hub:${repoId}`, workingDir, useWorktreeRef.current, permissionModeRef.current, providerRef?.current)
+  }, [activeWorkingDir, repos, clearMessages, leaveSession, wsCreateSession, permissionModeRef, useWorktreeRef, providerRef])
 
   const handleNewSessionFromArchive = useCallback((workingDir: string, context: string) => {
     const repo = repos.find(r => r.workingDir === workingDir)
@@ -146,8 +148,8 @@ export function useSessionOrchestration({
     pendingContextRef.current = context
     clearMessages()
     leaveSession()
-    wsCreateSession(`hub:${repo.id}`, repo.workingDir, useWorktreeRef.current, permissionModeRef.current)
-  }, [repos, clearMessages, leaveSession, wsCreateSession, pendingContextRef, permissionModeRef, useWorktreeRef])
+    wsCreateSession(`hub:${repo.id}`, repo.workingDir, useWorktreeRef.current, permissionModeRef.current, providerRef?.current)
+  }, [repos, clearMessages, leaveSession, wsCreateSession, pendingContextRef, permissionModeRef, useWorktreeRef, providerRef])
 
   return {
     activeSession,

--- a/src/lib/ccApi.ts
+++ b/src/lib/ccApi.ts
@@ -448,3 +448,19 @@ export function wsUrl(): string {
   const proto = location.protocol === 'https:' ? 'wss:' : 'ws:'
   return `${proto}//${location.host}/cc/`
 }
+
+/** Fetch available models from the OpenCode server. */
+export async function fetchOpenCodeModels(
+  token: string,
+  workingDir?: string,
+): Promise<{
+  models: Array<{ id: string; name: string; providerID: string; providerName: string }>
+  defaults: Record<string, string>
+}> {
+  const params = workingDir ? `?workingDir=${encodeURIComponent(workingDir)}` : ''
+  const res = await fetch(`${BASE}/api/opencode/models${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) return { models: [], defaults: {} }
+  return res.json()
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,29 @@ export interface RepoManifest {
  */
 export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions' | 'dangerouslySkipPermissions'
 
+/**
+ * Supported AI coding assistant providers.
+ * - 'claude': Claude Code CLI (subprocess, NDJSON on stdin/stdout)
+ * - 'opencode': OpenCode server (HTTP REST + SSE)
+ */
+export type CodingProvider = 'claude' | 'opencode'
+
+/** Provider metadata for the UI selector. */
+export const PROVIDERS: { id: CodingProvider; label: string; description: string }[] = [
+  { id: 'claude', label: 'Claude Code', description: 'Anthropic Claude Code CLI' },
+  { id: 'opencode', label: 'OpenCode', description: 'OpenCode server (multi-provider)' },
+]
+
+/** Model option for UI selectors. */
+export interface ModelOption { id: string; label: string }
+
+/** Static models for Claude Code CLI. */
+export const CLAUDE_MODELS: ModelOption[] = [
+  { id: 'claude-opus-4-6', label: 'Opus 4.6' },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+  { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
+]
+
 /** Permission mode metadata for the UI selector. */
 export const PERMISSION_MODES: { id: PermissionMode; label: string; description: string; icon: string; dangerous?: boolean }[] = [
   { id: 'default', label: 'Ask permissions', description: 'Always ask before making changes', icon: 'shield' },
@@ -77,6 +100,8 @@ export interface Session {
   lastActivity: string
   /** How the session was created: manually by a user, by a GitHub webhook, or by a workflow. */
   source?: 'manual' | 'webhook' | 'workflow' | 'stepflow' | 'orchestrator' | 'agent'
+  /** Which AI provider powers this session. Defaults to 'claude'. */
+  provider?: CodingProvider
 }
 
 /**
@@ -95,11 +120,12 @@ export interface Session {
  */
 export type WsClientMessage =
   | { type: 'auth'; token: string }
-  | { type: 'create_session'; name: string; workingDir: string; model?: string; useWorktree?: boolean; permissionMode?: PermissionMode; allowedTools?: string[] }
+  | { type: 'create_session'; name: string; workingDir: string; model?: string; useWorktree?: boolean; permissionMode?: PermissionMode; allowedTools?: string[]; provider?: CodingProvider }
   | { type: 'join_session'; sessionId: string }
   | { type: 'leave_session' }
   | { type: 'start_claude'; options?: Record<string, unknown> }
   | { type: 'set_model'; model: string }
+  | { type: 'set_provider'; provider: CodingProvider }
   | { type: 'set_permission_mode'; permissionMode: PermissionMode }
   | { type: 'stop' }
   | { type: 'input'; data: string; displayText?: string }


### PR DESCRIPTION
## Summary

Cherry-picked and adapted from PR #319 (external fork contribution by @benjamin-talic). This is the largest of the split PRs and introduces a provider abstraction for AI coding assistants.

**Should merge after** #320 (agent permissions) and #321 (PR webhooks) since it touches shared core files.

### CodingProcess Abstraction
- New `CodingProcess` interface in `server/coding-process.ts` — defines the common surface for AI process management (start/stop, sendMessage, isAlive, isReady, events)
- `ClaudeProcess` now `implements CodingProcess` with `isReady()`, `provider`, `capabilities`
- `CodingProvider` type: `'claude' | 'opencode'`

### OpenCode Provider
- `OpenCodeProcess` class (~792 lines) — HTTP/SSE client wrapping OpenCode's REST API behind the CodingProcess interface
- Singleton server management (start/stop `opencode serve`)
- Dynamic model fetching from OpenCode's `/config/providers` endpoint

### Session System
- `Session.provider` field, persisted across restarts
- `SessionManager.setProvider()` — switch provider mid-session (clears session ID, restarts)
- `isReady()` queuing in `sendInput()` — OpenCode needs to wait for server init before accepting messages
- Webhook sessions excluded from auto-restore on server restart

### Frontend
- `CodingProvider`, `ModelOption`, `CLAUDE_MODELS` types in `src/types.ts`
- `InputBar` accepts `availableModels` prop (dynamic, no more hardcoded list)
- `App.tsx` manages provider state, fetches OpenCode models on demand
- Session creation passes provider through WebSocket message

## Changed files (23 files)

**New:** `coding-process.ts`, `opencode-process.ts`, + 3 test files
**Modified:** `claude-process.ts`, `types.ts`, `session-manager.ts`, `session-lifecycle.ts`, `session-persistence.ts`, `prompt-router.ts`, `ws-message-handler.ts`, `ws-server.ts`, `App.tsx`, `InputBar.tsx`, `SessionContent.tsx`, `LeftSidebar.tsx`, `useChatSocket.ts`, `useSessionOrchestration.ts`, `ccApi.ts`, `src/types.ts`, + 2 test files

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (1409 tests across 51 files)
- [x] `npm run lint` passes (0 errors)
- [ ] Manual: create a Claude session, verify it works identically to before
- [ ] Manual: if OpenCode binary is available, create an OpenCode session and verify streaming works
- [ ] Manual: switch provider on a running session, verify restart behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)