### PR TITLE
test: add coverage for session-lifecycle, orchestrator-children, and prompt-router

### DIFF
--- a/server/orchestrator-children.test.ts
+++ b/server/orchestrator-children.test.ts
@@ -1,12 +1,19 @@
-/** Tests for OrchestratorChildManager — verifies prompt generation for
- * worktree vs non-worktree scenarios and worktree failure context. */
-import { describe, it, expect, vi } from 'vitest'
+/** Tests for OrchestratorChildManager — verifies spawn, status tracking,
+ * listing, timeout, and prompt generation. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
 vi.mock('./config.js', () => ({
   getAgentDisplayName: () => 'TestAgent',
+  PORT: 32352,
+  DATA_DIR: '/tmp/codekin-test',
 }))
 
 import { OrchestratorChildManager, type ChildSessionRequest } from './orchestrator-children.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
 function makeRequest(overrides: Partial<ChildSessionRequest> = {}): ChildSessionRequest {
   return {
@@ -20,39 +27,317 @@ function makeRequest(overrides: Partial<ChildSessionRequest> = {}): ChildSession
   }
 }
 
-function fakeSessionManager(worktreeSucceeds = true) {
+function makeMockSessions(worktreeSucceeds = true) {
   const sentInputs: string[] = []
+  const resultListeners: Array<(sessionId: string, isError: boolean) => void> = []
+  const exitListeners: Array<(sessionId: string, code: number | null, signal: string | null, willRestart: boolean) => void> = []
+
   return {
-    create: vi.fn(() => ({ id: 'child-session-id' })),
+    create: vi.fn(),
     createWorktree: vi.fn(async () => worktreeSucceeds ? '/repos/myproject-wt-child123' : null),
     startClaude: vi.fn(),
-    sendInput: vi.fn((_, prompt: string) => { sentInputs.push(prompt) }),
+    sendInput: vi.fn((_: string, prompt: string) => { sentInputs.push(prompt) }),
     get: vi.fn(() => ({
-      claudeProcess: {
-        isAlive: () => true,
-        on: vi.fn(),
-        once: vi.fn(),
-      },
+      claudeProcess: { isAlive: vi.fn(() => false), stop: vi.fn() },
       outputHistory: [],
+      pendingToolApprovals: new Map(),
+      pendingControlRequests: new Map(),
     })),
-    onSessionExit: vi.fn(() => vi.fn()),
-    onSessionResult: vi.fn(() => vi.fn()),
+    onSessionResult: vi.fn((cb: any) => {
+      resultListeners.push(cb)
+      return () => { const idx = resultListeners.indexOf(cb); if (idx >= 0) resultListeners.splice(idx, 1) }
+    }),
+    onSessionExit: vi.fn((cb: any) => {
+      exitListeners.push(cb)
+      return () => { const idx = exitListeners.indexOf(cb); if (idx >= 0) exitListeners.splice(idx, 1) }
+    }),
     clearProcessingFlag: vi.fn(),
     _sentInputs: sentInputs,
+    _resultListeners: resultListeners,
+    _exitListeners: exitListeners,
   } as any
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 describe('OrchestratorChildManager', () => {
-  describe('spawn() prompt generation', () => {
+  let sessions: ReturnType<typeof makeMockSessions>
+  let manager: OrchestratorChildManager
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // spawn
+  // -------------------------------------------------------------------------
+
+  describe('spawn', () => {
+    beforeEach(() => {
+      sessions = makeMockSessions()
+      manager = new OrchestratorChildManager(sessions)
+    })
+
+    it('creates a child that transitions from starting to running', async () => {
+      const child = await manager.spawn(makeRequest())
+
+      expect(child.status).toBe('running')
+      expect(child.request.task).toBe('Fix the login bug')
+      expect(child.startedAt).toBeTruthy()
+      expect(child.completedAt).toBeNull()
+      expect(child.result).toBeNull()
+    })
+
+    it('calls sessions.create with correct args', async () => {
+      const child = await manager.spawn(makeRequest())
+
+      expect(sessions.create).toHaveBeenCalledWith(
+        'testagent:fix/login-bug',
+        '/repos/myproject',
+        expect.objectContaining({
+          source: 'agent',
+          id: child.id,
+          groupDir: '/repos/myproject',
+          permissionMode: 'acceptEdits',
+        }),
+      )
+      expect(sessions.startClaude).toHaveBeenCalledWith(child.id)
+      expect(sessions.sendInput).toHaveBeenCalledWith(child.id, expect.stringContaining('Fix the login bug'))
+    })
+
+    it('creates a worktree when requested', async () => {
+      const child = await manager.spawn(makeRequest({ useWorktree: true }))
+
+      expect(sessions.createWorktree).toHaveBeenCalledWith(child.id, '/repos/myproject', 'fix/login-bug')
+      expect(child.status).toBe('running')
+    })
+
+    it('falls back gracefully when worktree creation fails', async () => {
+      sessions = makeMockSessions(false)
+      manager = new OrchestratorChildManager(sessions)
+
+      const child = await manager.spawn(makeRequest({ useWorktree: true }))
+
+      expect(child.status).toBe('running')
+      const prompt = sessions._sentInputs[0]
+      expect(prompt).toContain('Worktree Not Available')
+    })
+
+    it('records failed status when session creation throws', async () => {
+      sessions.create = vi.fn(() => { throw new Error('create failed') })
+
+      const child = await manager.spawn(makeRequest())
+
+      expect(child.status).toBe('failed')
+      expect(child.error).toBe('create failed')
+      expect(child.completedAt).toBeTruthy()
+    })
+
+    it('throws when at max concurrent sessions (5)', async () => {
+      for (let i = 0; i < 5; i++) {
+        await manager.spawn(makeRequest({ branchName: `fix/bug-${i}` }))
+      }
+
+      await expect(manager.spawn(makeRequest({ branchName: 'fix/one-too-many' }))).rejects.toThrow(/concurrent sessions/)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Status tracking via monitorChild hooks
+  // -------------------------------------------------------------------------
+
+  describe('status tracking', () => {
+    beforeEach(() => {
+      sessions = makeMockSessions()
+      manager = new OrchestratorChildManager(sessions)
+    })
+
+    it('marks child as completed when result event fires', async () => {
+      sessions.get = vi.fn(() => ({
+        claudeProcess: { isAlive: vi.fn(() => false), stop: vi.fn() },
+        outputHistory: [{ type: 'output', data: 'Done! Created PR #42 with all changes.' }],
+        pendingToolApprovals: new Map(),
+        pendingControlRequests: new Map(),
+      }))
+
+      const child = await manager.spawn(makeRequest())
+
+      for (const listener of sessions._resultListeners) {
+        listener(child.id, false)
+      }
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('completed')
+      })
+      expect(child.result).toContain('Created PR #42')
+    })
+
+    it('marks child as failed on error result', async () => {
+      sessions.get = vi.fn(() => ({
+        claudeProcess: { isAlive: vi.fn(() => false), stop: vi.fn() },
+        outputHistory: [{ type: 'output', data: 'Error: something broke badly' }],
+        pendingToolApprovals: new Map(),
+        pendingControlRequests: new Map(),
+      }))
+
+      const child = await manager.spawn(makeRequest())
+
+      for (const listener of sessions._resultListeners) {
+        listener(child.id, true)
+      }
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('failed')
+      })
+      expect(child.error).toBe('Claude returned an error')
+    })
+
+    it('marks child as completed on exit with sufficient output', async () => {
+      sessions.get = vi.fn(() => ({
+        claudeProcess: null,
+        outputHistory: [{ type: 'output', data: 'A'.repeat(200) }],
+        pendingToolApprovals: new Map(),
+        pendingControlRequests: new Map(),
+      }))
+
+      const child = await manager.spawn(makeRequest())
+
+      for (const listener of sessions._exitListeners) {
+        listener(child.id, 0, null, false)
+      }
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('completed')
+      })
+    })
+
+    it('marks child as failed on exit without sufficient output', async () => {
+      sessions.get = vi.fn(() => ({
+        claudeProcess: null,
+        outputHistory: [{ type: 'output', data: 'short' }],
+        pendingToolApprovals: new Map(),
+        pendingControlRequests: new Map(),
+      }))
+
+      const child = await manager.spawn(makeRequest())
+
+      for (const listener of sessions._exitListeners) {
+        listener(child.id, 1, null, false)
+      }
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('failed')
+      })
+      expect(child.error).toContain('without sufficient output')
+    })
+
+    it('keeps monitoring when exit has willRestart=true', async () => {
+      const child = await manager.spawn(makeRequest())
+
+      for (const listener of sessions._exitListeners) {
+        listener(child.id, 1, 'SIGTERM', true)
+      }
+
+      expect(child.status).toBe('running')
+    })
+
+    it('marks child as failed when session is deleted', async () => {
+      sessions.get = vi.fn(() => null)
+
+      const child = await manager.spawn(makeRequest())
+
+      for (const listener of sessions._resultListeners) {
+        listener(child.id, false)
+      }
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('failed')
+      })
+      expect(child.error).toBe('Session was deleted')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Timeout
+  // -------------------------------------------------------------------------
+
+  describe('timeout', () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      sessions = makeMockSessions()
+      manager = new OrchestratorChildManager(sessions)
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('times out after specified duration', async () => {
+      sessions.get = vi.fn(() => ({
+        claudeProcess: { isAlive: vi.fn(() => true), stop: vi.fn() },
+        outputHistory: [],
+        pendingToolApprovals: new Map(),
+        pendingControlRequests: new Map(),
+      }))
+
+      const child = await manager.spawn(makeRequest({ timeoutMs: 5000 }))
+
+      vi.advanceTimersByTime(5000)
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('timed_out')
+      })
+      expect(child.error).toContain('Timed out')
+      expect(child.completedAt).toBeTruthy()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Listing and retrieval
+  // -------------------------------------------------------------------------
+
+  describe('list and get', () => {
+    beforeEach(() => {
+      sessions = makeMockSessions()
+      manager = new OrchestratorChildManager(sessions)
+    })
+
+    it('lists children and retrieves by ID', async () => {
+      const child1 = await manager.spawn(makeRequest({ branchName: 'fix/a' }))
+      const child2 = await manager.spawn(makeRequest({ branchName: 'fix/b' }))
+
+      const list = manager.list()
+      expect(list.length).toBe(2)
+      // Both children should be present
+      const ids = list.map(c => c.id)
+      expect(ids).toContain(child1.id)
+      expect(ids).toContain(child2.id)
+    })
+
+    it('retrieves a child by ID', async () => {
+      const child = await manager.spawn(makeRequest())
+
+      expect(manager.get(child.id)).toBe(child)
+      expect(manager.get('nonexistent')).toBeNull()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Prompt generation (existing tests migrated + expanded)
+  // -------------------------------------------------------------------------
+
+  describe('prompt generation', () => {
+    beforeEach(() => {
+      sessions = makeMockSessions()
+      manager = new OrchestratorChildManager(sessions)
+    })
+
     it('includes worktree environment section when worktree succeeds', async () => {
-      const sm = fakeSessionManager(true)
-      const mgr = new OrchestratorChildManager(sm)
-      const request = makeRequest({ useWorktree: true })
+      await manager.spawn(makeRequest({ useWorktree: true }))
 
-      await mgr.spawn(request)
-
-      expect(sm._sentInputs).toHaveLength(1)
-      const prompt = sm._sentInputs[0]
+      const prompt = sessions._sentInputs[0]
       expect(prompt).toContain('Worktree Environment')
       expect(prompt).toContain('isolated git worktree')
       expect(prompt).toContain('fix/login-bug')
@@ -60,69 +345,43 @@ describe('OrchestratorChildManager', () => {
     })
 
     it('does NOT include worktree section when worktree not requested', async () => {
-      const sm = fakeSessionManager(true)
-      const mgr = new OrchestratorChildManager(sm)
-      const request = makeRequest({ useWorktree: false })
+      await manager.spawn(makeRequest({ useWorktree: false }))
 
-      await mgr.spawn(request)
-
-      const prompt = sm._sentInputs[0]
+      const prompt = sessions._sentInputs[0]
       expect(prompt).not.toContain('Worktree Environment')
       expect(prompt).not.toContain('EnterWorktree')
     })
 
-    it('includes worktree failure warning when worktree creation fails', async () => {
-      const sm = fakeSessionManager(false) // worktree fails
-      const mgr = new OrchestratorChildManager(sm)
-      const request = makeRequest({ useWorktree: true })
-
-      await mgr.spawn(request)
-
-      const prompt = sm._sentInputs[0]
-      expect(prompt).toContain('Worktree Not Available')
-      expect(prompt).toContain('directly in the main repository')
-      expect(prompt).toContain('Create branch `fix/login-bug`')
-      expect(prompt).not.toContain('Worktree Environment')
-    })
-
     it('omits create-branch step in PR completion when in worktree', async () => {
-      const sm = fakeSessionManager(true)
-      const mgr = new OrchestratorChildManager(sm)
-      const request = makeRequest({ useWorktree: true, completionPolicy: 'pr' })
+      await manager.spawn(makeRequest({ useWorktree: true, completionPolicy: 'pr' }))
 
-      await mgr.spawn(request)
-
-      const prompt = sm._sentInputs[0]
-      // Should NOT tell Claude to create/switch branches
+      const prompt = sessions._sentInputs[0]
       expect(prompt).not.toContain('Create and switch to branch')
-      // Should still mention push + PR
       expect(prompt).toContain('Push the branch')
       expect(prompt).toContain('Pull Request')
     })
 
-    it('includes create-branch step in PR completion when NOT in worktree', async () => {
-      const sm = fakeSessionManager(false) // worktree fails
-      const mgr = new OrchestratorChildManager(sm)
-      const request = makeRequest({ useWorktree: true, completionPolicy: 'pr' })
+    it('includes create-branch step when NOT in worktree', async () => {
+      sessions = makeMockSessions(false)
+      manager = new OrchestratorChildManager(sessions)
+      await manager.spawn(makeRequest({ useWorktree: true, completionPolicy: 'pr' }))
 
-      await mgr.spawn(request)
-
-      const prompt = sm._sentInputs[0]
+      const prompt = sessions._sentInputs[0]
       expect(prompt).toContain('Create and switch to branch')
     })
 
-    it('passes branchName to createWorktree', async () => {
-      const sm = fakeSessionManager(true)
-      const mgr = new OrchestratorChildManager(sm)
-      const request = makeRequest({ branchName: 'feat/my-feature' })
+    it('generates merge completion instructions', async () => {
+      await manager.spawn(makeRequest({ completionPolicy: 'merge', useWorktree: false }))
 
-      await mgr.spawn(request)
+      const prompt = sessions._sentInputs[0]
+      expect(prompt).toContain('Push directly to the current branch')
+    })
 
-      expect(sm.createWorktree).toHaveBeenCalledWith(
-        expect.any(String),
-        '/repos/myproject',
-        'feat/my-feature',
-      )
+    it('generates commit-only completion instructions', async () => {
+      await manager.spawn(makeRequest({ completionPolicy: 'commit-only', useWorktree: false }))
+
+      const prompt = sessions._sentInputs[0]
+      expect(prompt).toContain('Do NOT push')
     })
   })
 })

--- a/server/prompt-router.test.ts
+++ b/server/prompt-router.test.ts
@@ -1,0 +1,479 @@
+/** Tests for PromptRouter — verifies auto-approval decision tree, control request handling, and prompt routing. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { PromptRouter, type PromptRouterDeps } from './prompt-router.js'
+import type { Session, WsServerMessage } from './types.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePlanManager() {
+  return {
+    reset: vi.fn(),
+    onEnterPlanMode: vi.fn(),
+    onTurnEnd: vi.fn(),
+    onExitPlanModeRequested: vi.fn(() => null),
+    deny: vi.fn(),
+    approve: vi.fn(),
+    state: 'idle' as const,
+    pendingReviewId: null,
+  }
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-1',
+    name: 'test-session',
+    workingDir: '/repos/test',
+    created: new Date().toISOString(),
+    source: 'manual',
+    claudeProcess: {
+      isAlive: vi.fn(() => true),
+      sendMessage: vi.fn(),
+      sendControlResponse: vi.fn(),
+    } as any,
+    clients: new Set(['ws-client'] as any),
+    outputHistory: [],
+    claudeSessionId: null,
+    permissionMode: 'default',
+    allowedTools: [],
+    restartCount: 0,
+    lastRestartAt: null,
+    _stoppedByUser: false,
+    _wasActiveBeforeRestart: false,
+    pendingControlRequests: new Map(),
+    pendingToolApprovals: new Map(),
+    isProcessing: false,
+    _turnCount: 0,
+    _claudeTurnCount: 0,
+    _namingAttempts: 0,
+    _apiRetryCount: 0,
+    _lastActivityAt: Date.now(),
+    planManager: makePlanManager() as any,
+    ...overrides,
+  } as Session
+}
+
+function makeDeps(session: Session, overrides: Partial<PromptRouterDeps> = {}): PromptRouterDeps {
+  return {
+    getSession: vi.fn(() => session),
+    allSessions: vi.fn(function* () { yield session }),
+    broadcast: vi.fn(),
+    addToHistory: vi.fn(),
+    globalBroadcast: vi.fn(),
+    approvalManager: {
+      checkAutoApproval: vi.fn(() => false),
+      saveAlwaysAllow: vi.fn(),
+      savePatternApproval: vi.fn(),
+      derivePattern: vi.fn(() => null),
+      NEVER_AUTO_APPROVE_TOOLS: new Set(),
+    } as any,
+    promptListeners: [],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PromptRouter', () => {
+  let session: Session
+  let deps: PromptRouterDeps
+  let router: PromptRouter
+
+  beforeEach(() => {
+    session = makeSession()
+    deps = makeDeps(session)
+    router = new PromptRouter(deps)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // resolveAutoApproval
+  // -------------------------------------------------------------------------
+
+  describe('resolveAutoApproval', () => {
+    it('returns "permissionMode" for file tools in acceptEdits mode', () => {
+      session.permissionMode = 'acceptEdits'
+      const result = router.resolveAutoApproval(session, 'Read', {})
+      expect(result).toBe('permissionMode')
+    })
+
+    it('returns "permissionMode" for Edit in bypassPermissions mode', () => {
+      session.permissionMode = 'bypassPermissions'
+      expect(router.resolveAutoApproval(session, 'Edit', {})).toBe('permissionMode')
+    })
+
+    it('does not auto-approve file tools in default mode', () => {
+      session.permissionMode = 'default'
+      expect(router.resolveAutoApproval(session, 'Read', {})).toBe('prompt')
+    })
+
+    it('returns "registry" when approval manager matches', () => {
+      ;(deps.approvalManager.checkAutoApproval as any).mockReturnValue(true)
+      const result = router.resolveAutoApproval(session, 'Bash', { command: 'npm test' })
+      expect(result).toBe('registry')
+    })
+
+    it('returns "session" when tool matches session allowedTools', () => {
+      session.allowedTools = ['WebFetch']
+      const result = router.resolveAutoApproval(session, 'WebFetch', {})
+      expect(result).toBe('session')
+    })
+
+    it('returns "session" for parameterized allowedTools pattern', () => {
+      session.allowedTools = ['Bash(curl:*)']
+      const result = router.resolveAutoApproval(session, 'Bash', { command: 'curl https://example.com' })
+      expect(result).toBe('session')
+    })
+
+    it('does not match parameterized pattern when prefix differs', () => {
+      session.allowedTools = ['Bash(curl:*)']
+      const result = router.resolveAutoApproval(session, 'Bash', { command: 'wget https://example.com' })
+      expect(result).toBe('prompt')
+    })
+
+    it('returns "headless" for webhook session with no clients', () => {
+      session.source = 'webhook'
+      session.clients = new Set() as any
+      const result = router.resolveAutoApproval(session, 'Bash', { command: 'npm test' })
+      expect(result).toBe('headless')
+    })
+
+    it('returns "headless" for orchestrator session with no clients', () => {
+      session.source = 'orchestrator'
+      session.clients = new Set() as any
+      expect(router.resolveAutoApproval(session, 'Bash', {})).toBe('headless')
+    })
+
+    it('returns "prompt" for manual session with no clients', () => {
+      session.source = 'manual'
+      session.clients = new Set() as any
+      expect(router.resolveAutoApproval(session, 'Bash', {})).toBe('prompt')
+    })
+
+    it('returns "prompt" when nothing matches', () => {
+      expect(router.resolveAutoApproval(session, 'Bash', { command: 'rm -rf /' })).toBe('prompt')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // requestToolApproval — auto-approval paths
+  // -------------------------------------------------------------------------
+
+  describe('requestToolApproval', () => {
+    it('auto-approves via permissionMode', async () => {
+      session.permissionMode = 'acceptEdits'
+      const result = await router.requestToolApproval('sess-1', 'Write', { file_path: '/test.ts' })
+      expect(result).toEqual({ allow: true, always: false })
+    })
+
+    it('auto-approves via registry', async () => {
+      ;(deps.approvalManager.checkAutoApproval as any).mockReturnValue(true)
+      const result = await router.requestToolApproval('sess-1', 'Bash', { command: 'npm test' })
+      expect(result).toEqual({ allow: true, always: true })
+    })
+
+    it('auto-approves via session allowedTools', async () => {
+      session.allowedTools = ['WebFetch']
+      const result = await router.requestToolApproval('sess-1', 'WebFetch', {})
+      expect(result).toEqual({ allow: true, always: false })
+    })
+
+    it('auto-approves headless session', async () => {
+      session.source = 'webhook'
+      session.clients = new Set() as any
+      const result = await router.requestToolApproval('sess-1', 'Bash', { command: 'ls' })
+      expect(result).toEqual({ allow: true, always: false })
+    })
+
+    it('returns deny for unknown session', async () => {
+      ;(deps.getSession as any).mockReturnValue(undefined)
+      const result = await router.requestToolApproval('no-exist', 'Bash', {})
+      expect(result).toEqual({ allow: false, always: false })
+    })
+
+    it('broadcasts prompt to clients when approval needed', async () => {
+      // Don't await — just check the broadcast happened
+      const promise = router.requestToolApproval('sess-1', 'Bash', { command: 'npm test' })
+
+      // Should have broadcast a prompt
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({
+        type: 'prompt',
+        promptType: 'permission',
+        toolName: 'Bash',
+      }))
+
+      // Resolve the pending approval
+      const approvalEntry = Array.from(session.pendingToolApprovals.values())[0]
+      approvalEntry.resolve({ allow: true, always: false })
+
+      await promise
+    })
+
+    it('alwaysAllow persists via approval manager', async () => {
+      const promise = router.requestToolApproval('sess-1', 'Bash', { command: 'npm test' })
+
+      // Simulate "always_allow" response through sendPromptResponse
+      const approvalEntry = Array.from(session.pendingToolApprovals.values())[0]
+      router.sendPromptResponse('sess-1', 'always_allow', approvalEntry.requestId)
+
+      const result = await promise
+      expect(result.allow).toBe(true)
+      expect(result.always).toBe(true)
+      expect(deps.approvalManager.saveAlwaysAllow).toHaveBeenCalledWith('/repos/test', 'Bash', { command: 'npm test' })
+    })
+
+    it('deny resolves with allow=false', async () => {
+      const promise = router.requestToolApproval('sess-1', 'Bash', { command: 'rm -rf /' })
+
+      const approvalEntry = Array.from(session.pendingToolApprovals.values())[0]
+      router.sendPromptResponse('sess-1', 'deny', approvalEntry.requestId)
+
+      const result = await promise
+      expect(result.allow).toBe(false)
+      expect(result.always).toBe(false)
+    })
+
+    it('dismisses prompt from pendingToolApprovals after resolution', async () => {
+      const promise = router.requestToolApproval('sess-1', 'Bash', { command: 'ls' })
+
+      const approvalEntry = Array.from(session.pendingToolApprovals.values())[0]
+      const reqId = approvalEntry.requestId
+      router.sendPromptResponse('sess-1', 'allow', reqId)
+
+      await promise
+
+      expect(session.pendingToolApprovals.has(reqId)).toBe(false)
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'prompt_dismiss', requestId: reqId }))
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // onControlRequestEvent
+  // -------------------------------------------------------------------------
+
+  describe('onControlRequestEvent', () => {
+    it('rejects invalid requestId', () => {
+      const cp = { sendControlResponse: vi.fn() } as any
+
+      router.onControlRequestEvent(cp, session, 'sess-1', 'invalid id with spaces!!!!!!!!!', 'Bash', {})
+
+      expect(cp.sendControlResponse).not.toHaveBeenCalled()
+    })
+
+    it('auto-approves when resolveAutoApproval matches', () => {
+      session.permissionMode = 'acceptEdits'
+      const cp = { sendControlResponse: vi.fn() } as any
+
+      router.onControlRequestEvent(cp, session, 'sess-1', 'req-1', 'Read', {})
+
+      expect(cp.sendControlResponse).toHaveBeenCalledWith('req-1', 'allow')
+    })
+
+    it('auto-approves when PreToolUse hook already handles the tool', () => {
+      session.pendingToolApprovals.set('hook-req', {
+        resolve: vi.fn(),
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        requestId: 'hook-req',
+      })
+      const cp = { sendControlResponse: vi.fn() } as any
+
+      router.onControlRequestEvent(cp, session, 'sess-1', 'ctrl-req', 'Bash', { command: 'ls' })
+
+      expect(cp.sendControlResponse).toHaveBeenCalledWith('ctrl-req', 'allow')
+    })
+
+    it('broadcasts prompt when manual approval needed', () => {
+      const cp = { sendControlResponse: vi.fn() } as any
+
+      router.onControlRequestEvent(cp, session, 'sess-1', 'req-42', 'Bash', { command: 'rm -rf /' })
+
+      expect(session.pendingControlRequests.has('req-42')).toBe(true)
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({
+        type: 'prompt',
+        promptType: 'permission',
+        toolName: 'Bash',
+        requestId: 'req-42',
+      }))
+    })
+
+    it('broadcasts globally when no clients connected', () => {
+      session.clients = new Set() as any
+      const cp = { sendControlResponse: vi.fn() } as any
+
+      router.onControlRequestEvent(cp, session, 'sess-1', 'req-99', 'Bash', { command: 'ls' })
+
+      expect(deps.globalBroadcast).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'prompt',
+        sessionId: 'sess-1',
+        sessionName: 'test-session',
+      }))
+    })
+
+    it('notifies prompt listeners', () => {
+      const listener = vi.fn()
+      deps.promptListeners.push(listener)
+      const cp = { sendControlResponse: vi.fn() } as any
+
+      router.onControlRequestEvent(cp, session, 'sess-1', 'req-1', 'Bash', {})
+
+      expect(listener).toHaveBeenCalledWith('sess-1', 'permission', 'Bash', 'req-1')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // sendPromptResponse — control request path
+  // -------------------------------------------------------------------------
+
+  describe('sendPromptResponse (control requests)', () => {
+    it('resolves control request with allow', () => {
+      session.pendingControlRequests.set('cr-1', {
+        requestId: 'cr-1',
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+      })
+
+      router.sendPromptResponse('sess-1', 'allow', 'cr-1')
+
+      expect(session.claudeProcess!.sendControlResponse).toHaveBeenCalledWith('cr-1', 'allow')
+      expect(session.pendingControlRequests.has('cr-1')).toBe(false)
+    })
+
+    it('resolves control request with deny', () => {
+      session.pendingControlRequests.set('cr-2', {
+        requestId: 'cr-2',
+        toolName: 'Bash',
+        toolInput: { command: 'rm -rf /' },
+      })
+
+      router.sendPromptResponse('sess-1', 'deny', 'cr-2')
+
+      expect(session.claudeProcess!.sendControlResponse).toHaveBeenCalledWith('cr-2', 'deny')
+    })
+
+    it('persists always_allow for control requests', () => {
+      session.pendingControlRequests.set('cr-3', {
+        requestId: 'cr-3',
+        toolName: 'Bash',
+        toolInput: { command: 'npm test' },
+      })
+
+      router.sendPromptResponse('sess-1', 'always_allow', 'cr-3')
+
+      expect(deps.approvalManager.saveAlwaysAllow).toHaveBeenCalledWith('/repos/test', 'Bash', { command: 'npm test' })
+    })
+
+    it('infers sole pending prompt when no requestId given', () => {
+      session.pendingControlRequests.set('cr-only', {
+        requestId: 'cr-only',
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+      })
+
+      router.sendPromptResponse('sess-1', 'allow')
+
+      expect(session.claudeProcess!.sendControlResponse).toHaveBeenCalledWith('cr-only', 'allow')
+    })
+
+    it('rejects when multiple pending prompts and no requestId', () => {
+      session.pendingControlRequests.set('cr-a', { requestId: 'cr-a', toolName: 'Bash', toolInput: {} })
+      session.pendingControlRequests.set('cr-b', { requestId: 'cr-b', toolName: 'Read', toolInput: {} })
+
+      router.sendPromptResponse('sess-1', 'allow')
+
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({
+        type: 'system_message',
+        subtype: 'error',
+        text: expect.stringContaining('multiple prompts pending'),
+      }))
+    })
+
+    it('falls back to sendMessage when no pending prompts match', () => {
+      router.sendPromptResponse('sess-1', 'hello world')
+
+      expect(session.claudeProcess!.sendMessage).toHaveBeenCalledWith('hello world')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // summarizeToolPermission
+  // -------------------------------------------------------------------------
+
+  describe('summarizeToolPermission', () => {
+    it('formats Bash commands', () => {
+      const result = router.summarizeToolPermission('Bash', { command: 'echo hello\necho world' })
+      expect(result).toContain('$ echo hello...')
+    })
+
+    it('formats Read with file path', () => {
+      expect(router.summarizeToolPermission('Read', { file_path: '/src/foo.ts' })).toContain('/src/foo.ts')
+    })
+
+    it('formats unknown tools', () => {
+      expect(router.summarizeToolPermission('WebFetch', {})).toBe('Allow WebFetch?')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // getPendingPrompts
+  // -------------------------------------------------------------------------
+
+  describe('getPendingPrompts', () => {
+    it('returns empty when no pending prompts', () => {
+      expect(router.getPendingPrompts()).toEqual([])
+    })
+
+    it('returns pending tool approvals and control requests', () => {
+      session.pendingToolApprovals.set('ta-1', {
+        resolve: vi.fn(),
+        toolName: 'Bash',
+        toolInput: { command: 'ls' },
+        requestId: 'ta-1',
+      })
+      session.pendingControlRequests.set('cr-1', {
+        requestId: 'cr-1',
+        toolName: 'AskUserQuestion',
+        toolInput: { questions: [{ question: 'What color?' }] },
+      })
+
+      const results = router.getPendingPrompts()
+      expect(results).toHaveLength(1)
+      expect(results[0].prompts).toHaveLength(2)
+      expect(results[0].prompts[0]).toMatchObject({ requestId: 'ta-1', promptType: 'permission', toolName: 'Bash' })
+      expect(results[0].prompts[1]).toMatchObject({ requestId: 'cr-1', promptType: 'question', toolName: 'AskUserQuestion' })
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // onPromptEvent
+  // -------------------------------------------------------------------------
+
+  describe('onPromptEvent', () => {
+    it('broadcasts prompt and stores in pendingControlRequests when requestId present', () => {
+      router.onPromptEvent(session, 'question', 'Pick a color', [{ label: 'Red', value: 'red' }], false, undefined, undefined, 'req-prompt-1', undefined)
+
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({
+        type: 'prompt',
+        promptType: 'question',
+        requestId: 'req-prompt-1',
+      }))
+      expect(session.pendingControlRequests.has('req-prompt-1')).toBe(true)
+    })
+
+    it('notifies prompt listeners', () => {
+      const listener = vi.fn()
+      deps.promptListeners.push(listener)
+
+      router.onPromptEvent(session, 'permission', 'Allow?', [], false, 'Bash', undefined, 'req-2', undefined)
+
+      expect(listener).toHaveBeenCalledWith('sess-1', 'permission', 'Bash', 'req-2')
+    })
+  })
+})

--- a/server/session-lifecycle.test.ts
+++ b/server/session-lifecycle.test.ts
@@ -1,0 +1,491 @@
+/** Tests for SessionLifecycle — verifies startClaude, handleClaudeExit, and restart logic. */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// Mock fs.existsSync so we can control working-directory checks
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    existsSync: vi.fn(() => true),
+  }
+})
+
+// Mock ClaudeProcess — we don't want real CLI spawns
+vi.mock('./claude-process.js', () => {
+  const { EventEmitter } = require('node:events')
+  class MockClaudeProcess extends EventEmitter {
+    start = vi.fn()
+    stop = vi.fn()
+    isAlive = vi.fn(() => true)
+    sendMessage = vi.fn()
+    sendControlResponse = vi.fn()
+    hasSessionConflict = vi.fn(() => false)
+    hadOutput = vi.fn(() => true)
+    hasSpawnFailed = vi.fn(() => false)
+    waitForExit = vi.fn(() => Promise.resolve())
+  }
+  return { ClaudeProcess: MockClaudeProcess }
+})
+
+// Mock crypto-utils
+vi.mock('./crypto-utils.js', () => ({
+  deriveSessionToken: vi.fn(() => 'mock-session-token'),
+}))
+
+// Mock session-restart-scheduler
+const mockEvaluateRestart = vi.hoisted(() => vi.fn())
+vi.mock('./session-restart-scheduler.js', () => ({
+  evaluateRestart: mockEvaluateRestart,
+}))
+
+import { SessionLifecycle, type SessionLifecycleDeps } from './session-lifecycle.js'
+import { existsSync } from 'fs'
+import type { Session, WsServerMessage } from './types.js'
+import { EventEmitter } from 'node:events'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePlanManager() {
+  return {
+    reset: vi.fn(),
+    onEnterPlanMode: vi.fn(),
+    onTurnEnd: vi.fn(),
+    onExitPlanModeRequested: vi.fn(),
+    deny: vi.fn(),
+    approve: vi.fn(),
+    state: 'idle' as const,
+    pendingReviewId: null,
+  }
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+  return {
+    id: 'sess-1',
+    name: 'test-session',
+    workingDir: '/repos/test',
+    created: new Date().toISOString(),
+    source: 'manual',
+    claudeProcess: null,
+    clients: new Set(),
+    outputHistory: [],
+    claudeSessionId: null,
+    restartCount: 0,
+    lastRestartAt: null,
+    _stoppedByUser: false,
+    _wasActiveBeforeRestart: false,
+    pendingControlRequests: new Map(),
+    pendingToolApprovals: new Map(),
+    isProcessing: false,
+    _turnCount: 0,
+    _claudeTurnCount: 0,
+    _namingAttempts: 0,
+    _apiRetryCount: 0,
+    _lastActivityAt: Date.now(),
+    planManager: makePlanManager() as any,
+    ...overrides,
+  } as Session
+}
+
+function makeDeps(overrides: Partial<SessionLifecycleDeps> = {}): SessionLifecycleDeps {
+  return {
+    getSession: vi.fn(() => undefined),
+    hasSession: vi.fn(() => true),
+    broadcast: vi.fn(),
+    addToHistory: vi.fn(),
+    broadcastAndHistory: vi.fn(),
+    persistToDisk: vi.fn(),
+    globalBroadcast: vi.fn(),
+    authToken: 'test-token',
+    serverPort: 32352,
+    approvalManager: {
+      getAllowedToolsForRepo: vi.fn(() => []),
+      checkAutoApproval: vi.fn(() => false),
+      saveAlwaysAllow: vi.fn(),
+      savePatternApproval: vi.fn(),
+      derivePattern: vi.fn(),
+    } as any,
+    promptRouter: {
+      onPromptEvent: vi.fn(),
+      onControlRequestEvent: vi.fn(),
+    } as any,
+    exitListeners: [],
+    onSystemInit: vi.fn(),
+    onTextEvent: vi.fn(),
+    onThinkingEvent: vi.fn(),
+    onToolOutputEvent: vi.fn(),
+    onImageEvent: vi.fn(),
+    onToolActiveEvent: vi.fn(),
+    onToolDoneEvent: vi.fn(),
+    handleClaudeResult: vi.fn(),
+    buildSessionContext: vi.fn(() => null),
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SessionLifecycle', () => {
+  let deps: SessionLifecycleDeps
+  let lifecycle: SessionLifecycle
+  let session: Session
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    session = makeSession()
+    deps = makeDeps({ getSession: vi.fn(() => session), hasSession: vi.fn(() => true) })
+    lifecycle = new SessionLifecycle(deps)
+    ;(existsSync as any).mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // startClaude
+  // -------------------------------------------------------------------------
+
+  describe('startClaude', () => {
+    it('returns false when session not found', () => {
+      deps.getSession = vi.fn(() => undefined) as any
+      lifecycle = new SessionLifecycle(deps)
+      expect(lifecycle.startClaude('no-exist')).toBe(false)
+    })
+
+    it('spawns a ClaudeProcess, wires events, and broadcasts session_started', () => {
+      const result = lifecycle.startClaude('sess-1')
+
+      expect(result).toBe(true)
+      expect(session.claudeProcess).not.toBeNull()
+      expect(session.claudeProcess!.start).toHaveBeenCalled()
+      expect(session._stoppedByUser).toBe(false)
+
+      // Should broadcast claude_started
+      expect(deps.addToHistory).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'claude_started' }))
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'claude_started' }))
+      expect(deps.globalBroadcast).toHaveBeenCalledWith({ type: 'sessions_updated' })
+    })
+
+    it('kills existing process before starting a new one', () => {
+      const oldProcess = new EventEmitter() as any
+      oldProcess.removeAllListeners = vi.fn()
+      oldProcess.stop = vi.fn()
+      session.claudeProcess = oldProcess
+
+      lifecycle.startClaude('sess-1')
+
+      expect(oldProcess.stop).toHaveBeenCalled()
+      expect(session.claudeProcess).not.toBe(oldProcess)
+    })
+
+    it('clears _stoppedByUser and _restartTimer on start', () => {
+      session._stoppedByUser = true
+      session._restartTimer = setTimeout(() => {}, 10000) as any
+
+      lifecycle.startClaude('sess-1')
+
+      expect(session._stoppedByUser).toBe(false)
+      expect(session._restartTimer).toBeUndefined()
+    })
+
+    it('falls back to groupDir when workingDir is missing', () => {
+      session.workingDir = '/repos/dead-worktree'
+      session.groupDir = '/repos/test'
+      session.worktreePath = '/repos/dead-worktree'
+      ;(existsSync as any).mockImplementation((p: string) => {
+        if (p === '/repos/dead-worktree') return false
+        return true
+      })
+
+      const result = lifecycle.startClaude('sess-1')
+      expect(result).toBe(true)
+      expect(session.workingDir).toBe('/repos/test')
+      expect(session.worktreePath).toBeUndefined()
+      expect(deps.persistToDisk).toHaveBeenCalled()
+    })
+
+    it('returns false and stops when workingDir missing and no fallback', () => {
+      session.workingDir = '/repos/gone'
+      session.groupDir = undefined
+      ;(existsSync as any).mockImplementation((p: string) => {
+        if (p === '/repos/gone') return false
+        return true
+      })
+
+      const result = lifecycle.startClaude('sess-1')
+      expect(result).toBe(false)
+      expect(session._stoppedByUser).toBe(true)
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'system_message', subtype: 'error' }))
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // handleClaudeExit
+  // -------------------------------------------------------------------------
+
+  describe('handleClaudeExit', () => {
+    let exitedProcess: any
+
+    beforeEach(() => {
+      exitedProcess = new EventEmitter() as any
+      exitedProcess.hasSessionConflict = vi.fn(() => false)
+      exitedProcess.hadOutput = vi.fn(() => true)
+      exitedProcess.hasSpawnFailed = vi.fn(() => false)
+      exitedProcess.removeAllListeners = vi.fn()
+      session.claudeProcess = exitedProcess
+    })
+
+    it('ignores exit from stale (replaced) process', () => {
+      const newProcess = new EventEmitter()
+      session.claudeProcess = newProcess as any
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 0, null)
+
+      // Should not have nulled claudeProcess or called any deps
+      expect(session.claudeProcess).toBe(newProcess)
+      expect(deps.broadcast).not.toHaveBeenCalled()
+    })
+
+    it('broadcasts exit message on clean stopped-by-user exit', () => {
+      session._stoppedByUser = true
+      mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 0, null)
+
+      expect(session.claudeProcess).toBeNull()
+      expect(session.isProcessing).toBe(false)
+      expect(deps.addToHistory).toHaveBeenCalledWith(session, expect.objectContaining({ subtype: 'exit' }))
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'exit' }))
+    })
+
+    it('broadcasts session conflict message when session ID is in use', () => {
+      exitedProcess.hasSessionConflict.mockReturnValue(true)
+      mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      expect(deps.addToHistory).toHaveBeenCalledWith(
+        session,
+        expect.objectContaining({ text: expect.stringContaining('session ID is already in use') }),
+      )
+    })
+
+    it('notifies exit listeners with willRestart=false on stopped_by_user', () => {
+      const listener = vi.fn()
+      deps.exitListeners.push(listener)
+      mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 0, null)
+
+      expect(listener).toHaveBeenCalledWith('sess-1', 0, null, false)
+    })
+
+    it('schedules restart on unexpected exit', () => {
+      mockEvaluateRestart.mockReturnValue({
+        kind: 'restart',
+        attempt: 1,
+        maxAttempts: 3,
+        delayMs: 2000,
+        updatedCount: 1,
+        updatedLastRestartAt: Date.now(),
+      })
+      const listener = vi.fn()
+      deps.exitListeners.push(listener)
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, 'SIGTERM')
+
+      expect(listener).toHaveBeenCalledWith('sess-1', 1, 'SIGTERM', true)
+      expect(session.restartCount).toBe(1)
+      expect(deps.addToHistory).toHaveBeenCalledWith(session, expect.objectContaining({ subtype: 'restart' }))
+
+      // Restart timer should fire and call startClaude
+      expect(session._restartTimer).toBeDefined()
+    })
+
+    it('restart timer calls startClaude after delay', () => {
+      mockEvaluateRestart.mockReturnValue({
+        kind: 'restart',
+        attempt: 1,
+        maxAttempts: 3,
+        delayMs: 2000,
+        updatedCount: 1,
+        updatedLastRestartAt: Date.now(),
+      })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      // Before timer fires, startClaude shouldn't have been called (claudeProcess is null from exit)
+      expect(session.claudeProcess).toBeNull()
+
+      // Advance timer
+      vi.advanceTimersByTime(2000)
+
+      // startClaude should have run — session.claudeProcess should be set again
+      expect(session.claudeProcess).not.toBeNull()
+    })
+
+    it('restart timer does nothing if session was stopped', () => {
+      mockEvaluateRestart.mockReturnValue({
+        kind: 'restart',
+        attempt: 1,
+        maxAttempts: 3,
+        delayMs: 2000,
+        updatedCount: 1,
+        updatedLastRestartAt: Date.now(),
+      })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      // User stops the session before timer fires
+      session._stoppedByUser = true
+
+      vi.advanceTimersByTime(2000)
+
+      // Should not have started a new process
+      expect(session.claudeProcess).toBeNull()
+    })
+
+    it('restart timer does nothing if session was removed', () => {
+      mockEvaluateRestart.mockReturnValue({
+        kind: 'restart',
+        attempt: 1,
+        maxAttempts: 3,
+        delayMs: 2000,
+        updatedCount: 1,
+        updatedLastRestartAt: Date.now(),
+      })
+      ;(deps.hasSession as any).mockReturnValue(false)
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+      vi.advanceTimersByTime(2000)
+
+      expect(session.claudeProcess).toBeNull()
+    })
+
+    it('broadcasts error on exhausted restarts', () => {
+      mockEvaluateRestart.mockReturnValue({ kind: 'exhausted', maxAttempts: 3 })
+      const listener = vi.fn()
+      deps.exitListeners.push(listener)
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      expect(listener).toHaveBeenCalledWith('sess-1', 1, null, false)
+      expect(deps.addToHistory).toHaveBeenCalledWith(session, expect.objectContaining({ subtype: 'error' }))
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'exit' }))
+    })
+
+    it('clears claudeSessionId when process had no output', () => {
+      session.claudeSessionId = 'old-session-id'
+      exitedProcess.hadOutput.mockReturnValue(false)
+      mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      expect(session.claudeSessionId).toBeNull()
+    })
+
+    it('preserves claudeSessionId when spawn failed', () => {
+      session.claudeSessionId = 'old-session-id'
+      exitedProcess.hadOutput.mockReturnValue(false)
+      exitedProcess.hasSpawnFailed.mockReturnValue(true)
+      mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      expect(session.claudeSessionId).toBe('old-session-id')
+    })
+
+    it('falls back to groupDir when workingDir disappears mid-session', () => {
+      session.workingDir = '/repos/dead-worktree'
+      session.groupDir = '/repos/test'
+      session.worktreePath = '/repos/dead-worktree'
+      ;(existsSync as any).mockImplementation((p: string) => {
+        if (p === '/repos/dead-worktree') return false
+        return true
+      })
+      mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      expect(session.workingDir).toBe('/repos/test')
+      expect(session.worktreePath).toBeUndefined()
+      expect(deps.persistToDisk).toHaveBeenCalled()
+    })
+
+    it('stops session when workingDir gone and no fallback', () => {
+      session.workingDir = '/repos/gone'
+      session.groupDir = undefined
+      ;(existsSync as any).mockImplementation((p: string) => {
+        if (p === '/repos/gone') return false
+        return true
+      })
+      // evaluateRestart should NOT be called in this path
+      mockEvaluateRestart.mockReturnValue({ kind: 'restart', attempt: 1, maxAttempts: 3, delayMs: 2000, updatedCount: 1, updatedLastRestartAt: Date.now() })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      expect(session._stoppedByUser).toBe(true)
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'exit' }))
+    })
+
+    it('swallows errors from exit listeners', () => {
+      const badListener = vi.fn(() => { throw new Error('boom') })
+      const goodListener = vi.fn()
+      deps.exitListeners.push(badListener, goodListener)
+      mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
+
+      // Should not throw
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 0, null)
+
+      expect(badListener).toHaveBeenCalled()
+      expect(goodListener).toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // stopClaude / stopClaudeAndWait
+  // -------------------------------------------------------------------------
+
+  describe('stopClaude', () => {
+    it('stops the process and broadcasts claude_stopped', () => {
+      const proc = new EventEmitter() as any
+      proc.removeAllListeners = vi.fn()
+      proc.stop = vi.fn()
+      session.claudeProcess = proc
+
+      lifecycle.stopClaude('sess-1')
+
+      expect(proc.stop).toHaveBeenCalled()
+      expect(session.claudeProcess).toBeNull()
+      expect(session._stoppedByUser).toBe(true)
+      expect(deps.broadcast).toHaveBeenCalledWith(session, { type: 'claude_stopped' })
+    })
+
+    it('does nothing when no process is running', () => {
+      session.claudeProcess = null
+      lifecycle.stopClaude('sess-1')
+      expect(deps.broadcast).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('stopClaudeAndWait', () => {
+    it('waits for process exit before nulling reference', async () => {
+      const proc = new EventEmitter() as any
+      proc.removeAllListeners = vi.fn()
+      proc.stop = vi.fn()
+      proc.waitForExit = vi.fn(() => Promise.resolve())
+      session.claudeProcess = proc
+
+      await lifecycle.stopClaudeAndWait('sess-1')
+
+      expect(proc.waitForExit).toHaveBeenCalled()
+      expect(session.claudeProcess).toBeNull()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Add `server/session-lifecycle.test.ts` — 23 tests covering `startClaude` (spawn, event wiring, working directory fallback), `handleClaudeExit` (clean exit, restart scheduling, stale process guard, exhausted restarts, session conflict), and `stopClaude`/`stopClaudeAndWait`
- Add `server/prompt-router.test.ts` — 39 tests covering `resolveAutoApproval` (permissionMode, registry, session allowedTools, headless, parameterized patterns), `requestToolApproval` (auto-approve paths, interactive allow/deny/alwaysAllow), `onControlRequestEvent` (validation, auto-approve, double-gate prevention), `sendPromptResponse` routing, and `getPendingPrompts`
- Expand `server/orchestrator-children.test.ts` — 21 tests covering `spawn` (status transitions, worktree creation/fallback, failure handling, concurrency limit), status tracking via monitor hooks (completed, failed, exit, willRestart, session deleted), timeout, listing/retrieval, and prompt generation for all completion policies

## Test plan

- [x] All 83 new tests pass
- [x] Full test suite (1432 tests across 50 files) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)