### PR TITLE
fix: resolve lint errors in test files from #328

### DIFF
--- a/server/prompt-router.test.ts
+++ b/server/prompt-router.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { PromptRouter, type PromptRouterDeps } from './prompt-router.js'
-import type { Session, WsServerMessage } from './types.js'
+import type { Session } from './types.js'
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/server/session-lifecycle.test.ts
+++ b/server/session-lifecycle.test.ts
@@ -12,8 +12,8 @@ vi.mock('fs', async (importOriginal) => {
 })
 
 // Mock ClaudeProcess — we don't want real CLI spawns
-vi.mock('./claude-process.js', () => {
-  const { EventEmitter } = require('node:events')
+vi.mock('./claude-process.js', async () => {
+  const { EventEmitter } = await import('node:events')
   class MockClaudeProcess extends EventEmitter {
     start = vi.fn()
     stop = vi.fn()
@@ -41,7 +41,7 @@ vi.mock('./session-restart-scheduler.js', () => ({
 
 import { SessionLifecycle, type SessionLifecycleDeps } from './session-lifecycle.js'
 import { existsSync } from 'fs'
-import type { Session, WsServerMessage } from './types.js'
+import type { Session } from './types.js'
 import { EventEmitter } from 'node:events'
 
 // ---------------------------------------------------------------------------

--- a/server/session-lifecycle.test.ts
+++ b/server/session-lifecycle.test.ts
@@ -2,7 +2,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 
-// Mock fs.existsSync so we can control working-directory checks
+// Mock fs so we can control working-directory checks and prevent realpathSync
+// from crashing when the path doesn't exist (e.g. in CI).
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>()
   return {

--- a/server/session-lifecycle.test.ts
+++ b/server/session-lifecycle.test.ts
@@ -8,6 +8,7 @@ vi.mock('fs', async (importOriginal) => {
   return {
     ...actual,
     existsSync: vi.fn(() => true),
+    realpathSync: vi.fn((p: string) => p),
   }
 })
 


### PR DESCRIPTION
## Summary
- Remove unused `WsServerMessage` type import from `session-lifecycle.test.ts` and `prompt-router.test.ts`
- Replace forbidden `require('node:events')` with `await import('node:events')` in `session-lifecycle.test.ts`

PR #328 was merged while CI was still running, so these 3 lint errors landed on `main`.

## Test plan
- [ ] CI lint step passes (was failing with 3 errors, 716 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)