### PR TITLE
chore: bump version to v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codekin",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codekin",
-      "version": "0.5.4",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codekin",
-  "version": "0.5.5",
+  "version": "0.6.0",
   "license": "MIT",
   "licenseNotes": "dompurify is dual-licensed (MPL-2.0 OR Apache-2.0); both are permissively compatible with MIT for library use. lightningcss (MPL-2.0) is a build-time-only dependency used by TailwindCSS and is not included in distributed artifacts.",
   "author": "multiplier-labs",


### PR DESCRIPTION
## Summary
- Bump package version from 0.5.5 to 0.6.0

## Test plan
- [ ] CI passes
- [ ] After merge, tag `v0.6.0` and push to trigger npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)