### PR TITLE
feat: add PR Review workflow to Workflows UI

### DIFF
--- a/server/workflows/pr-review.md
+++ b/server/workflows/pr-review.md
@@ -1,0 +1,27 @@
+---
+kind: pr-review
+name: PR Review
+sessionPrefix: pr-review
+outputDir: .codekin/reports/pr-review
+filenameSuffix: _pr-review.md
+commitMessage: chore: pr review
+---
+You are performing an automated code review of a pull request. Please do the following:
+
+1. Run `gh pr list --state open --json number,title,headRefName,author` to find open PRs
+2. For the most recent PR, run `gh pr view <number> --json title,body,files,additions,deletions,commits`
+3. Run `gh pr diff <number>` to get the full diff
+4. Review the changes, focusing on:
+   - Code correctness and logic errors
+   - Security vulnerabilities (injection, auth issues, data exposure)
+   - Performance implications
+   - Code style, readability, and maintainability
+   - Test coverage for new or changed code
+
+Produce a structured review report with:
+- **Summary**: 1-2 sentence overview of the PR
+- **Findings**: Grouped by severity (Critical / Warning / Suggestion / Nitpick)
+  - For each finding: file path, line number(s), description, and suggested fix
+- **Overall Assessment**: Approve / Request Changes / Comment
+
+If the PR looks clean, say so briefly — no need to pad the report.

--- a/src/components/AddWorkflowModal.tsx
+++ b/src/components/AddWorkflowModal.tsx
@@ -266,12 +266,18 @@ function StepConfigure({
       {eventDriven ? (
         <div>
           <p className="text-[13px] text-neutral-4 mb-3">
-            This workflow runs automatically on every commit via a post-commit hook.
+            {form.kind === 'pr-review'
+              ? 'This workflow runs automatically when a pull request is opened or updated via GitHub webhooks.'
+              : 'This workflow runs automatically on every commit via a post-commit hook.'}
           </p>
           <div className="rounded-lg border border-purple-700/40 bg-purple-900/20 px-4 py-3">
-            <span className="text-[14px] font-medium text-purple-400">Trigger: On commit</span>
+            <span className="text-[14px] font-medium text-purple-400">
+              {form.kind === 'pr-review' ? 'Trigger: On pull request' : 'Trigger: On commit'}
+            </span>
             <p className="text-[13px] text-neutral-4 mt-1">
-              Each commit will be reviewed automatically. No schedule needed.
+              {form.kind === 'pr-review'
+                ? 'Each PR will be reviewed automatically when opened, updated, or reopened. No schedule needed.'
+                : 'Each commit will be reviewed automatically. No schedule needed.'}
             </p>
           </div>
         </div>

--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -123,9 +123,13 @@ export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
           {/* Schedule — hidden for event-driven workflows */}
           {eventDriven ? (
             <div className="rounded-lg border border-purple-700/40 bg-purple-900/20 px-4 py-3">
-              <span className="text-[14px] font-medium text-purple-400">Trigger: On commit</span>
+              <span className="text-[14px] font-medium text-purple-400">
+                {form.kind === 'pr-review' ? 'Trigger: On pull request' : 'Trigger: On commit'}
+              </span>
               <p className="text-[13px] text-neutral-4 mt-1">
-                Each commit will be reviewed automatically. No schedule needed.
+                {form.kind === 'pr-review'
+                  ? 'Each PR will be reviewed automatically when opened, updated, or reopened. No schedule needed.'
+                  : 'Each commit will be reviewed automatically. No schedule needed.'}
               </p>
             </div>
           ) : (

--- a/src/components/workflows/WorkflowRow.tsx
+++ b/src/components/workflows/WorkflowRow.tsx
@@ -70,7 +70,7 @@ export function WorkflowRow({
         )}
         <span className={`text-[14px] whitespace-nowrap shrink-0 ${eventDriven ? 'text-purple-400' : 'text-neutral-5'}`}>
           {eventDriven
-            ? 'On commit'
+            ? (repo.kind === 'pr-review' ? 'On pull request' : 'On commit')
             : schedule ? describeCron(schedule.cronExpression) : describeCron(repo.cronExpression)}
         </span>
         {modelLabel(repo.model) && (

--- a/src/lib/workflowHelpers.test.ts
+++ b/src/lib/workflowHelpers.test.ts
@@ -32,8 +32,8 @@ describe('workflowHelpers', () => {
   })
 
   describe('EVENT_CRON', () => {
-    it('describeCron returns "On commit" for event cron', () => {
-      expect(describeCron(EVENT_CRON)).toBe('On commit')
+    it('describeCron returns "On event" for event cron', () => {
+      expect(describeCron(EVENT_CRON)).toBe('On event')
     })
   })
 

--- a/src/lib/workflowHelpers.ts
+++ b/src/lib/workflowHelpers.ts
@@ -20,6 +20,7 @@ export const WORKFLOW_KINDS = [
   { value: 'coverage.daily', label: 'Coverage Assessment', category: 'assessment' as WorkflowCategory },
   { value: 'code-review.daily', label: 'Code Review', category: 'assessment' as WorkflowCategory },
   { value: 'commit-review', label: 'Commit Review', category: 'event' as WorkflowCategory },
+  { value: 'pr-review', label: 'PR Review', category: 'event' as WorkflowCategory },
   { value: 'comment-assessment.daily', label: 'Comment Assessment', category: 'assessment' as WorkflowCategory },
   { value: 'dependency-health.daily', label: 'Dependency Health', category: 'assessment' as WorkflowCategory },
   { value: 'security-audit.weekly', label: 'Security Audit', category: 'assessment' as WorkflowCategory },
@@ -29,7 +30,7 @@ export const WORKFLOW_KINDS = [
 ]
 
 /** Event-driven workflow kinds that are triggered by hooks rather than cron schedules. */
-export const EVENT_DRIVEN_KINDS = new Set(['commit-review'])
+export const EVENT_DRIVEN_KINDS = new Set(['commit-review', 'pr-review'])
 
 /** Check if a workflow kind is event-driven (triggered by hooks, not cron). */
 export function isEventDriven(kind: string): boolean {
@@ -118,7 +119,7 @@ export const EVENT_CRON = 'event'
 
 /** Convert a 5-field cron expression into a human-readable description, e.g. `"Daily at 06:00"`. */
 export function describeCron(expr: string): string {
-  if (expr === EVENT_CRON) return 'On commit'
+  if (expr === EVENT_CRON) return 'On event'
   const parts = expr.trim().split(/\s+/)
   if (parts.length !== 5) return expr
   const [min, hour, dom, , dow] = parts


### PR DESCRIPTION
## Summary
- Registers `pr-review` as an event-driven workflow kind so it appears in the Workflows UI alongside commit-review
- Adds workflow definition file (`server/workflows/pr-review.md`) and updates all UI components (AddWorkflowModal, EditWorkflowModal, WorkflowRow) to show PR-specific trigger text
- Updates `describeCron` to use generic "On event" label for the event sentinel, since it now covers both commit and PR triggers

## Test plan
- [x] All 1557 tests pass
- [x] TypeScript compiles clean
- [x] Lint passes (no new errors)
- [ ] Verify "PR Review" appears in the workflow type picker (Step 2 of Add Workflow)
- [ ] Verify Step 3 shows "Trigger: On pull request" when PR Review is selected
- [ ] Verify WorkflowRow shows "On pull request" for pr-review workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)