### PR TITLE
fix: close symlink path traversal bypass in session-routes

### DIFF
--- a/server/session-routes.ts
+++ b/server/session-routes.ts
@@ -74,7 +74,7 @@ export function createSessionRouter(
     try {
       resolvedDir = fsRealpathSync(pathResolve(workingDir))
     } catch {
-      resolvedDir = pathResolve(workingDir)
+      return res.status(400).json({ error: 'workingDir could not be resolved (path does not exist or is inaccessible)' })
     }
     if (!allowedRoots.some(root => resolvedDir === root || resolvedDir.startsWith(root + '/'))) {
       return res.status(403).json({ error: 'workingDir is outside allowed directories' })
@@ -285,7 +285,7 @@ export function createSessionRouter(
     try {
       resolved = fsRealpathSync(base)
     } catch {
-      resolved = pathResolve(base)
+      return res.status(400).json({ error: 'Path could not be resolved (does not exist or is inaccessible)' })
     }
     if (!allowedRoots.some(root => resolved === root || resolved.startsWith(root + '/'))) {
       return res.status(403).json({ error: 'Path is outside allowed directories' })


### PR DESCRIPTION
## Summary

Fixes the remaining finding (L1) from the April 2 security audit and April 7 code review. The other 7 findings (W-01 through W-04, M1, M2, L5) were already addressed in prior PRs.

**L1 — Path traversal symlink bypass in session-routes.ts**: Both `POST /api/sessions/create` and `GET /api/browse-dirs` had a `realpathSync()` fallback to `pathResolve()` when the real path couldn't be resolved. Since `pathResolve()` doesn't follow symlinks, a symlink inside an allowed directory pointing outside it could bypass the `startsWith()` boundary check. Now rejects the path outright when `realpathSync()` fails, consistent with the WebSocket handler (W-04) which was already fixed.

### Already addressed in prior PRs
- **W-01**: WS rate-limiter map size cap (10,000 entries)
- **W-02**: API retry timer race condition (scheduled flag + clearTimeout)
- **W-03**: Worktree cleanup error logging
- **W-04**: Path traversal symlink bypass in ws-message-handler
- **M1**: Unauthenticated server start exits in non-development mode
- **M2**: Stepflow without webhook secret exits at startup
- **L5**: File upload MIME filter uses `&&` (both extension AND MIME required)

## Test plan
- [x] All 1557 existing tests pass
- [ ] Verify `POST /api/sessions/create` with a non-existent path returns 400
- [ ] Verify `GET /api/browse-dirs` with a non-existent path returns 400
- [ ] Verify symlink pointing outside allowed roots is rejected (realpathSync resolves through symlink, startsWith check catches it)


🤖 Generated with [Claude Code](https://claude.com/claude-code)