### PR TITLE
fix: include provider in session serialization for OpenCode model list

### DIFF
--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -669,6 +669,7 @@ export class SessionManager {
       connectedClients: s.clients.size,
       lastActivity: new Date(s._lastActivityAt).toISOString(),
       source: s.source,
+      provider: s.provider,
     }
   }
 


### PR DESCRIPTION
## Summary
- `serializeSession()` was missing the `provider` field, so the frontend always fell back to showing Claude models in the dropdown — even for OpenCode sessions
- Adding `provider: s.provider` to the serialized output lets the frontend correctly detect OpenCode sessions and fetch/display OpenCode models (e.g. `openai/gpt-5.4`)

## Test plan
- [ ] Start an OpenCode session and verify the model dropdown shows OpenCode models, not Claude models
- [ ] Verify Claude sessions still show Claude models as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)