### PR TITLE
fix: strip user echo, handle reasoning deltas, and support text attachments in OpenCode

### DIFF
--- a/server/opencode-process.test.ts
+++ b/server/opencode-process.test.ts
@@ -179,6 +179,83 @@ describe('OpenCodeProcess', () => {
       expect(textHandler).not.toHaveBeenCalled()
     })
 
+    it('strips user echo prefix from text deltas', () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+      // Simulate sendMessage storing lastUserInput
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).lastUserInput = 'hello'
+
+      // First delta — matches user input, should be buffered
+      callHandleSSE(ocp, {
+        type: 'message.part.delta',
+        properties: { sessionID: 'oc-session-1', field: 'text', delta: 'hello' },
+      })
+      expect(textHandler).not.toHaveBeenCalled()
+
+      // Second delta — flushes buffer, strips user echo, emits remainder
+      callHandleSSE(ocp, {
+        type: 'message.part.delta',
+        properties: { sessionID: 'oc-session-1', field: 'text', delta: 'Hello there!' },
+      })
+      // Buffer was "helloHello there!" which starts with "hello", so emits "Hello there!"
+      expect(textHandler).toHaveBeenCalledWith('Hello there!')
+    })
+
+    it('emits full buffer when no user echo match', () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).lastUserInput = 'hello'
+
+      // Delta that doesn't match user input once it reaches the threshold
+      callHandleSSE(ocp, {
+        type: 'message.part.delta',
+        properties: { sessionID: 'oc-session-1', field: 'text', delta: 'Sure, I can help!' },
+      })
+      expect(textHandler).toHaveBeenCalledWith('Sure, I can help!')
+    })
+
+    it('emits reasoning deltas as thinking events', () => {
+      const thinkingHandler = vi.fn()
+      ocp.on('thinking', thinkingHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      // Short reasoning — not enough for summary
+      callHandleSSE(ocp, {
+        type: 'message.part.delta',
+        properties: { sessionID: 'oc-session-1', field: 'reasoning', delta: 'Let me ' },
+      })
+      expect(thinkingHandler).not.toHaveBeenCalled()
+
+      // More reasoning — exceeds threshold, emits thinking summary
+      callHandleSSE(ocp, {
+        type: 'message.part.delta',
+        properties: { sessionID: 'oc-session-1', field: 'reasoning', delta: 'think about this carefully.' },
+      })
+      expect(thinkingHandler).toHaveBeenCalledTimes(1)
+      expect(thinkingHandler.mock.calls[0][0]).toContain('Let me think about this carefully.')
+    })
+
+    it('strips user echo from full text in message.part.updated', () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).lastUserInput = 'hello'
+
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          part: { type: 'text', text: 'helloHere is my response.' },
+        },
+      })
+      expect(textHandler).toHaveBeenCalledWith('Here is my response.')
+    })
+
     it('ignores text part updates (content arrives via deltas)', () => {
       const textHandler = vi.fn()
       ocp.on('text', textHandler)

--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -258,6 +258,16 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   private receivedDeltas = false
   /** Whether we've already emitted text via message.part.updated (to avoid re-emitting from message.updated). */
   private emittedPartText = false
+  /** Last user input text — used to detect and strip user echo from assistant deltas. */
+  private lastUserInput = ''
+  /** Buffer for initial text deltas — held until we can check for user echo prefix. */
+  private deltaBuffer = ''
+  /** Whether the delta buffer has been flushed (user echo check complete). */
+  private deltaBufferFlushed = false
+  /** Accumulated reasoning delta text for emitting thinking summaries during streaming. */
+  private reasoningBuffer = ''
+  /** Whether we've already emitted a thinking summary from reasoning deltas. */
+  private emittedReasoningSummary = false
 
   constructor(workingDir: string, opts?: Partial<OpenCodeProcessOptions>) {
     super()
@@ -444,6 +454,20 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     return sessionID === this.opencodeSessionId
   }
 
+  /** Flush any buffered text deltas that haven't been emitted yet (e.g. turn ended before buffer threshold). */
+  private flushDeltaBuffer(): void {
+    if (!this.deltaBufferFlushed && this.deltaBuffer) {
+      this.deltaBufferFlushed = true
+      if (this.lastUserInput && this.deltaBuffer.startsWith(this.lastUserInput)) {
+        const remainder = this.deltaBuffer.slice(this.lastUserInput.length)
+        if (remainder) this.emit('text', remainder)
+      } else {
+        this.emit('text', this.deltaBuffer)
+      }
+      this.deltaBuffer = ''
+    }
+  }
+
   /** Map an OpenCode SSE event to CodingProcess events. */
   private handleSSEEvent(event: OpenCodeSSEEvent): void {
     const { type, properties } = event
@@ -456,7 +480,38 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         const delta = properties.delta as string | undefined
         if (field === 'text' && delta) {
           this.receivedDeltas = true
-          this.emit('text', delta)
+          // Buffer initial deltas to detect and strip user echo prefix.
+          // Some providers echo the user message at the start of the assistant
+          // response, which causes duplicate display.
+          if (!this.deltaBufferFlushed && this.lastUserInput) {
+            this.deltaBuffer += delta
+            if (this.deltaBuffer.length >= this.lastUserInput.length) {
+              this.deltaBufferFlushed = true
+              if (this.deltaBuffer.startsWith(this.lastUserInput)) {
+                const remainder = this.deltaBuffer.slice(this.lastUserInput.length)
+                if (remainder) this.emit('text', remainder)
+              } else {
+                this.emit('text', this.deltaBuffer)
+              }
+              this.deltaBuffer = ''
+            }
+            // Still buffering — don't emit yet
+          } else {
+            this.emit('text', delta)
+          }
+        } else if (field === 'reasoning' && delta) {
+          // Accumulate reasoning deltas and emit a thinking summary once we
+          // have enough content, so the UI shows a thinking indicator during
+          // streaming (not only when message.part.updated arrives later).
+          this.reasoningBuffer += delta
+          if (this.reasoningBuffer.length > 20 && !this.emittedReasoningSummary) {
+            this.emittedReasoningSummary = true
+            const match = this.reasoningBuffer.match(/^(.+?[.!?\n])/)
+            const summary = match && match[1].length <= 120
+              ? match[1].replace(/\n/g, ' ').trim()
+              : this.reasoningBuffer.slice(0, 80).trim()
+            this.emit('thinking', summary)
+          }
         }
         break
       }
@@ -476,7 +531,12 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
             // an earlier message.part.updated event.
             if (part.text && !this.receivedDeltas && !this.emittedPartText) {
               this.emittedPartText = true
-              this.emit('text', part.text)
+              // Strip user echo prefix if the full text starts with the last input
+              let text = part.text
+              if (this.lastUserInput && text.startsWith(this.lastUserInput)) {
+                text = text.slice(this.lastUserInput.length)
+              }
+              if (text) this.emit('text', text)
             }
             break
           }
@@ -543,6 +603,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         if (statusType === 'idle') {
           if (this.turnComplete) break
           this.turnComplete = true
+          this.flushDeltaBuffer()
           this.emit('result', '', false)
         }
         break
@@ -591,6 +652,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         if (!this.isOwnSession(properties)) break
         if (this.turnComplete) break
         this.turnComplete = true
+        this.flushDeltaBuffer()
         this.emit('result', '', false)
         break
       }
@@ -604,6 +666,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         if (sType === 'idle') {
           if (this.turnComplete) break
           this.turnComplete = true
+          this.flushDeltaBuffer()
           this.emit('result', '', false)
         }
         break
@@ -614,6 +677,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         if (!this.isOwnSession(properties)) break
         if (this.turnComplete) break
         this.turnComplete = true
+        this.flushDeltaBuffer()
         this.emit('result', '', false)
         break
       }
@@ -729,6 +793,10 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     this.turnComplete = false // reset completion latch for new turn
     this.receivedDeltas = false
     this.emittedPartText = false
+    this.deltaBuffer = ''
+    this.deltaBufferFlushed = false
+    this.reasoningBuffer = ''
+    this.emittedReasoningSummary = false
 
     const baseUrl = `http://localhost:${serverState.port}`
     // Parse [Attached files: ...] prefix and convert image paths to proper parts.
@@ -740,19 +808,32 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     if (attachMatch) {
       textContent = content.slice(attachMatch[0].length)
       const filePaths = attachMatch[1].split(',').map(p => p.trim())
+      const imageMimeMap: Record<string, string> = {
+        '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+        '.gif': 'image/gif', '.webp': 'image/webp',
+      }
+      const textExtensions = new Set(['.md', '.txt', '.csv', '.json', '.xml', '.yaml', '.yml', '.log'])
       for (const filePath of filePaths) {
-        const ext = extname(filePath).toLowerCase()
-        const mimeMap: Record<string, string> = {
-          '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
-          '.gif': 'image/gif', '.webp': 'image/webp',
+        if (!existsSync(filePath)) {
+          console.warn(`[opencode] Attached file not found: ${filePath}`)
+          continue
         }
-        const mime = mimeMap[ext]
-        if (mime && existsSync(filePath)) {
+        const ext = extname(filePath).toLowerCase()
+        const imageMime = imageMimeMap[ext]
+        if (imageMime) {
           const base64 = readFileSync(filePath).toString('base64')
-          parts.push({ type: 'image', image: base64, mime })
+          parts.push({ type: 'image', image: base64, mime: imageMime })
+        } else if (textExtensions.has(ext)) {
+          // Send text-based files as inline text content
+          const fileContent = readFileSync(filePath, 'utf-8')
+          const fileName = filePath.split('/').pop() || filePath
+          parts.push({ type: 'text', text: `--- ${fileName} ---\n${fileContent}` })
+        } else {
+          console.warn(`[opencode] Unsupported file type for attachment: ${ext} (${filePath})`)
         }
       }
     }
+    this.lastUserInput = textContent.trim()
     if (textContent.trim()) {
       parts.push({ type: 'text', text: textContent })
     }


### PR DESCRIPTION
## Summary
- **Duplicate messages**: Buffer initial text deltas and strip user echo prefix when providers echo user input at the start of assistant responses
- **Reasoning display**: Accumulate `field:'reasoning'` deltas and emit `thinking` events during streaming (previously silently dropped); also strip user echo from full text in `message.part.updated`
- **File attachments**: Support text-based file types (`.md`, `.txt`, `.csv`, `.json`, etc.) as inline text content instead of silently dropping them; add warnings for missing/unsupported files

## Test plan
- [x] 4 new unit tests for user echo stripping (deltas + full text), reasoning delta accumulation, and no-match passthrough
- [x] All 1561 existing tests pass
- [x] TypeScript type check passes
- [ ] Manual test with GPT-5.4 OpenCode session to verify no duplicate messages
- [ ] Manual test uploading `.md` file attachment in OpenCode session

🤖 Generated with [Claude Code](https://claude.com/claude-code)