### PR TITLE
fix: use FilePartInput format for image attachments in OpenCode

### DIFF
--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -822,7 +822,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         const imageMime = imageMimeMap[ext]
         if (imageMime) {
           const base64 = readFileSync(filePath).toString('base64')
-          parts.push({ type: 'image', image: base64, mime: imageMime })
+          parts.push({ type: 'file', mime: imageMime, filename: filePath.split('/').pop(), url: `data:${imageMime};base64,${base64}` })
         } else if (textExtensions.has(ext)) {
           // Send text-based files as inline text content
           const fileContent = readFileSync(filePath, 'utf-8')


### PR DESCRIPTION
## Summary
- Image uploads in OpenCode sessions returned HTTP 400 because we sent `{ type: 'image', image, mime }` which isn't a valid OpenCode part type
- Changed to `FilePartInput` format: `{ type: 'file', mime, filename, url: 'data:...;base64,...' }` which is what OpenCode's `prompt_async` API expects

## Test plan
- [x] All 41 existing tests pass
- [x] TypeScript compiles cleanly
- [ ] Upload an image in an OpenCode session and verify it's accepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)