### PR TITLE
feat: show disconnected message for OpenCode sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -197,6 +197,7 @@ export default function App() {
   )
   // Dynamic model list for OpenCode (fetched from server on demand)
   const [openCodeModels, setOpenCodeModels] = useState<ModelOption[]>([])
+  const [openCodeConnected, setOpenCodeConnected] = useState<boolean | null>(null) // null = unknown
   const openCodeModelsDirRef = useRef<string | undefined>(undefined)
   // Derive the active session's provider (falls back to the default for new sessions)
   const activeSessionProvider = sessions.find(s => s.id === activeSessionId)?.provider ?? currentProvider
@@ -220,6 +221,7 @@ export default function App() {
         label: `${m.name} (${m.providerName})`,
       }))
       setOpenCodeModels(models)
+      setOpenCodeConnected(models.length > 0)
       openCodeModelsDirRef.current = activeWd
       const currentIsOpenCode = currentModelRef.current && models.some(m => m.id === currentModelRef.current)
       if (!currentIsOpenCode) {
@@ -227,7 +229,7 @@ export default function App() {
         if (defaultProvider && defaultModelId) setModel(`${defaultProvider}/${defaultModelId}`)
         else if (models.length > 0) setModel(models[0].id)
       }
-    }).catch(() => { /* OpenCode server not available */ })
+    }).catch(() => { setOpenCodeConnected(false) })
   }, [activeSessionProvider, settings.token, openCodeModels.length, setModel, activeOpenCodeWd])
 
   // Reset file-change tracking when switching sessions
@@ -676,6 +678,7 @@ export default function App() {
             onPermissionModeChange={handlePermissionModeChange}
             moveToWorktree={moveToWorktree}
             worktreePath={activeSession?.worktreePath}
+            openCodeConnected={activeSessionProvider === 'opencode' ? openCodeConnected : null}
           />
         ) : (
           <RepoSelector groups={groups} token={settings.token} ghMissing={ghMissing} onOpen={handleOpenSession} onRefreshRepos={refreshRepos} />

--- a/src/components/SessionContent.tsx
+++ b/src/components/SessionContent.tsx
@@ -56,6 +56,8 @@ export interface SessionContentProps {
   onPermissionModeChange: (mode: PermissionMode) => void
   moveToWorktree: (() => void) | undefined
   worktreePath: string | undefined
+  /** null = not an OpenCode session, true = connected, false = not connected */
+  openCodeConnected: boolean | null
 }
 
 export function SessionContent({
@@ -96,19 +98,35 @@ export function SessionContent({
   onPermissionModeChange,
   moveToWorktree,
   worktreePath,
+  openCodeConnected,
 }: SessionContentProps) {
+  const isOpenCodeDisconnected = openCodeConnected === false
   return (
     <div className="flex flex-1 flex-col overflow-hidden min-h-0">
       <div className="relative flex-1 min-h-0 flex flex-col">
         <ChatView
           messages={messages}
           fontSize={fontSize}
-          disabled={disabled}
+          disabled={disabled || isOpenCodeDisconnected}
           planningMode={planningMode}
           activityLabel={activityLabel}
           isMobile={isMobile}
         />
         <TodoPanel tasks={tasks} />
+
+        {/* OpenCode not connected banner */}
+        {isOpenCodeDisconnected && messages.length === 0 && (
+          <div className="absolute inset-0 flex items-center justify-center z-10">
+            <div className="flex flex-col items-center gap-3 text-center px-6 max-w-md">
+              <div className="text-[15px] font-medium text-neutral-3">OpenCode is not connected</div>
+              <p className="text-[13px] text-neutral-5 leading-relaxed">
+                Install OpenCode to use this session. Visit{' '}
+                <a href="https://opencode.ai" target="_blank" rel="noopener noreferrer" className="text-primary-5 hover:underline">opencode.ai</a>
+                {' '}and run <code className="bg-neutral-10 px-1.5 py-0.5 rounded text-[12px]">opencode serve</code> to start the server.
+              </p>
+            </div>
+          </div>
+        )}
 
         {/* Diff view button — top-right corner, visible when files have been changed */}
         {hasFileChanges && !diffPanelOpen && (
@@ -159,7 +177,7 @@ export function SessionContent({
         ref={inputBarRef}
         onSendInput={onSendInput}
         isWaiting={!!activePrompt}
-        disabled={disabled}
+        disabled={disabled || isOpenCodeDisconnected}
         onEscape={() => {}}
         pendingFiles={pendingFiles}
         onAddFiles={onAddFiles}


### PR DESCRIPTION
## Summary
- When OpenCode server is not reachable, shows a centered "OpenCode is not connected" message with install instructions (link to opencode.ai + `opencode serve` command)
- Disables the input bar so users can't send messages to a disconnected session

## Test plan
- [ ] Create an OpenCode session without `opencode serve` running — verify banner appears and input is disabled
- [ ] Start `opencode serve` and create a session — verify no banner and input works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)