### PR TITLE
feat: add connection status popup with disable/enable toggles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -140,6 +140,8 @@ export default function App() {
     currentModel,
     setModel,
     send: wsSend,
+    disconnect: wsDisconnect,
+    reconnect: wsReconnect,
     currentPermissionMode,
     setPermissionMode,
     moveToWorktree,
@@ -198,6 +200,8 @@ export default function App() {
   // Dynamic model list for OpenCode (fetched from server on demand)
   const [openCodeModels, setOpenCodeModels] = useState<ModelOption[]>([])
   const [openCodeConnected, setOpenCodeConnected] = useState<boolean | null>(null) // null = unknown
+  const [claudeDisabled, setClaudeDisabled] = useState(false)
+  const [openCodeDisabled, setOpenCodeDisabled] = useState(false)
   const openCodeModelsDirRef = useRef<string | undefined>(undefined)
   // Derive the active session's provider (falls back to the default for new sessions)
   const activeSessionProvider = sessions.find(s => s.id === activeSessionId)?.provider ?? currentProvider
@@ -483,6 +487,37 @@ export default function App() {
   }, [settings.theme])
 
   // Derive session name for mobile top bar
+  // Connection toggle handlers
+  const handleToggleClaude = useCallback(() => {
+    if (claudeDisabled) {
+      setClaudeDisabled(false)
+      wsReconnect()
+    } else {
+      setClaudeDisabled(true)
+      wsDisconnect()
+    }
+  }, [claudeDisabled, wsDisconnect, wsReconnect])
+
+  const handleToggleOpenCode = useCallback(() => {
+    if (openCodeDisabled) {
+      setOpenCodeDisabled(false)
+      // Re-fetch models to check connection
+      if (settings.token) {
+        fetchOpenCodeModels(settings.token).then(result => {
+          const models: ModelOption[] = result.models.map(m => ({
+            id: `${m.providerID}/${m.id}`,
+            label: `${m.name} (${m.providerName})`,
+          }))
+          setOpenCodeModels(models)
+          setOpenCodeConnected(models.length > 0)
+        }).catch(() => { setOpenCodeConnected(false) })
+      }
+    } else {
+      setOpenCodeDisabled(true)
+      setOpenCodeConnected(null)
+    }
+  }, [openCodeDisabled, settings.token])
+
   const activeSession = sessions.find(s => s.id === activeSessionId)
   const activeSessionName = activeSession?.name ?? null
   const activeRepoName = activeRepo?.name ?? activeWorkingDir?.split('/').pop() ?? null
@@ -508,6 +543,11 @@ export default function App() {
         theme={settings.theme}
         fontSize={settings.fontSize}
         connState={connState}
+        claudeDisabled={claudeDisabled}
+        openCodeConnected={openCodeConnected}
+        openCodeDisabled={openCodeDisabled}
+        onToggleClaude={handleToggleClaude}
+        onToggleOpenCode={handleToggleOpenCode}
         view={view}
         archiveRefreshKey={archiveRefreshKey}
         onSelectSession={(id) => { docsBrowser.close(); if (view === 'orchestrator') navigate(`/s/${id}`); handleSelectSession(id) }}

--- a/src/components/ConnectionPopup.tsx
+++ b/src/components/ConnectionPopup.tsx
@@ -1,0 +1,111 @@
+/**
+ * ConnectionPopup — shows status of Claude Code and OpenCode connections
+ * with toggle buttons to temporarily disable/enable each.
+ */
+
+import { useRef, useEffect } from 'react'
+import type { ConnectionState } from '../types'
+
+interface Props {
+  /** Claude Code WebSocket connection state. */
+  claudeState: ConnectionState
+  /** Whether Claude Code connection is disabled by the user. */
+  claudeDisabled: boolean
+  /** Toggle Claude Code connection on/off. */
+  onToggleClaude: () => void
+  /** OpenCode connection state: true=connected, false=disconnected, null=unknown/not configured. */
+  openCodeConnected: boolean | null
+  /** Whether OpenCode connection is disabled by the user. */
+  openCodeDisabled: boolean
+  /** Toggle OpenCode connection on/off. */
+  onToggleOpenCode: () => void
+  /** Close the popup. */
+  onClose: () => void
+}
+
+function StatusDot({ color }: { color: string }) {
+  return <span className={`inline-block h-2 w-2 rounded-full flex-shrink-0 ${color}`} />
+}
+
+export function ConnectionPopup({
+  claudeState,
+  claudeDisabled,
+  onToggleClaude,
+  openCodeConnected,
+  openCodeDisabled,
+  onToggleOpenCode,
+  onClose,
+}: Props) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) onClose()
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [onClose])
+
+  const claudeDotColor = claudeDisabled
+    ? 'bg-neutral-6'
+    : claudeState === 'connected' ? 'bg-success-7' : claudeState === 'connecting' ? 'bg-warning-6' : 'bg-error-7'
+  const claudeLabel = claudeDisabled
+    ? 'Disabled'
+    : claudeState === 'connected' ? 'Connected' : claudeState === 'connecting' ? 'Connecting' : 'Disconnected'
+
+  const ocDotColor = openCodeDisabled
+    ? 'bg-neutral-6'
+    : openCodeConnected === true ? 'bg-success-7' : openCodeConnected === false ? 'bg-error-7' : 'bg-neutral-6'
+  const ocLabel = openCodeDisabled
+    ? 'Disabled'
+    : openCodeConnected === true ? 'Connected' : openCodeConnected === false ? 'Disconnected' : 'Not configured'
+
+  return (
+    <div
+      ref={ref}
+      className="absolute bottom-full left-0 mb-2 w-56 rounded-lg border border-neutral-8/40 bg-neutral-11 shadow-lg z-50"
+    >
+      <div className="px-3 py-2 border-b border-neutral-8/30 text-[11px] font-medium uppercase tracking-wider text-neutral-5">
+        Connections
+      </div>
+
+      {/* Claude Code */}
+      <div className="px-3 py-2.5 flex items-center gap-2">
+        <StatusDot color={claudeDotColor} />
+        <div className="flex-1 min-w-0">
+          <div className="text-[13px] text-neutral-2 font-medium">Claude Code</div>
+          <div className="text-[11px] text-neutral-5">{claudeLabel}</div>
+        </div>
+        <button
+          onClick={onToggleClaude}
+          className={`text-[11px] px-2 py-0.5 rounded border transition-colors ${
+            claudeDisabled
+              ? 'border-success-8/50 text-success-5 hover:bg-success-9/20'
+              : 'border-neutral-8/50 text-neutral-4 hover:bg-neutral-8/30'
+          }`}
+        >
+          {claudeDisabled ? 'Enable' : 'Disable'}
+        </button>
+      </div>
+
+      {/* OpenCode */}
+      <div className="px-3 py-2.5 flex items-center gap-2 border-t border-neutral-8/20">
+        <StatusDot color={ocDotColor} />
+        <div className="flex-1 min-w-0">
+          <div className="text-[13px] text-neutral-2 font-medium">OpenCode</div>
+          <div className="text-[11px] text-neutral-5">{ocLabel}</div>
+        </div>
+        <button
+          onClick={onToggleOpenCode}
+          className={`text-[11px] px-2 py-0.5 rounded border transition-colors ${
+            openCodeDisabled
+              ? 'border-success-8/50 text-success-5 hover:bg-success-9/20'
+              : 'border-neutral-8/50 text-neutral-4 hover:bg-neutral-8/30'
+          }`}
+        >
+          {openCodeDisabled ? 'Enable' : 'Disable'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -13,13 +13,14 @@ import {
   IconLogout, IconSun, IconMoon,
   IconChevronRight, IconChevronLeft, IconSparkles, IconX, IconRobotFace,
 } from '@tabler/icons-react'
-import type { Session, Module, Repo, DocsPickerProps, MobileProps } from '../types'
+import type { Session, Module, Repo, DocsPickerProps, MobileProps, ConnectionState } from '../types'
 import type { RepoGroup } from '../hooks/useRepos'
 import AppIcon from './AppIcon'
 import { NewSessionButton } from './NewSessionButton'
 import { RepoSection, type RepoNode } from './RepoSection'
 import { ArchivedSessionsPanel } from './ArchivedSessionsPanel'
 import { ModuleBrowser } from './ModuleBrowser'
+import { ConnectionPopup } from './ConnectionPopup'
 import { groupKey } from '../hooks/useSessionOrchestration'
 
 const SIDEBAR_WIDTH_KEY = 'codekin-left-sidebar-width'
@@ -92,6 +93,16 @@ interface Props {
   fontSize: number
   /** WebSocket connection state ('disconnected' | 'connecting' | 'connected'). */
   connState: string
+  /** Whether Claude Code connection is disabled by the user. */
+  claudeDisabled: boolean
+  /** OpenCode connection state: true=connected, false=disconnected, null=unknown. */
+  openCodeConnected: boolean | null
+  /** Whether OpenCode connection is disabled by the user. */
+  openCodeDisabled: boolean
+  /** Toggle Claude Code connection on/off. */
+  onToggleClaude: () => void
+  /** Toggle OpenCode connection on/off. */
+  onToggleOpenCode: () => void
   /** Current route view ('chat' | 'workflows'). */
   view: string
   /** Agent display name for the orchestrator button. */
@@ -150,6 +161,11 @@ export function LeftSidebar({
   theme,
   fontSize,
   connState,
+  claudeDisabled,
+  openCodeConnected,
+  openCodeDisabled,
+  onToggleClaude,
+  onToggleOpenCode,
   view,
   archiveRefreshKey,
   onSelectSession,
@@ -177,6 +193,7 @@ export function LeftSidebar({
     return stored ? Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, Number(stored))) : DEFAULT_WIDTH
   })
   const [modulesOpen, setModulesOpen] = useState(false)
+  const [connPopupOpen, setConnPopupOpen] = useState(false)
   const [archiveViewSessionId, setArchiveViewSessionId] = useState<string | null>(null)
   const modulesRef = useRef<HTMLDivElement>(null)
   const dragging = useRef(false)
@@ -275,8 +292,25 @@ export function LeftSidebar({
           >
             {theme === 'dark' ? <IconSun size={14} stroke={2} /> : <IconMoon size={14} stroke={2} />}
           </button>
-          <div title={connState.charAt(0).toUpperCase() + connState.slice(1)}>
-            <span className={`inline-block h-2 w-2 rounded-full ${connDotColor}`} />
+          <div className="relative">
+            <button
+              onClick={() => setConnPopupOpen(o => !o)}
+              className="flex items-center justify-center rounded p-1 hover:bg-neutral-6 transition-colors"
+              title="Connection status"
+            >
+              <span className={`inline-block h-2 w-2 rounded-full ${connDotColor}`} />
+            </button>
+            {connPopupOpen && (
+              <ConnectionPopup
+                claudeState={connState as ConnectionState}
+                claudeDisabled={claudeDisabled}
+                onToggleClaude={onToggleClaude}
+                openCodeConnected={openCodeConnected}
+                openCodeDisabled={openCodeDisabled}
+                onToggleOpenCode={onToggleOpenCode}
+                onClose={() => setConnPopupOpen(false)}
+              />
+            )}
           </div>
         </div>
       </div>
@@ -445,8 +479,25 @@ export function LeftSidebar({
       {/* Bottom toolbar */}
       <div className="flex flex-col border-t border-neutral-8/30 flex-shrink-0">
         <div className={`flex items-center gap-0.5 px-2 ${isMobile ? 'gap-1 py-3' : 'py-2'}`}>
-          <div className="flex items-center justify-center px-1 py-1" title={connState.charAt(0).toUpperCase() + connState.slice(1)}>
-            <span className={`inline-block h-2 w-2 rounded-full ${connDotColor}`} />
+          <div className="relative">
+            <button
+              onClick={() => setConnPopupOpen(o => !o)}
+              className="flex items-center justify-center px-1 py-1 rounded hover:bg-neutral-6 transition-colors"
+              title="Connection status"
+            >
+              <span className={`inline-block h-2 w-2 rounded-full ${connDotColor}`} />
+            </button>
+            {connPopupOpen && (
+              <ConnectionPopup
+                claudeState={connState as ConnectionState}
+                claudeDisabled={claudeDisabled}
+                onToggleClaude={onToggleClaude}
+                openCodeConnected={openCodeConnected}
+                openCodeDisabled={openCodeDisabled}
+                onToggleOpenCode={onToggleOpenCode}
+                onClose={() => setConnPopupOpen(false)}
+              />
+            )}
           </div>
           <button
             onClick={onSettingsOpen}


### PR DESCRIPTION
## Summary
- Clicking the status dot in the sidebar now opens a popup showing Claude Code and OpenCode connection status
- Each connection has a Disable/Enable toggle button to temporarily close or re-establish the connection
- Works in both collapsed and expanded sidebar modes

## Test plan
- [ ] Click status dot in expanded sidebar — popup appears above the dot
- [ ] Click status dot in collapsed sidebar — popup appears correctly
- [ ] Verify Claude Code shows "Connected" with green dot when WS is active
- [ ] Click "Disable" on Claude Code — WS disconnects, dot turns gray, label shows "Disabled", button says "Enable"
- [ ] Click "Enable" — WS reconnects, status returns to green/connected
- [ ] Verify OpenCode status reflects actual server availability
- [ ] Click outside the popup to dismiss it

🤖 Generated with [Claude Code](https://claude.com/claude-code)