### PR TITLE
fix: prevent false session resets from zombie detection

### DIFF
--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -317,7 +317,7 @@ describe('SessionManager', () => {
       // Not denied yet — grace period active
       expect(cp.sendControlResponse).not.toHaveBeenCalled()
 
-      vi.advanceTimersByTime(3000)
+      vi.advanceTimersByTime(10_000)
 
       expect(cp.sendControlResponse).toHaveBeenCalledTimes(2)
       expect(cp.sendControlResponse).toHaveBeenCalledWith('req-1', 'deny')
@@ -358,7 +358,7 @@ describe('SessionManager', () => {
       // Not denied yet — grace period active
       expect(resolve).not.toHaveBeenCalled()
 
-      vi.advanceTimersByTime(3000)
+      vi.advanceTimersByTime(10_000)
 
       expect(resolve).toHaveBeenCalledWith({ allow: false, always: false })
       expect(s.pendingToolApprovals.size).toBe(0)
@@ -418,7 +418,7 @@ describe('SessionManager', () => {
 
       sm.leave(s.id, ws)
 
-      vi.advanceTimersByTime(3000)
+      vi.advanceTimersByTime(10_000)
 
       expect(cp.sendControlResponse).toHaveBeenCalledWith('req-1', 'deny')
       expect(s.pendingControlRequests.size).toBe(0)

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -739,6 +739,8 @@ export class SessionManager {
 
       // If no clients remain, wait a grace period before auto-denying.
       // This prevents false denials when the user is just refreshing the page.
+      // The grace period must be long enough for the client to complete its
+      // reconnect flow: zombie retry pings (up to 6s) + auth check + WS handshake.
       if (session.clients.size === 0) {
         if (session._leaveGraceTimer) clearTimeout(session._leaveGraceTimer)
 
@@ -762,7 +764,7 @@ export class SessionManager {
               session.pendingToolApprovals.clear()
             }
           }
-        }, 3000)
+        }, 10_000)
       }
     }
   }

--- a/src/hooks/useChatSocket.hook.test.ts
+++ b/src/hooks/useChatSocket.hook.test.ts
@@ -818,9 +818,13 @@ describe('useChatSocket hook', () => {
         workingDir: '/tmp',
       } as WsServerMessage))
       act(() => result.current.restoreSession())
-      // Wait 2s without pong — should force close
+      // First ping sent immediately; retries at 2s and 4s; zombie close at 6s
       act(() => { vi.advanceTimersByTime(2000) })
-      expect(ws.readyState).toBe(MockWebSocket.CLOSED)
+      expect(ws.readyState).toBe(MockWebSocket.OPEN) // still alive after first timeout
+      act(() => { vi.advanceTimersByTime(2000) })
+      expect(ws.readyState).toBe(MockWebSocket.OPEN) // still alive after second timeout
+      act(() => { vi.advanceTimersByTime(2000) })
+      expect(ws.readyState).toBe(MockWebSocket.CLOSED) // closed after all 3 retries exhausted
       unmount()
     })
 

--- a/src/hooks/useWsConnection.ts
+++ b/src/hooks/useWsConnection.ts
@@ -45,9 +45,9 @@ export function useWsConnection({
   // Session restore / health check state machine:
   //
   //   Tab hidden → Tab visible
-  //     ├─ WS OPEN:  set awaitingHealthPong=true, send ping, start 2s timeout
-  //     │    ├─ pong received before timeout → call onHealthPong (rejoin session)
-  //     │    └─ timeout fires → close WS as zombie, reconnect via onclose
+  //     ├─ WS OPEN:  set awaitingHealthPong=true, send ping, start retry loop
+  //     │    ├─ pong received before deadline → call onHealthPong (rejoin session)
+  //     │    └─ all retries exhausted (3 pings over 6s) → close WS as zombie, reconnect
   //     ├─ WS CONNECTING: no-op (onopen will complete the handshake)
   //     └─ WS CLOSED: check auth → reconnect()
   //
@@ -56,6 +56,8 @@ export function useWsConnection({
   const restoringRef = useRef(false)
   const awaitingHealthPong = useRef(false)
   const healthPongTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  /** How many health pings have been sent in the current restore attempt. */
+  const healthPingCount = useRef(0)
 
   // Stable refs for callbacks that may change
   const onDisconnectRef = useRef(onDisconnect)
@@ -148,26 +150,41 @@ export function useWsConnection({
 
   /**
    * Restore the connection after a visibility change (tab focus return).
-   * Case 1: WS open — health ping, rejoin on pong, zombie timeout at 2s.
+   * Case 1: WS open — health ping with retries (3 attempts over 6s), rejoin on pong.
    * Case 2: WS connecting — let existing onopen handle it.
    * Case 3: WS closed — check auth, then reconnect.
    */
   const restoreSession = useCallback(() => {
     if (restoringRef.current) return
     restoringRef.current = true
-    setTimeout(() => { restoringRef.current = false }, 3000)
+    setTimeout(() => { restoringRef.current = false }, 8000)
 
     const ws = wsRef.current
 
     if (ws && ws.readyState === WebSocket.OPEN) {
       awaitingHealthPong.current = true
-      healthPongTimer.current = setTimeout(() => {
-        awaitingHealthPong.current = false
-        healthPongTimer.current = null
-        backoff.current = 1000
-        ws.close()
-      }, 2000)
+      healthPingCount.current = 1
+
+      const scheduleRetryOrClose = () => {
+        healthPongTimer.current = setTimeout(() => {
+          healthPongTimer.current = null
+          if (!awaitingHealthPong.current) return // pong arrived
+          if (healthPingCount.current < 3) {
+            // Retry: send another ping
+            healthPingCount.current += 1
+            send({ type: 'ping' })
+            scheduleRetryOrClose()
+          } else {
+            // All retries exhausted — connection is dead
+            awaitingHealthPong.current = false
+            backoff.current = 1000
+            ws.close()
+          }
+        }, 2000)
+      }
+
       send({ type: 'ping' })
+      scheduleRetryOrClose()
       return
     }
 


### PR DESCRIPTION
## Summary

- **Zombie detection**: Changed from a single ping with 2s hard timeout to 3 retry pings over 6s. A single dropped packet or slow server response no longer kills the WebSocket connection and triggers a full session reset.
- **Leave grace period**: Increased from 3s to 10s. The previous 3s window was too tight for the client to complete its reconnect flow (zombie retry + auth check + backoff + WS handshake), causing pending tool approvals and control requests to be auto-denied — which could crash or restart the Claude process.

## Root cause

Every tab visibility change (alt-tab, window switch) triggered `restoreSession()`, which sent a health ping with a 2s timeout. If the server was under load or network had any latency spike, the pong arrived late, the WebSocket was force-closed, and the session appeared to "reset" from the user's perspective. The 3s server-side leave grace period compounded the issue by auto-denying pending prompts before the client could reconnect.

## Test plan

- [x] All 1561 existing tests pass
- [x] Build succeeds
- [ ] Manual: open a session, switch tabs repeatedly under load, verify no spurious resets
- [ ] Manual: trigger a tool approval, switch away and back, verify approval persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)