### PR TITLE
fix: harden session restart logic to reduce spurious restarts

### DIFF
--- a/server/prompt-router.test.ts
+++ b/server/prompt-router.test.ts
@@ -49,6 +49,8 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     _claudeTurnCount: 0,
     _namingAttempts: 0,
     _apiRetryCount: 0,
+    _processGeneration: 0,
+    _noOutputExitCount: 0,
     _lastActivityAt: Date.now(),
     planManager: makePlanManager() as any,
     ...overrides,

--- a/server/session-lifecycle.test.ts
+++ b/server/session-lifecycle.test.ts
@@ -85,6 +85,8 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     _claudeTurnCount: 0,
     _namingAttempts: 0,
     _apiRetryCount: 0,
+    _processGeneration: 0,
+    _noOutputExitCount: 0,
     _lastActivityAt: Date.now(),
     planManager: makePlanManager() as any,
     ...overrides,
@@ -224,6 +226,15 @@ describe('SessionLifecycle', () => {
       expect(result).toBe(false)
       expect(session._stoppedByUser).toBe(true)
       expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'system_message', subtype: 'error' }))
+    })
+
+    it('bumps _processGeneration on each call', () => {
+      expect(session._processGeneration).toBe(0)
+      lifecycle.startClaude('sess-1')
+      expect(session._processGeneration).toBe(1)
+      // Second call kills existing process and bumps again
+      lifecycle.startClaude('sess-1')
+      expect(session._processGeneration).toBe(2)
     })
   })
 
@@ -382,14 +393,16 @@ describe('SessionLifecycle', () => {
       expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'exit' }))
     })
 
-    it('clears claudeSessionId when process had no output', () => {
+    it('increments no-output counter but preserves claudeSessionId on single no-output exit', () => {
       session.claudeSessionId = 'old-session-id'
+      session._noOutputExitCount = 0
       exitedProcess.hadOutput.mockReturnValue(false)
       mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
 
       lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
 
-      expect(session.claudeSessionId).toBeNull()
+      expect(session.claudeSessionId).toBe('old-session-id')
+      expect(session._noOutputExitCount).toBe(1)
     })
 
     it('preserves claudeSessionId when spawn failed', () => {
@@ -434,6 +447,84 @@ describe('SessionLifecycle', () => {
 
       expect(session._stoppedByUser).toBe(true)
       expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'exit' }))
+    })
+
+    // --- Generation ID tests ---
+
+    it('restart timer skips if generation changed (another start happened)', () => {
+      mockEvaluateRestart.mockReturnValue({
+        kind: 'restart',
+        attempt: 1,
+        maxAttempts: 3,
+        delayMs: 2000,
+        updatedCount: 1,
+        updatedLastRestartAt: Date.now(),
+      })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      // Simulate another code path starting Claude before the timer fires
+      // (e.g. user sends input which triggers sendInput → startClaude)
+      session._processGeneration = 99
+
+      vi.advanceTimersByTime(2000)
+
+      // The timer should have been a no-op — claudeProcess stays null
+      // (startClaude was not called by the timer)
+      expect(session.claudeProcess).toBeNull()
+    })
+
+    // --- Non-retryable exit code tests ---
+
+    it('does not restart on non-retryable exit code', () => {
+      mockEvaluateRestart.mockReturnValue({ kind: 'non_retryable', exitCode: 2 })
+      const listener = vi.fn()
+      deps.exitListeners.push(listener)
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 2, null)
+
+      expect(listener).toHaveBeenCalledWith('sess-1', 2, null, false)
+      expect(deps.addToHistory).toHaveBeenCalledWith(session, expect.objectContaining({
+        subtype: 'error',
+        text: expect.stringContaining('non-retryable'),
+      }))
+      expect(deps.broadcast).toHaveBeenCalledWith(session, expect.objectContaining({ type: 'exit' }))
+    })
+
+    // --- No-output threshold tests ---
+
+    it('preserves claudeSessionId on first no-output exit (threshold not reached)', () => {
+      session.claudeSessionId = 'old-session-id'
+      session._noOutputExitCount = 0
+      exitedProcess.hadOutput.mockReturnValue(false)
+      mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      expect(session.claudeSessionId).toBe('old-session-id')
+      expect(session._noOutputExitCount).toBe(1)
+    })
+
+    it('clears claudeSessionId after consecutive no-output exits reach threshold', () => {
+      session.claudeSessionId = 'old-session-id'
+      session._noOutputExitCount = 1 // already had one failure
+      exitedProcess.hadOutput.mockReturnValue(false)
+      mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 1, null)
+
+      expect(session.claudeSessionId).toBeNull()
+      expect(session._noOutputExitCount).toBe(0) // reset after clearing
+    })
+
+    it('resets no-output counter when process produces output', () => {
+      session._noOutputExitCount = 1
+      exitedProcess.hadOutput.mockReturnValue(true)
+      mockEvaluateRestart.mockReturnValue({ kind: 'stopped_by_user' })
+
+      lifecycle.handleClaudeExit(exitedProcess, session, 'sess-1', 0, null)
+
+      expect(session._noOutputExitCount).toBe(0)
     })
 
     it('swallows errors from exit listeners', () => {

--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -68,6 +68,9 @@ export class SessionLifecycle {
     // Clear stopped flag and any pending restart timer on explicit start
     session._stoppedByUser = false
     if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }
+    // Bump generation so any in-flight restart timers from a previous process
+    // become stale and no-op when they fire.
+    session._processGeneration = (session._processGeneration ?? 0) + 1
 
     // Validate that the working directory still exists.  Worktree directories
     // can be removed externally (cleanup, manual deletion, failed creation that
@@ -268,17 +271,28 @@ export class SessionLifecycle {
     const spawnFailed = proc.hasSpawnFailed ? proc.hasSpawnFailed() : false
 
     // If the process exited without ever producing stdout output, --resume
-    // hung on a broken/stale session. Clear claudeSessionId so the next
-    // restart attempt uses a fresh session instead of retrying the same
-    // broken resume — which would just hang again.
+    // likely hung on a broken/stale session.  But one failure could be transient
+    // (slow startup, brief network blip), so we track consecutive no-output exits
+    // and only clear claudeSessionId after 2 consecutive failures.  This avoids
+    // silent context loss from a single unlucky exit.
     // Exception: if spawn() itself failed (ENOENT/EACCES), the process never
-    // started — the session data on disk is fine, so preserve the ID for retry.
-    if (!producedOutput && session.claudeSessionId && !spawnFailed) {
-      console.warn(`[restart] Session ${sessionId} produced no output before exit — clearing claudeSessionId to force fresh session`)
-      session.claudeSessionId = null
-    }
+    // started — the session data on disk is fine, so preserve the ID and don't
+    // count it.
     if (spawnFailed) {
       console.warn(`[restart] Session ${sessionId} spawn failed (binary not found) — preserving claudeSessionId for retry`)
+    } else if (!producedOutput && session.claudeSessionId) {
+      session._noOutputExitCount = (session._noOutputExitCount ?? 0) + 1
+      const NO_OUTPUT_THRESHOLD = 2
+      if (session._noOutputExitCount >= NO_OUTPUT_THRESHOLD) {
+        console.warn(`[restart] Session ${sessionId} produced no output ${session._noOutputExitCount} consecutive times — clearing claudeSessionId to force fresh session`)
+        session.claudeSessionId = null
+        session._noOutputExitCount = 0
+      } else {
+        console.warn(`[restart] Session ${sessionId} produced no output before exit (${session._noOutputExitCount}/${NO_OUTPUT_THRESHOLD}) — will retry with same session ID`)
+      }
+    } else if (producedOutput) {
+      // Successful output resets the consecutive no-output counter
+      session._noOutputExitCount = 0
     }
 
     // Before evaluating restart, check if the working directory still exists.
@@ -324,7 +338,24 @@ export class SessionLifecycle {
       restartCount: session.restartCount,
       lastRestartAt: session.lastRestartAt,
       stoppedByUser: session._stoppedByUser || sessionConflict,
+      exitCode: code,
+      exitSignal: signal,
     })
+
+    if (action.kind === 'non_retryable') {
+      for (const listener of this.deps.exitListeners) {
+        try { listener(sessionId, code, signal, false) } catch { /* listener error */ }
+      }
+      const msg: WsServerMessage = {
+        type: 'system_message',
+        subtype: 'error',
+        text: `Claude process exited with non-retryable error (code=${action.exitCode}). This usually indicates a configuration or argument problem. Please check your session settings and restart manually.`,
+      }
+      this.deps.addToHistory(session, msg)
+      this.deps.broadcast(session, msg)
+      this.deps.broadcast(session, { type: 'exit', code: code ?? -1, signal })
+      return
+    }
 
     if (action.kind === 'stopped_by_user') {
       for (const listener of this.deps.exitListeners) {
@@ -358,10 +389,17 @@ export class SessionLifecycle {
 
       // Clear any previously scheduled restart to prevent duplicate spawns
       if (session._restartTimer) clearTimeout(session._restartTimer)
+      const generationAtSchedule = session._processGeneration ?? 0
       session._restartTimer = setTimeout(() => {
         session._restartTimer = undefined
-        // Verify session still exists and hasn't been stopped
+        // Verify session still exists, hasn't been stopped, and no newer
+        // process was started (by sendInput, manual restart, etc.) while
+        // this timer was pending.
         if (!this.deps.hasSession(sessionId) || session._stoppedByUser) return
+        if (session._processGeneration !== generationAtSchedule) {
+          console.log(`[restart] Skipping stale restart timer for session ${sessionId} (generation ${generationAtSchedule} → ${session._processGeneration})`)
+          return
+        }
         // startClaude uses --resume when claudeSessionId exists, so the CLI
         // picks up the full conversation history from the JSONL automatically.
         this.startClaude(sessionId)

--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -3513,21 +3513,32 @@ describe('SessionManager', () => {
       vi.useRealTimers()
     })
 
-    it('clears claudeSessionId when process had no output but spawn succeeded', () => {
+    it('clears claudeSessionId after consecutive no-output exits reach threshold', () => {
       vi.useFakeTimers()
       const s = sm.create('no-output-test', '/tmp')
       const session = sm.get(s.id)!
       ;(session as any).claudeSessionId = 'stale-session'
       ;(session as any).restartCount = 0
+      ;(session as any)._noOutputExitCount = 0
 
-      const cp = fakeClaudeProcess(false)
-      cp.hadOutput.mockReturnValue(false)
-      cp.hasSpawnFailed.mockReturnValue(false)
+      const cp1 = fakeClaudeProcess(false)
+      cp1.hadOutput.mockReturnValue(false)
+      cp1.hasSpawnFailed.mockReturnValue(false)
 
-      ;(sm as any).handleClaudeExit(cp, session, s.id, 1, null)
+      // First no-output exit: should preserve claudeSessionId (threshold=2)
+      ;(sm as any).handleClaudeExit(cp1, session, s.id, 1, null)
+      expect(session.claudeSessionId).toBe('stale-session')
+      expect((session as any)._noOutputExitCount).toBe(1)
 
-      // claudeSessionId should be cleared since process started but produced nothing
+      // Second no-output exit: should clear claudeSessionId
+      session.claudeProcess = null // reset for second exit
+      const cp2 = fakeClaudeProcess(false)
+      cp2.hadOutput.mockReturnValue(false)
+      cp2.hasSpawnFailed.mockReturnValue(false)
+      ;(sm as any).handleClaudeExit(cp2, session, s.id, 1, null)
       expect(session.claudeSessionId).toBeNull()
+      expect((session as any)._noOutputExitCount).toBe(0)
+
       vi.useRealTimers()
     })
   })

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -301,6 +301,8 @@ export class SessionManager {
       _turnCount: 0,
       _claudeTurnCount: 0,
       _namingAttempts: 0,
+      _processGeneration: 0,
+      _noOutputExitCount: 0,
       isProcessing: false,
       pendingControlRequests: new Map(),
       pendingToolApprovals: new Map(),

--- a/server/session-persistence.ts
+++ b/server/session-persistence.ts
@@ -132,6 +132,8 @@ export class SessionPersistence {
           _turnCount: 99, // restored sessions already have a name
           _claudeTurnCount: 0,
           _namingAttempts: 0,
+          _processGeneration: 0,
+          _noOutputExitCount: 0,
           isProcessing: false,
           pendingControlRequests: new Map(),
           pendingToolApprovals: new Map(),

--- a/server/session-restart-scheduler.test.ts
+++ b/server/session-restart-scheduler.test.ts
@@ -1,0 +1,71 @@
+/** Tests for evaluateRestart — pure restart decision logic. */
+import { describe, it, expect } from 'vitest'
+import { evaluateRestart, type RestartState } from './session-restart-scheduler.js'
+
+function makeState(overrides: Partial<RestartState> = {}): RestartState {
+  return {
+    restartCount: 0,
+    lastRestartAt: null,
+    stoppedByUser: false,
+    exitCode: null,
+    exitSignal: null,
+    ...overrides,
+  }
+}
+
+describe('evaluateRestart', () => {
+  it('returns stopped_by_user when stoppedByUser is true', () => {
+    const action = evaluateRestart(makeState({ stoppedByUser: true }))
+    expect(action.kind).toBe('stopped_by_user')
+  })
+
+  it('returns restart on first unexpected exit', () => {
+    const action = evaluateRestart(makeState())
+    expect(action).toMatchObject({
+      kind: 'restart',
+      attempt: 1,
+      maxAttempts: 3,
+      updatedCount: 1,
+    })
+  })
+
+  it('returns exhausted after max restarts', () => {
+    const action = evaluateRestart(makeState({ restartCount: 3, lastRestartAt: Date.now() }))
+    expect(action).toMatchObject({ kind: 'exhausted', maxAttempts: 3 })
+  })
+
+  it('resets counter after cooldown window elapses', () => {
+    const action = evaluateRestart(makeState({
+      restartCount: 3,
+      lastRestartAt: Date.now() - 6 * 60 * 1000, // 6 minutes ago
+    }))
+    expect(action).toMatchObject({ kind: 'restart', attempt: 1 })
+  })
+
+  // --- Non-retryable exit code tests ---
+
+  it('returns non_retryable for exit code 2 (usage error)', () => {
+    const action = evaluateRestart(makeState({ exitCode: 2 }))
+    expect(action).toMatchObject({ kind: 'non_retryable', exitCode: 2 })
+  })
+
+  it('returns non_retryable for exit code 78 (config error)', () => {
+    const action = evaluateRestart(makeState({ exitCode: 78 }))
+    expect(action).toMatchObject({ kind: 'non_retryable', exitCode: 78 })
+  })
+
+  it('still restarts for non-deterministic exit codes', () => {
+    const action = evaluateRestart(makeState({ exitCode: 1 }))
+    expect(action.kind).toBe('restart')
+  })
+
+  it('still restarts when exit code is null (signal kill)', () => {
+    const action = evaluateRestart(makeState({ exitCode: null, exitSignal: 'SIGKILL' }))
+    expect(action.kind).toBe('restart')
+  })
+
+  it('stopped_by_user takes precedence over non-retryable exit code', () => {
+    const action = evaluateRestart(makeState({ stoppedByUser: true, exitCode: 2 }))
+    expect(action.kind).toBe('stopped_by_user')
+  })
+})

--- a/server/session-restart-scheduler.ts
+++ b/server/session-restart-scheduler.ts
@@ -2,8 +2,8 @@
  * Restart decision logic extracted from SessionManager.handleClaudeExit.
  *
  * Pure function that evaluates whether a crashed session should be auto-restarted,
- * based on restart count, cooldown window, and user-stop state. Returns an action
- * descriptor that the caller (SessionManager) executes.
+ * based on restart count, cooldown window, exit classification, and user-stop state.
+ * Returns an action descriptor that the caller (SessionManager) executes.
  */
 
 /** Max auto-restart attempts before requiring manual intervention. */
@@ -13,14 +13,28 @@ const RESTART_COOLDOWN_MS = 5 * 60 * 1000
 /** Delay between crash and auto-restart attempt. */
 const RESTART_DELAY_MS = 2000
 
+/**
+ * Exit codes that indicate a deterministic failure — retrying will produce
+ * the same result every time, so auto-restart is wasteful.
+ *
+ * - 2: CLI usage / argument error (e.g. invalid --model, bad flags)
+ * - 78: EX_CONFIG — configuration error (sysexits.h convention)
+ */
+const NON_RETRYABLE_EXIT_CODES = new Set([2, 78])
+
 export interface RestartState {
   restartCount: number
   lastRestartAt: number | null
   stoppedByUser: boolean
+  /** Exit code from the process, if available. Used to classify failure type. */
+  exitCode?: number | null
+  /** Signal that killed the process, if any. */
+  exitSignal?: string | null
 }
 
 export type RestartAction =
   | { kind: 'stopped_by_user' }
+  | { kind: 'non_retryable'; exitCode: number }
   | { kind: 'restart'; attempt: number; maxAttempts: number; delayMs: number; updatedCount: number; updatedLastRestartAt: number }
   | { kind: 'exhausted'; maxAttempts: number }
 
@@ -31,6 +45,11 @@ export type RestartAction =
 export function evaluateRestart(state: RestartState): RestartAction {
   if (state.stoppedByUser) {
     return { kind: 'stopped_by_user' }
+  }
+
+  // Deterministic failures: retrying won't help, tell the user immediately
+  if (state.exitCode != null && NON_RETRYABLE_EXIT_CODES.has(state.exitCode)) {
+    return { kind: 'non_retryable', exitCode: state.exitCode }
   }
 
   const now = Date.now()

--- a/server/types.ts
+++ b/server/types.ts
@@ -103,6 +103,14 @@ export interface Session {
   }
   /** Timer handle for scheduled auto-restart, stored to prevent duplicate restarts. */
   _restartTimer?: ReturnType<typeof setTimeout>
+  /** Monotonically increasing counter bumped on every startClaude() call.
+   *  Restart timers capture the generation at scheduling time and bail if it
+   *  has changed by the time they fire — prevents stale timers from replacing
+   *  a healthy process that was started by a different code path. */
+  _processGeneration: number
+  /** Number of consecutive no-output exits with the same claudeSessionId.
+   *  Only after reaching the threshold do we clear claudeSessionId. */
+  _noOutputExitCount: number
   /** Grace period timer before auto-denying prompts after last client leaves. */
   _leaveGraceTimer?: ReturnType<typeof setTimeout> | null
   /** Timestamp of last meaningful activity (input, prompt response, client join). Used by idle reaper. */

--- a/server/ws-message-handler.test.ts
+++ b/server/ws-message-handler.test.ts
@@ -39,6 +39,8 @@ function mockSession(overrides: Partial<Session> = {}): Session {
     isProcessing: false,
     _turnCount: 0,
     _namingAttempts: 0,
+    _processGeneration: 0,
+    _noOutputExitCount: 0,
     _apiRetry: { count: 0 },
     ...overrides,
   }


### PR DESCRIPTION
## Summary

- **Generation ID on restart timers**: Each `startClaude()` bumps `_processGeneration`; restart timer callbacks check it before firing, preventing stale timers from replacing a healthy process started by another code path (e.g. `sendInput` auto-start)
- **Exit code classification**: `evaluateRestart` now returns `non_retryable` for deterministic exit codes (2=usage error, 78=config error), stopping the session immediately with a clear message instead of burning through 3 doomed restart attempts
- **No-output threshold**: Instead of immediately wiping `claudeSessionId` on the first no-output exit (causing silent context loss), consecutive failures are tracked via `_noOutputExitCount` — session ID is only cleared after 2 consecutive no-output exits

## Test plan

- [x] All 1576 existing tests pass
- [x] New unit tests for `session-restart-scheduler` (exit code classification)
- [x] New lifecycle tests: generation ID bump, stale timer skip, non-retryable exit, no-output threshold (1st exit preserves, 2nd clears, output resets counter)
- [x] Updated `session-manager.test.ts` for new threshold behavior
- [x] Lint clean (0 errors), build clean
- [ ] Manual: verify session survives a single transient startup failure without losing context
- [ ] Manual: verify bad `--model` flag (exit code 2) shows clear error and doesn't restart-loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)