### PR TITLE
fix: prevent stdio buffer deadlock in OpenCode server spawn

### DIFF
--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -116,7 +116,7 @@ async function startOpenCodeServer(workingDir: string): Promise<void> {
 
   const proc = spawn('opencode', ['serve', '--port', String(serverState.port)], {
     cwd: workingDir,
-    stdio: ['pipe', 'pipe', 'pipe'],
+    stdio: 'ignore', // prevents buffer deadlock — pipes were never drained
     env,
   })
   serverState.process = proc


### PR DESCRIPTION
## Summary
- Changed `stdio` from `['pipe','pipe','pipe']` to `'ignore'` in the OpenCode server spawn
- Pipes were never drained, causing the child process to block when stdout/stderr buffers filled (e.g. during noisy git operations)
- This was the root cause of app freezes when running git via bash

## Test plan
- [ ] Verify OpenCode server starts and becomes healthy
- [ ] Run git-heavy operations through the UI and confirm no freezes

🤖 Generated with [Claude Code](https://claude.com/claude-code)