### PR TITLE
fix: strip GIT_* env vars from OpenCode server for worktree compat

### DIFF
--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -105,10 +105,17 @@ async function startOpenCodeServer(workingDir: string): Promise<void> {
   serverState.port = 14096 + Math.floor(Math.random() * 1000)
   serverState.password = randomUUID()
 
+  // Strip API keys and GIT_* vars (except GIT_EDITOR) — same filtering as
+  // claude-process.ts.  GIT_INDEX_FILE=.git/index breaks worktrees where
+  // .git is a file, and stale API keys override OpenCode's own auth.
+  const API_KEY_VARS = new Set(['ANTHROPIC_API_KEY', 'CLAUDE_CODE_API_KEY', 'AUTH_TOKEN', 'AUTH_TOKEN_FILE'])
   const env: Record<string, string> = {
     ...Object.fromEntries(
       Object.entries(process.env).filter(
-        (entry): entry is [string, string] => entry[1] != null
+        (entry): entry is [string, string] =>
+          entry[1] != null &&
+          !API_KEY_VARS.has(entry[0]) &&
+          (!entry[0].startsWith('GIT_') || entry[0] === 'GIT_EDITOR')
       )
     ),
     OPENCODE_SERVER_PASSWORD: serverState.password,


### PR DESCRIPTION
## Summary
- Strip `GIT_*` env vars (except `GIT_EDITOR`) and API key vars from the OpenCode server process environment
- Matches the same filtering already applied in `claude-process.ts`
- `GIT_INDEX_FILE=.git/index` (inherited from parent shell) breaks all git operations in worktrees where `.git` is a file pointing to the main repo — this caused OpenCode to think the repo was broken and bash/git actions to fail or hang

## Test plan
- [ ] Start an OpenCode session in a worktree
- [ ] Run git commands (status, log, diff) via bash — should succeed
- [ ] Verify OpenCode no longer reports the repo as "broken" or tries to copy files to the main repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)