### PR TITLE
fix: restore wss:/ws: in CSP connect-src to unbreak WebSocket

### DIFF
--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -292,7 +292,7 @@ app.use((_req, res, next) => {
   res.header('X-Frame-Options', 'DENY')
   res.header('Referrer-Policy', 'strict-origin-when-cross-origin')
   res.header('Permissions-Policy', 'camera=(), microphone=(), geolocation=()')
-  res.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self'; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com")
+  res.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' wss: ws:; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com")
   if (process.env.NODE_ENV === 'production') {
     res.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
   }


### PR DESCRIPTION
## Summary
- The security hardening in #355 removed `wss:` and `ws:` from the CSP `connect-src` directive, breaking all WebSocket connections in the browser
- The WebSocket origin validation was also failing because `CORS_ORIGIN` was never set in the PM2 env (defaulted to `http://localhost:5173` while browsers sent `https://claude.trec.one`)
- Restores `connect-src 'self' wss: ws:` in the CSP header
- Also added `CORS_ORIGIN` and `NODE_ENV` to the local (gitignored) `ecosystem.config.cjs`

## Test plan
- [x] Server starts without crash loop (was 66 restarts in 3min, now 0)
- [x] `CORS_ORIGIN=https://claude.trec.one` and `NODE_ENV=production` confirmed in PM2 env
- [ ] Verify WebSocket connections work in browser at claude.trec.one

🤖 Generated with [Claude Code](https://claude.com/claude-code)