### PR TITLE
docs: update changelog and README to feature OpenCode support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Features
+- **Connection status popup** — Real-time provider health indicators with disable/enable toggles (#346)
+- **PR Review workflow** — Add PR Review as event-driven workflow kind in Workflows UI (#334)
+
+### Fixes
+- Restore `wss:`/`ws:` in CSP connect-src to unbreak WebSocket connections (#356)
+- Harden server security: auth token in headers only, rate limiting, CSP, WebSocket origin validation (#355)
+- Strip GIT_* env vars from OpenCode server to fix worktree git operations (#353)
+- Prevent stdio buffer deadlock in OpenCode server spawn (#352)
+- Harden session restart logic to reduce spurious restarts and context loss (#351)
+- Suppress spurious restart message during graceful shutdown (#350)
+- Prevent false session resets from aggressive zombie detection and leave grace period (#349)
+- Provider disabled overlay and input bar UX improvements (#348)
+- Disable input and show message when provider is disabled (#347)
+- Show disconnected message for OpenCode sessions (#345)
+- Use FilePartInput format for image attachments in OpenCode sessions (#343)
+- Strip user echo, handle reasoning deltas, and support text file attachments in OpenCode (#342)
+- Make model dropdown scrollable with max 10 visible items (#341)
+- Include provider field in serialized session info (#340)
+- Prevent duplicate OpenCode messages and support image attachments (#339)
+- Remove realpathSync fallback to prevent symlink path traversal (#337)
+
+### Refactoring
+- Migrate to open-source @multiplier-labs/stepflow (#333)
+
+## [0.6.0] - 2026-04-10
+
+### Features
+- **OpenCode multi-provider support** — Use any LLM provider (Claude, OpenAI, etc.) via [OpenCode](https://github.com/nicepkg/opencode) as an alternative backend, with full streaming, tool events, plan mode, and permission control (#322)
+- **Provider selector** — Choose between Claude Code and OpenCode per session, with dynamic model list fetching from configured providers
+- **Pull request webhook handler** — Automated PR code review via GitHub webhook integration (#321)
+- **Expanded agent permissions** — Curated tool allowlist for Agent Joe child sessions (#320)
+
+### Fixes
+- Wire provider through REST endpoints, workflows, and sidebar UI (#323)
+- Address Apr 10 security and code review findings (#327)
+- Resolve lint errors failing CI (#330)
+
+### Refactoring
+- Complexity quick wins — remove deprecated constructor, deduplicate methods, extract helpers (#331)
+
+### Tests
+- Add coverage for session-lifecycle, orchestrator-children, and prompt-router (#328)
+
 ## [0.5.5] - 2026-04-10
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **[codekin.ai](https://codekin.ai)**
 
-Web UI for Claude Code sessions — multi-session support, WebSocket streaming, file uploads, and slash-command skills.
+Web UI for [Claude Code](https://github.com/anthropics/claude-code) and [OpenCode](https://github.com/nicepkg/opencode) sessions — multi-provider AI coding with multi-session support, WebSocket streaming, file uploads, and slash-command skills.
 
 ![Codekin screenshot](docs/screenshot.png)
 
@@ -14,6 +14,7 @@ Web UI for Claude Code sessions — multi-session support, WebSocket streaming, 
 **Prerequisites:**
 - macOS or Linux
 - [Claude Code CLI](https://github.com/anthropics/claude-code) installed and authenticated (`claude` must be in your PATH)
+- *(Optional)* [OpenCode](https://github.com/nicepkg/opencode) installed for multi-provider LLM support
 
 **One-liner:**
 
@@ -46,21 +47,23 @@ codekin uninstall               # Remove Codekin entirely
 
 ## Features
 
-- **Multi-session terminal** — Open and switch between multiple Claude Code sessions, one per repo
+- **Multi-provider AI** — Use Claude Code or [OpenCode](https://github.com/nicepkg/opencode) as the backend per session. OpenCode enables any LLM provider (OpenAI, Gemini, etc.) through a single interface, with full streaming, tool events, plan mode, and permission control
+- **Multi-session terminal** — Open and switch between multiple coding sessions, one per repo
 - **Agent Joe** — AI orchestrator agent that spawns and manages up to 5 concurrent child sessions, with a dedicated chat UI, welcome screen, and color-coded sidebar status indicators
 - **Git worktrees** — Isolate sessions in dedicated worktree directories, with mid-session creation, auto-enable setting, and session context preservation
 - **Session archive** — Full retrieval and re-activation of archived sessions
 - **Repo browser** — Auto-discovers local repos and GitHub org repos
-- **Screenshot upload** — Drag-and-drop or paste images; the file path is sent to Claude so it can read them natively
+- **Screenshot upload** — Drag-and-drop or paste images; the file path is sent to the AI so it can read them natively
 - **Skill browser** — Browse and invoke `/skills` defined in each repo's `.claude/skills/`, with inline slash-command autocomplete
 - **Diff viewer** — Side panel showing staged/unstaged file changes with per-file discard support
 - **Command palette** — `Ctrl+K` to quickly search repos, skills, and actions
 - **Approval management** — Persistent approval storage with per-permission revoking, permission mode selector, per-session tool pre-approvals, and `--dangerously-skip-permissions` mode for sandboxed environments
+- **Connection status** — Real-time provider health indicators with disable/enable toggles for each backend
 - **Subscription & API key auth** — Works with both Claude subscription (OAuth) and API key authentication
 - **Mobile-friendly** — Responsive layout that works on phones and tablets
 - **Markdown browser** — Browse and view `.md` files directly in the UI
 - **AI Workflows** — Scheduled code and repository audits and maintenance, with support for custom workflows defined as Markdown files
-- **GitHub webhooks** — Automated bugfixing on CI failures via webhook integration
+- **GitHub webhooks** — Automated bugfixing on CI failures and PR code review via webhook integration
 - **Upgrade notifications** — In-app banner when a newer version is available
 
 ## Upgrade


### PR DESCRIPTION
## Summary
- Add **v0.6.0** changelog section featuring OpenCode multi-provider support as the headline feature, plus PR review webhooks, expanded agent permissions, and related fixes
- Add **Unreleased** section covering all post-0.6.0 work (connection status popup, PR review workflow, 16 OpenCode/security/stability fixes, stepflow migration)
- Update **README** tagline, prerequisites, and feature list to position OpenCode as a first-class provider alongside Claude Code

## Test plan
- [ ] Verify CHANGELOG.md renders correctly on GitHub
- [ ] Verify README.md renders correctly on GitHub
- [ ] Confirm all PR numbers reference real PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)