### PR TITLE
fix: prevent symlink-based path traversal in docs and reports endpoints

### DIFF
--- a/server/docs-routes.ts
+++ b/server/docs-routes.ts
@@ -114,7 +114,7 @@ export function createDocsRouter(
       return res.status(403).json({ error: 'Access denied' })
     }
 
-    const mdFiles = findMarkdownFiles(repoPath, 3)
+    const mdFiles = findMarkdownFiles(realRepo, 3)
     const pinnedSet = new Set(PINNED_FILES.map(f => f.toLowerCase()))
 
     const pinned: DocFile[] = []
@@ -168,10 +168,16 @@ export function createDocsRouter(
       return res.status(400).json({ error: 'Only .md files are supported' })
     }
 
-    // Path traversal guard
-    const resolved = resolve(repoPath, filePath)
-    const repoResolved = resolve(repoPath)
-    if (!resolved.startsWith(repoResolved + '/') && resolved !== repoResolved) {
+    // Path traversal guard — dereference symlinks to prevent escape
+    let resolved: string
+    let realRepo: string
+    try {
+      resolved = realpathSync(resolve(repoPath, filePath))
+      realRepo = realpathSync(resolve(repoPath))
+    } catch {
+      return res.status(404).json({ error: 'File not found' })
+    }
+    if (!resolved.startsWith(realRepo + '/') && resolved !== realRepo) {
       return res.status(404).json({ error: 'File not found' })
     }
 

--- a/server/orchestrator-reports.ts
+++ b/server/orchestrator-reports.ts
@@ -5,7 +5,7 @@
  * to the orchestrator session for triage and action.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from 'fs'
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from 'fs'
 import { join, basename, resolve } from 'path'
 import { REPOS_ROOT, DATA_DIR } from './config.js'
 
@@ -100,13 +100,18 @@ export function scanRepoReports(repoPath: string): ReportMeta[] {
  * Read a report's full content.
  */
 export function readReport(filePath: string): ReportContent | null {
-  const resolved = resolve(filePath)
+  // Dereference symlinks to prevent path traversal escape
+  let resolved: string
+  try {
+    resolved = realpathSync(resolve(filePath))
+  } catch {
+    return null
+  }
   // Verify the path is within a known reports directory (anchored startsWith, not includes)
   const isDataReport = resolved.startsWith(DATA_DIR + '/reports/')
   const isRepoReport = resolved.startsWith(REPOS_ROOT + '/') &&
     /^[^/]+\/\.codekin\/reports\//.test(resolved.slice(REPOS_ROOT.length + 1))
   if (!isDataReport && !isRepoReport) return null
-  if (!existsSync(resolved)) return null
 
   const content = readFileSync(resolved, 'utf-8')
   const stat = statSync(resolved)


### PR DESCRIPTION
## Summary

- **`server/docs-routes.ts` (`/api/docs/file`)**: Apply `realpathSync()` to the resolved file path *and* the repo root before the boundary check, so symlinks pointing outside the repo are caught. Wrapped in try/catch to return 404 for broken symlinks instead of crashing.
- **`server/docs-routes.ts` (`/api/docs` list)**: Use the already-dereferenced `realRepo` for `findMarkdownFiles()` instead of the raw `repoPath`, ensuring consistent symlink-resolved paths.
- **`server/orchestrator-reports.ts` (`readReport`)**: Apply `realpathSync()` to the resolved path before validating against `DATA_DIR/reports/` and `REPOS_ROOT` patterns. Returns `null` for broken symlinks instead of throwing.

## Why

Both endpoints used `resolve()` for path traversal guards but did not dereference symlinks. An attacker could create a symlink inside an allowed directory pointing to an arbitrary file outside it, bypassing the `startsWith` boundary check.

## Test plan

- [x] TypeScript compilation passes (`tsc --noEmit`)
- [ ] Manual: create a symlink inside a repo pointing to `/etc/passwd`, verify `/api/docs/file` returns 404
- [ ] Manual: create a broken symlink, verify 404 instead of server crash
- [ ] Manual: verify normal markdown file reads still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)