### PR TITLE
fix: address 4 server correctness bugs

### DIFF
--- a/server/native-permissions.ts
+++ b/server/native-permissions.ts
@@ -18,7 +18,7 @@ const writeLocks = new Map<string, Promise<void>>()
 /** Acquire a per-repo write lock. All sessions share one Node process. */
 function withLock(repoDir: string, fn: () => Promise<void>): Promise<void> {
   const prev = writeLocks.get(repoDir) ?? Promise.resolve()
-  const next = prev.then(fn, fn)
+  const next = prev.catch(() => {}).then(fn)
   writeLocks.set(repoDir, next)
   // Clean up the reference once done so we don't leak memory
   void next.then(() => {

--- a/server/prompt-router.ts
+++ b/server/prompt-router.ts
@@ -573,7 +573,8 @@ export class PromptRouter {
     }
 
     updatedInput.answers = answers
-    session.claudeProcess!.sendControlResponse(pending.requestId, 'allow', updatedInput)
+    if (!session.claudeProcess?.isAlive()) return
+    session.claudeProcess.sendControlResponse(pending.requestId, 'allow', updatedInput)
   }
 
   /** Send a permission control response (allow/always_allow/approve_pattern/deny). */
@@ -592,7 +593,8 @@ export class PromptRouter {
     }
 
     const behavior = isDeny ? 'deny' : 'allow'
-    session.claudeProcess!.sendControlResponse(pending.requestId, behavior)
+    if (!session.claudeProcess?.isAlive()) return
+    session.claudeProcess.sendControlResponse(pending.requestId, behavior)
   }
 
   /**

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -296,6 +296,7 @@ export class SessionManager {
       restartCount: 0,
       lastRestartAt: null,
       _stoppedByUser: false,
+      _isStarting: false,
       _wasActiveBeforeRestart: false,
       _apiRetry: { count: 0 },
       _turnCount: 0,
@@ -1103,10 +1104,14 @@ export class SessionManager {
     session._stoppedByUser = false
 
     if (!session.claudeProcess?.isAlive()) {
+      // Prevent two rapid sendInput calls from racing into two startClaude calls
+      if (session._isStarting) return
+      session._isStarting = true
       // Claude not running (e.g. after server restart or idle reap) — auto-start first.
       // Claude CLI in -p mode waits for first input before emitting init,
       // so we write directly to the stdin pipe buffer (no waiting for init).
       this.startClaude(sessionId)
+      session._isStarting = false
 
       // If we have a saved claudeSessionId, Claude CLI resumes with full
       // conversation history from its own session storage — no need for our

--- a/server/types.ts
+++ b/server/types.ts
@@ -68,6 +68,8 @@ export interface Session {
   lastRestartAt: number | null
   /** Set when the user explicitly stops Claude; prevents auto-restart. */
   _stoppedByUser: boolean
+  /** Guard to prevent concurrent startClaude calls from racing in sendInput. */
+  _isStarting: boolean
   /** Flag used during server restart to remember which sessions need auto-resume. */
   _wasActiveBeforeRestart: boolean
   /** In-flight control_request prompts awaiting user response, keyed by requestId. */

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -398,12 +398,13 @@ const WS_RATE_MAX_CONNECTIONS = 30
 const WS_RATE_MAP_MAX_SIZE = 10_000
 
 // Periodically purge expired rate-limit entries to prevent unbounded memory growth
-setInterval(() => {
+const wsRateCleanup = setInterval(() => {
   const now = Date.now()
   for (const [ip, entry] of wsConnections) {
     if (now >= entry.resetAt) wsConnections.delete(ip)
   }
 }, WS_RATE_WINDOW_MS)
+if (wsRateCleanup.unref) wsRateCleanup.unref()
 
 function checkWsRateLimit(ip: string): boolean {
   const now = Date.now()


### PR DESCRIPTION
## Summary

Fixes 4 bugs identified in server code review:

- **H-1: Mutex swallows errors** (`native-permissions.ts`) — `withLock` used `prev.then(fn, fn)` which called `fn` on both resolve and reject, silently eating errors. Changed to `prev.catch(() => {}).then(fn)` so errors propagate to callers while subsequent writes still run.
- **H-2: Non-null assertion crash** (`prompt-router.ts:576,595`) — `session.claudeProcess!` could be null if the process crashed between prompt and response. Added `if (!session.claudeProcess?.isAlive()) return` guards.
- **H-3: WS rate limiter interval missing `.unref()`** (`ws-server.ts:401-406`) — The WebSocket rate limiter cleanup `setInterval` did not call `.unref()`, unlike the API rate limiter on line 272. Added `.unref()` to match, preventing the timer from keeping the process alive.
- **H-4: Race condition in sendInput auto-start** (`session-manager.ts:1098-1166`) — Two rapid `sendInput` calls for an inactive session could trigger two `startClaude` calls. Added an `_isStarting` flag that prevents concurrent starts.

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] Verify mutex error propagation: trigger a write failure and confirm the error reaches the caller
- [ ] Verify prompt-router null guard: kill a Claude process mid-prompt and confirm no crash
- [ ] Verify WS rate limiter `.unref()`: confirm server shuts down cleanly without hanging
- [ ] Verify sendInput race: send two rapid inputs to a stopped session and confirm only one `startClaude` fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)