### PR TITLE
fix: add missing _isStarting property to restored sessions

### DIFF
--- a/server/session-persistence.ts
+++ b/server/session-persistence.ts
@@ -126,6 +126,7 @@ export class SessionPersistence {
           claudeSessionId: s.claudeSessionId ?? null,
           restartCount: 0,
           lastRestartAt: null,
+          _isStarting: false,
           _stoppedByUser: false,
           _wasActiveBeforeRestart: s.wasActive ?? false,
           _apiRetry: { count: 0 },


### PR DESCRIPTION
## Summary
- Fixes CI build failure from workflow run #892 on `main`
- Commit b3d42c4 added `_isStarting: boolean` to the `Session` type (H-4 race condition guard in `session-manager.ts`) but did not include the property in the session object constructed by `SessionPersistence.restore()` in `session-persistence.ts`
- This caused TypeScript error TS2741: `Property '_isStarting' is missing in type ... but required in type 'Session'`

## Fix
Added `_isStarting: false` to the restored session object, matching the default value used when creating new sessions in `session-manager.ts:299`.

## Test plan
- [ ] CI passes (build + lint + test) on this PR branch
- [ ] Verify restored sessions correctly initialize `_isStarting` to `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)