### PR TITLE
fix: add missing _isStarting property to restored sessions

### DIFF
--- a/server/session-persistence.ts
+++ b/server/session-persistence.ts
@@ -126,6 +126,7 @@ export class SessionPersistence {
           claudeSessionId: s.claudeSessionId ?? null,
           restartCount: 0,
           lastRestartAt: null,
+          _isStarting: false,
           _stoppedByUser: false,
           _wasActiveBeforeRestart: s.wasActive ?? false,
           _apiRetry: { count: 0 },


### PR DESCRIPTION
## Summary
- Adds the missing `_isStarting: false` property to the session object reconstructed in `SessionPersistence.restore()`, fixing a TS2741 build error that broke CI on workflow run #893.
- The `_isStarting` property was added to the `Session` type (in `session-manager.ts`) but was not included in the session reconstruction in `session-persistence.ts`.

## Test plan
- [ ] CI build (`tsc -b`) passes without TS2741 error
- [ ] Restored sessions behave correctly (not stuck in starting state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)