### PR TITLE
fix: validate model when switching between claude and opencode sessions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,7 +217,8 @@ export default function App() {
   useEffect(() => {
     if (activeSessionProvider !== 'opencode' || !settings.token) return
     const wdChanged = activeOpenCodeWd && activeOpenCodeWd !== openCodeModelsDirRef.current
-    if (!wdChanged && openCodeModels.length > 0) return
+    const currentIsValidOpenCode = currentModelRef.current && openCodeModels.some(m => m.id === currentModelRef.current)
+    if (!wdChanged && openCodeModels.length > 0 && currentIsValidOpenCode) return
     const activeWd = activeOpenCodeWd
     fetchOpenCodeModels(settings.token, activeWd).then(result => {
       const models: ModelOption[] = result.models.map(m => ({
@@ -240,6 +241,14 @@ export default function App() {
   useEffect(() => {
     setHasFileChanges(false) // eslint-disable-line react-hooks/set-state-in-effect -- sync with session change
   }, [activeSessionId])
+
+  // Validate currentModel when switching to a Claude session (OpenCode validation is in the other useEffect)
+  useEffect(() => {
+    if (activeSessionProvider !== 'claude') return
+    if (!CLAUDE_MODELS.some(m => m.id === currentModel)) {
+      setModel(CLAUDE_MODELS[0].id)
+    }
+  }, [activeSessionProvider, currentModel, setModel])
 
   // Session orchestration: switching, creating, deleting sessions & repos
   const {


### PR DESCRIPTION
## Summary
- Fix model dropdown showing wrong models when switching between Claude and OpenCode sessions
- Add validation to reset model to Claude default when switching to a Claude session
- Fix OpenCode model fetch to re-fetch when current model is not a valid OpenCode model

## Problem
When switching from an OpenCode session to a Claude session (or vice versa), the model dropdown would:
1. Show incorrect models (e.g., OpenCode models when in a Claude session)
2. Display a model that wasn't in the available list, causing it to show the raw model ID

## Root Cause
1. When switching TO Claude - no validation existed to reset the model if it was an OpenCode model
2. When switching TO OpenCode - could skip re-fetching if working directory hadn't changed, even if the current model wasn't a valid OpenCode model

## Changes
- `src/App.tsx`: Add useEffect to validate and reset model when switching to Claude session
- `src/App.tsx`: Fix OpenCode model fetch condition to check if current model is valid for OpenCode before skipping