### PR TITLE
docs: add comment quality audit report

### DIFF
--- a/.codekin/reports/comments/2026-04-11_comment-audit.md
+++ b/.codekin/reports/comments/2026-04-11_comment-audit.md
@@ -1,0 +1,285 @@
+# Comment Quality Audit Report
+
+**Date:** 2026-04-11
+**Repository:** codekin-wt-f4ea497f
+**Scope:** `src/`, `server/`, and configuration files
+
+---
+
+## 1. Overall Assessment: Good, with Notable Strengths and Gaps
+
+The codebase has a **generally good** commenting culture, significantly above average for a project of this size (~85 source files, ~10k+ lines). There is a clear and consistent style convention in place, and the best comments in the codebase are exemplary. However, there is uneven coverage: some modules are thoroughly documented while others are entirely uncommented.
+
+**Key statistics:**
+- ~2,821 single-line comment lines (`// `) across `src/` and `server/`
+- ~1,186 JSDoc block comment lines (`/**`) across `src/` and `server/`
+- 69 `eslint-disable` comments (all include explanatory suffixes)
+- 1 TODO/FIXME/HACK/NOTE comment found (a single `// NOTE` in `ccApi.test.ts`)
+- Nearly every component and hook file has a file-level JSDoc header
+
+---
+
+## 2. Specific Examples of Good Commenting
+
+### 2.1 File-Level Headers That Explain Architecture
+
+Nearly every file opens with a JSDoc block that describes not just what the file does, but its role in the system:
+
+```typescript
+// server/session-manager.ts (lines 1-20)
+/**
+ * Session lifecycle manager for Codekin.
+ *
+ * Manages creation, deletion, persistence, and auto-restart of Claude sessions.
+ * Each session wraps a ClaudeProcess, tracks connected WebSocket clients,
+ * maintains an output history buffer for replay, and handles tool permission
+ * approval workflows (both control_request and PreToolUse hook paths).
+ * ...
+ * Delegates to focused modules:
+ * - ApprovalManager: repo-level auto-approval rules
+ * - SessionNaming: AI-powered session name generation
+ * ...
+ */
+```
+
+This is excellent: it describes responsibilities, delegation boundaries, and the module's place in the architecture.
+
+### 2.2 Inline Comments That Explain "Why"
+
+The best comments explain rationale, not just mechanics:
+
+```typescript
+// src/App.tsx (lines 393-399)
+// React to browser back/forward navigation.
+// This effect syncs app state when the user clicks the browser back/forward buttons.
+// It tracks `urlSessionId` (from popstate) and intentionally OMITS `activeSessionId`,
+// `clearMessages`, `leaveSession`, `joinSession`, and `setActiveSessionIdRaw` from the
+// dependency array. Including `activeSessionId` would cause an infinite loop: this effect
+// sets it, which would re-trigger the effect. The other callbacks are stable refs that
+// don't change, but listing them would obscure the intentional `activeSessionId` omission.
+```
+
+This is a model example: it explains what the code does, what it deliberately does NOT do, and why omitting those dependencies is correct.
+
+```typescript
+// server/claude-process.ts (lines 166-174)
+// Pass through the full parent environment so the Claude CLI inherits
+// XDG paths, TERM, SHELL, and any other vars it needs.
+// Exclude ANTHROPIC_API_KEY / CLAUDE_CODE_API_KEY from inheritance --
+// stale or incorrect keys override the CLI's subscription/OAuth auth
+// and cause "Invalid API key" errors. Let the CLI use its own auth.
+// Also strip GIT_* vars (except GIT_EDITOR) that the server may have
+// inherited from the shell that launched it. In particular,
+// GIT_INDEX_FILE=.git/index breaks worktrees where .git is a file,
+// not a directory, causing all index-dependent git commands to fail.
+```
+
+Explains the bug scenarios that motivated the code -- exactly the kind of comment that saves hours of debugging.
+
+```typescript
+// server/session-manager.ts (lines 743-746)
+// If no clients remain, wait a grace period before auto-denying prompts.
+// This prevents false denials when the user is just refreshing the page.
+// The grace period must be long enough for the client to complete its
+// reconnect flow: zombie retry pings (up to 6s) + auth check + WS handshake.
+```
+
+### 2.3 JSDoc on Interface Properties
+
+`src/types.ts` and `server/types.ts` are thoroughly documented. Nearly every property on `Session`, `WsClientMessage`, `WsServerMessage`, and other interfaces has an inline JSDoc comment:
+
+```typescript
+/** Monotonically increasing counter bumped on every startClaude() call.
+ *  Restart timers capture the generation at scheduling time and bail if it
+ *  has changed by the time they fire -- prevents stale timers from replacing
+ *  a healthy process that was started by a different code path. */
+_processGeneration: number
+```
+
+### 2.4 Section Dividers in Large Files
+
+Large files use consistent visual section dividers:
+
+```typescript
+// ---------------------------------------------------------------------------
+// WorkflowsView
+// ---------------------------------------------------------------------------
+```
+
+This pattern appears consistently in `RepoSection.tsx`, `WorkflowsView.tsx`, `AddWorkflowModal.tsx`, and `session-manager.ts`.
+
+### 2.5 Eslint-Disable Comments Always Have Rationale
+
+All 69 `eslint-disable` comments include an explanatory `-- reason` suffix:
+
+```typescript
+// eslint-disable-line react-hooks/set-state-in-effect -- sync with session change
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments -- new Map() infers Map<any,any>
+```
+
+This is a disciplined practice that prevents silent accumulation of unexplained suppressions.
+
+### 2.6 Protocol Documentation in Types
+
+`src/types.ts` includes canonical message sequences and paired-message documentation:
+
+```typescript
+/**
+ * Messages sent from the browser client to the WebSocket server.
+ *
+ * Typical message flow:
+ *   auth -> create_session | join_session -> start_claude -> input* -> stop
+ *
+ * - `auth` must be sent first; the server drops the connection on failure.
+ * - `create_session` and `join_session` are mutually exclusive session entry points.
+ */
+```
+
+---
+
+## 3. Specific Examples of Missing or Poor Comments
+
+### 3.1 Under-Commented Hook: `useSessions.ts`
+
+The hook has a good file-level header but zero inline comments on its 76 lines of code:
+
+```typescript
+// /srv/repos/codekin-wt-f4ea497f/src/hooks/useSessions.ts
+// File header: good (7 lines)
+// Inline comments: 1 (just "// Poll every 10s")
+```
+
+The `create`, `rename`, and `remove` functions are self-explanatory, but the polling interval choice (10s) and the guard pattern (`if (!token) return`) would benefit from brief rationale.
+
+### 3.2 Completely Un-Commented Small Hooks
+
+Several hooks have only a file-level JSDoc and nothing else:
+
+- **`usePageVisibility.ts`** (22 lines): Has a one-line JSDoc but no comments on the `callbackRef` pattern or why `useEffect` has no dependency array.
+- **`useRouter.ts`** (56 lines): Has a file header but no comments on the `/joe` route or the `replace` parameter semantics.
+- **`useRepos.ts`** (61 lines): File header only, no inline comments.
+- **`useSettings.ts`** (63 lines): File header only, no inline comments.
+- **`useIsMobile.ts`** (23 lines): Well-documented for its size -- actually a good example.
+
+### 3.3 `chatFormatters.ts` -- Minimal Comments
+
+```typescript
+// /srv/repos/codekin-wt-f4ea497f/src/lib/chatFormatters.ts
+// 26 lines, 2 JSDoc blocks, 0 inline comments
+```
+
+The `formatModelName` function has a regex that parses Claude model IDs but no comment explaining the expected format or what happens with edge cases. The `formatUserText` function has an excellent JSDoc but the regex itself could use a brief inline note.
+
+### 3.4 `workflowApi.ts` -- Type Definitions Without Comments
+
+Lines 20-74 define 7+ interfaces (`WorkflowRun`, `WorkflowStep`, `WorkflowRunWithSteps`, `CronSchedule`, `ReviewRepoConfig`, `WorkflowConfig`, `WorkflowKindInfo`) with zero property-level documentation. A reader cannot tell the difference between `kind` and `name` without reading the server code.
+
+### 3.5 Diff Components -- Sparse Comments
+
+The diff sub-components (`DiffFileCard.tsx`, `DiffFileTree.tsx`, `DiffToolbar.tsx`, `DiffHunkView.tsx`) have file-level headers but minimal inline comments. `DiffHunkView.tsx` has a type-conversion function (`toRdvHunks`) with no explanation of why the mapping is needed or what the `as const` casts are for.
+
+### 3.6 `InputBar.tsx` -- Massive Component, Light Inline Commentary
+
+At 681 lines, `InputBar.tsx` is the largest component. While it has an excellent file header and well-documented props, the internal logic for the four layout variants (desktop-default, desktop-orchestrator, mobile-default, mobile-orchestrator) has no section comments or explanation of the variant matrix. The drag-to-resize logic (lines 284-301) is uncommented.
+
+### 3.7 `ChatView.tsx` -- Complex Rendering Logic, Partial Comments
+
+The 617-line `ChatView.tsx` has good component-level JSDoc, and the scroll logic is well-commented. But the message-grouping loop (lines 513-592) that handles tool runs, assistant message collapsing, and timestamp insertion has only sparse inline comments. The IIFE pattern `(() => { ... })()` is not explained.
+
+---
+
+## 4. Patterns of Inconsistency
+
+### 4.1 Server vs. Frontend: Server Is More Thoroughly Commented
+
+Server files average significantly more inline comments per line of code. `session-manager.ts` (1,586 lines) has 150 inline comments and 88 JSDoc blocks. By contrast, `useSessions.ts` (76 lines) has 1 inline comment and 1 JSDoc block. The ratio is roughly 1 comment per 10 lines on the server vs. 1 per 30+ lines in some frontend hooks.
+
+### 4.2 Components vs. Hooks: Components Are Better Documented
+
+Every component in `src/components/` has a file-level JSDoc header. Most hooks do too, but the quality drops off more quickly inside hook implementations. Complex hooks like `useChatSocket.ts` are well-commented, but simpler hooks like `usePageVisibility.ts` and `useRepos.ts` have only headers.
+
+### 4.3 Test Files Are Barely Commented
+
+Test files collectively have very few comments beyond the test structure itself. This is partially acceptable (test names should be self-documenting), but some complex mock setups and edge-case assertions would benefit from rationale comments.
+
+### 4.4 No TODO/FIXME/HACK Markers
+
+The near-total absence of TODO/FIXME/HACK comments (only 1 `// NOTE` found) is unusual. This could mean:
+- The codebase is unusually clean and debt-free (unlikely for a 10k+ line project)
+- Technical debt exists but is not tracked in-code
+- The team uses an external issue tracker exclusively
+
+If the latter, this is fine. If the former, it suggests a gap in technical debt tracking.
+
+### 4.5 Inconsistent Section Dividers
+
+Some files use `// --- Section Name ---` (e.g., `types.ts`), others use `// -----------\n// Section\n// -----------` (e.g., `session-manager.ts`), and many use no section dividers at all. This is a minor style inconsistency.
+
+---
+
+## 5. Recommendations
+
+### 5.1 High Priority
+
+1. **Add property-level JSDoc to `workflowApi.ts` interfaces.** The 7 interfaces (lines 20-74) define the workflow REST API contract and are consumed by both frontend and server. Each property should have a one-line description.
+
+2. **Add inline comments to the `ChatView.tsx` message-grouping loop** (lines 513-592). This is the most complex rendering logic in the frontend. The IIFE, the tool-run grouping, and the assistant-message collapsing each deserve a 1-2 line explanation.
+
+3. **Add section dividers and variant comments to `InputBar.tsx`.** The four layout variants (desktop/mobile x default/orchestrator) should be clearly labeled with comments. The drag-to-resize logic (lines 284-301) needs a brief explanation.
+
+### 5.2 Medium Priority
+
+4. **Document the `ccApi.ts` API client functions.** While `ccApi.ts` has 41 JSDoc blocks (good), some exported functions like `listSessions`, `createSession`, etc. could benefit from noting their HTTP method, endpoint, and error behavior.
+
+5. **Add comments to `useRouter.ts` explaining the `/joe` route.** This is a hardcoded special case that will confuse any new contributor.
+
+6. **Add rationale comments to `useSessions.ts` polling logic.** Why 10 seconds? What happens on error? Is there backoff?
+
+7. **Consider adding a CONTRIBUTING.md section on commenting standards.** The codebase already has good implicit conventions (JSDoc on exports, `// ` for inline, `-- reason` on eslint-disable). Making these explicit would help maintain consistency.
+
+### 5.3 Low Priority
+
+8. **Add JSDoc to test helper functions and complex mock setups.** Not all tests need comments, but the ones that set up elaborate mocks (e.g., `useChatSocket.hook.test.ts` at 964 lines) would benefit from setup explanations.
+
+9. **Standardize section divider style.** Pick one pattern (recommend the `// --- Section ---` style from `types.ts`) and apply it consistently.
+
+10. **Track technical debt in-code.** If the team does not currently use TODO/FIXME comments, consider adopting them for known issues that are deferred intentionally. This makes debt visible during code review.
+
+---
+
+## 6. Files That Most Need Better Comments
+
+Ranked by priority (combination of file complexity and comment sparsity):
+
+| Priority | File | Lines | Comments | Issue |
+|----------|------|-------|----------|-------|
+| 1 | `src/components/InputBar.tsx` | 681 | ~12 inline | Massive component, 4 layout variants undocumented internally |
+| 2 | `src/components/ChatView.tsx` | 617 | ~8 inline | Complex message-grouping loop needs explanation |
+| 3 | `src/lib/workflowApi.ts` | 230 | ~15 inline | 7 interfaces with zero property documentation |
+| 4 | `src/hooks/useRouter.ts` | 56 | ~1 inline | `/joe` route unexplained, `replace` param undocumented |
+| 5 | `src/hooks/useSessions.ts` | 76 | ~1 inline | Polling rationale missing, error handling unexplained |
+| 6 | `src/hooks/usePageVisibility.ts` | 22 | 0 inline | `callbackRef` pattern and empty deps unexplained |
+| 7 | `src/hooks/useRepos.ts` | 61 | ~1 inline | No inline comments at all |
+| 8 | `src/hooks/useSettings.ts` | 63 | ~3 inline | Minimal internal documentation |
+| 9 | `src/components/diff/DiffHunkView.tsx` | 69 | ~1 inline | Type conversion logic unexplained |
+| 10 | `src/lib/chatFormatters.ts` | 26 | 0 inline | Regex patterns undocumented |
+| 11 | `src/components/TimePicker.tsx` | ~40 | ~3 inline | Component logic unexplained |
+| 12 | `server/ws-message-handler.ts` | ~289 | ~31 inline | Good header but complex message routing needs section comments |
+
+---
+
+## 7. Summary
+
+This codebase demonstrates a **mature commenting culture** with several standout practices:
+- Excellent file-level JSDoc headers on nearly every module
+- Strong "why" comments on complex logic (especially in `session-manager.ts`, `claude-process.ts`, and `App.tsx`)
+- Disciplined eslint-disable rationale comments
+- Well-documented type definitions in `types.ts` and `server/types.ts`
+
+The main gaps are:
+- Internal logic in large components (`InputBar.tsx`, `ChatView.tsx`) lacks inline commentary
+- Some smaller hooks are under-commented relative to their complexity
+- Interface properties in `workflowApi.ts` are completely undocumented
+- No visible technical debt tracking via TODO/FIXME markers
+
+The codebase would benefit most from targeted improvements to the 3-4 highest-priority files listed above, rather than a blanket commenting pass.


### PR DESCRIPTION
## Summary
- Add comprehensive comment quality audit report to `.codekin/reports/comments/`
- Assesses ~85 source files across `src/` and `server/` directories
- Identifies strengths (file-level headers, "why" comments, JSDoc on interfaces) and gaps (InputBar.tsx, ChatView.tsx, workflowApi.ts)
- Provides prioritized recommendations for improving commenting consistency