### PR TITLE
fix: address 5 small issues from audit reports

### DIFF
--- a/server/approval-manager.ts
+++ b/server/approval-manager.ts
@@ -38,6 +38,9 @@ export class ApprovalManager {
   private _approvalPersistTimer: ReturnType<typeof setTimeout> | null = null
 
   constructor() {
+    // Note: "git push" intentionally appears in both PATTERNABLE (via JSDoc/design)
+    // and NEVER_PATTERN_PREFIXES. It is prefix-matched at runtime but blocked from
+    // wildcard persistence. The overlap warning below is expected for such entries.
     this.validatePrefixSets()
     this.restoreRepoApprovalsFromDisk()
   }
@@ -76,8 +79,13 @@ export class ApprovalManager {
    *
    * IMPORTANT: Inclusion here does NOT auto-approve anything — the user
    * still explicitly approves the pattern. It only means "we can group
-   * `git push origin feat/x` and `git push origin feat/y` into one
-   * `git push *` pattern" instead of storing each as an exact match.
+   * `git commit -m foo` and `git commit -m bar` into one `git commit *`
+   * pattern" instead of storing each as an exact match.
+   *
+   * NOTE: Some prefixes (e.g. "git push") intentionally appear in
+   * NEVER_PATTERN_PREFIXES as well. At runtime, the two-token deny check
+   * runs first, so they are matched by prefix but never persisted as a
+   * wildcard pattern. See NEVER_PATTERN_PREFIXES for details.
    */
   private static readonly PATTERNABLE_PREFIXES = new Set([
     // Git operations — safe to group by subcommand
@@ -122,7 +130,7 @@ export class ApprovalManager {
     'ssh', 'docker', 'docker-compose',
     'rm', 'sudo', 'curl', 'wget',
     'git reset', 'git clean',
-    'git push',  // cross-remote escalation risk — always stored as exact match only
+    'git push',  // Prefix-matched at runtime (two-token match) but never persisted as a wildcard pattern — cross-remote escalation risk
     'gh api',  // can perform DELETE/PUT — too broad to pattern
     // Code executors — "node *" / "python *" would match arbitrary code execution
     'node', 'npx', 'python', 'python3', 'deno', 'bun', 'pm2',

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -832,7 +832,7 @@ export class SessionManager {
     const totalOutputLength = session.outputHistory
       .filter((m): m is { type: 'output'; data: string } => m.type === 'output')
       .reduce((sum, m) => sum + m.data.length, 0)
-    if (totalOutputLength < 150) return
+    if (totalOutputLength < 150) return // Too short to be meaningful session output
 
     // If session was never named (still has hub: prefix), derive a name from the
     // first user message or fall back to a short ID-based placeholder.
@@ -1063,6 +1063,7 @@ export class SessionManager {
     // Suppress noise from orchestrator/agent sessions
     if ((session.source === 'orchestrator' || session.source === 'agent') && !isError) {
       const turnText = this.extractCurrentTurnText(session)
+      // Short canned responses like "no response requested" — skip archiving
       if (turnText && turnText.length < 80 && /^(no response requested|please approve|nothing to do|no action needed|acknowledged)[.!]?$/i.test(turnText.trim())) {
         this.stripCurrentTurnOutput(session)
         console.log(`[noise-filter] suppressed orchestrator noise: "${turnText.trim().slice(0, 60)}"`)
@@ -1104,7 +1105,8 @@ export class SessionManager {
     session._stoppedByUser = false
 
     if (!session.claudeProcess?.isAlive()) {
-      // Prevent two rapid sendInput calls from racing into two startClaude calls
+      // Race guard: prevent concurrent startClaude calls when multiple sendInput
+      // requests arrive for an inactive session
       if (session._isStarting) return
       session._isStarting = true
       // Claude not running (e.g. after server restart or idle reap) — auto-start first.
@@ -1368,7 +1370,7 @@ export class SessionManager {
 
     // Cap total context size
     let context = lines.join('\n')
-    if (context.length > 4000) {
+    if (context.length > 4000) { // Truncate to keep context injection reasonable
       // Keep the most recent exchanges
       while (context.length > 4000 && lines.length > 2) {
         lines.shift()

--- a/server/types.ts
+++ b/server/types.ts
@@ -16,7 +16,6 @@ import type { PlanManager } from './plan-manager.js'
  */
 export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions' | 'dangerouslySkipPermissions'
 
-/** Allow-list for server-side validation of client-supplied permission modes. */
 /** Allow-list for server-side validation of client-supplied provider names. */
 export const VALID_PROVIDERS = new Set<CodingProvider>(['claude', 'opencode'])
 

--- a/server/upload-routes.ts
+++ b/server/upload-routes.ts
@@ -284,6 +284,14 @@ export function createUploadRouter(
       res.status(400).json({ error: 'Invalid owner or repo name' })
       return
     }
+    if (owner.includes('..') || name.includes('..')) {
+      res.status(400).json({ error: 'Invalid owner or repo name' })
+      return
+    }
+    if (owner.length > 100 || name.length > 100) {
+      res.status(400).json({ error: 'Owner or repo name too long' })
+      return
+    }
 
     const reposRoot = realpathSync(resolveReposRoot())
     const dest = join(reposRoot, name)


### PR DESCRIPTION
## Summary

Bundle of small fixes identified in recent audit reports:

- **Clone endpoint hardening** (`server/upload-routes.ts`): Added explicit rejection of `..` path traversal sequences and 100-character length limit on owner/repo name parameters, complementing the existing regex validation
- **git push dual-membership clarification** (`server/approval-manager.ts`): Replaced contradictory inline comments — `git push` intentionally appears in both prefix sets (matched at runtime but never persisted as a wildcard pattern). Added clarifying comments at both set definitions and the `validatePrefixSets()` call site
- **Orphaned JSDoc removal** (`server/types.ts`): Deleted stray JSDoc comment that was not attached to any declaration
- **Magic number comments** (`server/session-manager.ts`): Added inline comments explaining the 80-char noise filter threshold, 150-char archive minimum, and 4000-char context summary cap
- **_isStarting race guard comment** (`server/session-manager.ts`): Improved comment on the `_isStarting` guard in `sendInput()` to clearly describe the race condition it prevents

## Test plan

- [x] TypeScript compilation passes (`tsc --noEmit`)
- [ ] Verify clone endpoint rejects `..` in owner/name and names > 100 chars
- [ ] Verify approval manager prefix matching behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)