### PR TITLE
fix: set NODE_ENV=test in vitest config to fix act-is-not-a-function failures

### DIFF
--- a/.codekin/reports/code-review/2026-04-11_code-review-daily.md
+++ b/.codekin/reports/code-review/2026-04-11_code-review-daily.md
@@ -1,0 +1,37 @@
+# Daily Code Review: codekin
+
+**Date**: 2026-04-11T04:04:32.637Z
+**Repository**: /srv/repos/codekin
+**Branch**: chore/complexity-report-2026-04-10
+**Workflow Run**: f77f3161-7dcb-4956-8883-0b1e201f73fa
+**Session**: b8248808-58a8-453f-8095-12ebc7641d81
+
+---
+
+Now I'll write the report and commit it.Report written to `.codekin/reports/code-review/2026-04-11_code-review.md` and PR opened: **Multiplier-Labs/codekin#338**
+
+---
+
+## Review Summary
+
+### Critical (1)
+
+**Path traversal via symlink fallback** — `server/session-routes.ts` lines ~74–77 and ~285–287. When `realpathSync()` throws, the code falls back to `path.resolve()` which doesn't resolve symlinks. A symlink inside an allowed directory pointing outside (e.g. `/repos/allowed/escape -> /etc`) passes the `startsWith` boundary check. Fix: return `403` on `realpathSync` failure, don't fall through.
+
+### Warnings (3)
+
+1. **Test coverage gap** — `commit-event-handler.ts`, `commit-event-hooks.ts`, `orchestrator-monitor.ts`, `version-check.ts` have no tests. These are high-consequence code paths (commit hooks, version enforcement).
+
+2. **Multer upload config unverified** — `server/upload-routes.ts` — need to confirm file size limits and MIME type allowlist are set.
+
+3. **Large files ongoing** — `session-manager.ts` (~1570 lines), `webhook-handler.ts` (~800 lines). Refactoring is in progress but `webhook-handler.ts` should be next priority.
+
+### Info (3)
+
+- `CROSS_REPO_THRESHOLD = 5` — recently raised from 2; consider raising to 10 or making env-configurable
+- Stepflow migration (`f7eed7f`) looks clean, no issues found
+- PR Review workflow addition (`97ec940`) follows existing patterns correctly
+
+### All Clear
+
+Token auth (timing-safe), HMAC webhook verification, DOMPurify XSS protection, write locks, session scoped tokens, npm audit (0 vulns) — all verified secure.Committed and pushed `.codekin/reports/repo-health/2026-04-11_repo-health.md` to the `chore/code-review-2026-04-11` branch (alongside the code review report).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,5 +6,6 @@ export default defineConfig({
   test: {
     environment: 'node',
     include: ['src/**/*.test.ts', 'server/**/*.test.ts', '.claude/hooks/**/*.test.mjs'],
+    env: { NODE_ENV: 'test' },
   },
 })


### PR DESCRIPTION
## Summary
- The system environment has `NODE_ENV=production`, which causes React 19 to load its production build — a build that does not export `act`
- All 8 frontend hook test files (`useSessions`, `useSettings`, `usePageVisibility`, etc.) were failing with `act is not a function` (154 failures total)
- Fix: add `env: { NODE_ENV: 'test' }` to `vitest.config.ts` so tests always run against the development React build regardless of the host environment
- Also includes the orphaned `.codekin/reports/code-review/2026-04-11_code-review-daily.md` report file

## Test plan
- [x] `npm test` → 57 test files, 1576 tests, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)