### PR TITLE
fix: tighten retry regex and dedupe model dropdown

### DIFF
--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -63,10 +63,10 @@ const API_RETRY_PATTERNS = [
   /internal server error/i,
   /overloaded/i,
   /rate.?limit/i,
-  /529/,
-  /500/,
-  /502/,
-  /503/,
+  /\b529\b/,
+  /\b500\b/,
+  /\b502\b/,
+  /\b503\b/,
 ]
 
 /** Sources that represent headless (non-interactive) sessions managed by their own lifecycles. */

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -169,8 +169,12 @@ function ModelDropdown({ currentModel, models, isOpen, menuRef, onToggle, onChan
       )
     : models
 
+  const recentSet = new Set(recents)
+  const allModelsFiltered = (!query && recents.length > 0)
+    ? filtered.filter(m => !recentSet.has(m.id))
+    : filtered
   const visibleList = (!query && recents.length > 0
-    ? [...recents.map(id => models.find(m => m.id === id)).filter(Boolean) as ModelOption[], ...filtered]
+    ? [...recents.map(id => models.find(m => m.id === id)).filter(Boolean) as ModelOption[], ...allModelsFiltered]
     : filtered)
 
   useEffect(() => {
@@ -242,7 +246,7 @@ function ModelDropdown({ currentModel, models, isOpen, menuRef, onToggle, onChan
               {!query && (
                 <div className="px-3 py-1 text-[11px] text-neutral-5">All Models</div>
               )}
-              {filtered.map((m, idx) => {
+              {allModelsFiltered.map((m, idx) => {
                 const baseIndex = (!query && recents.length > 0) ? recents.length : 0
                 const index = baseIndex + idx
                 return (


### PR DESCRIPTION
## Summary
- **API retry regex**: Added `\b` word boundary anchors to HTTP status code patterns (`500`, `502`, `503`, `529`) in `API_RETRY_PATTERNS` to prevent false matches on unrelated strings like "port 5000" or "1500 lines"
- **Model dropdown**: Filtered recent models out of the "All Models" section so they don't appear twice, eliminating duplicate entries and dead keyboard navigation positions

## Test plan
- [ ] Verify retry logic only triggers on actual HTTP status codes, not substrings
- [ ] Open model dropdown with recent models — confirm no duplicates between "Recent" and "All Models" sections
- [ ] Keyboard navigate through the dropdown — confirm no dead/duplicate positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)