### PR TITLE
feat: provider selection + searchable model picker in workflows

### DIFF
--- a/src/components/AddWorkflowModal.tsx
+++ b/src/components/AddWorkflowModal.tsx
@@ -13,13 +13,15 @@ import { useRepos } from '../hooks/useRepos'
 import { listKinds } from '../lib/workflowApi'
 import type { ReviewRepoConfig, WorkflowKindInfo } from '../lib/workflowApi'
 import {
-  WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL, MODEL_OPTIONS,
+  WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL,
   buildCron, describeCron, slugify, kindCategory,
   isBiweeklyDow, isEventDriven, EVENT_CRON,
 } from '../lib/workflowHelpers'
+import type { CodingProvider } from '../types'
 import { CategoryBadge } from './WorkflowBadges'
 import TimePicker from './TimePicker'
 import { RepoList } from './RepoList'
+import { ProviderModelSection } from './workflows/ProviderModelSection'
 
 type Step = 1 | 2 | 3
 
@@ -32,6 +34,7 @@ interface FormState {
   cronDow: string
   customPrompt: string
   model: string
+  provider: CodingProvider
 }
 
 interface Props {
@@ -252,9 +255,11 @@ function FrequencyButton({
 }
 
 function StepConfigure({
+  token,
   form,
   onChange,
 }: {
+  token: string
   form: FormState
   onChange: (patch: Partial<FormState>) => void
 }) {
@@ -363,26 +368,14 @@ function StepConfigure({
         </>
       )}
 
-      {/* Model selection */}
-      <div>
-        <label className="block text-[13px] font-medium text-neutral-3 mb-2">Model</label>
-        <div className="flex gap-1.5">
-          {MODEL_OPTIONS.map(m => (
-            <button
-              key={m.value}
-              type="button"
-              onClick={() => { onChange({ model: m.value }); }}
-              className={`rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors ${
-                form.model === m.value
-                  ? 'border-accent-6 bg-accent-9/40 text-accent-2'
-                  : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
-              }`}
-            >
-              {m.label}
-            </button>
-          ))}
-        </div>
-      </div>
+      {/* Provider + Model selection */}
+      <ProviderModelSection
+        token={token}
+        provider={form.provider}
+        model={form.model}
+        onProviderChange={provider => { onChange({ provider }); }}
+        onModelChange={model => { onChange({ model }); }}
+      />
 
       <div>
         <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">
@@ -417,6 +410,7 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
     cronDow: '*',
     customPrompt: '',
     model: '',
+    provider: 'claude' as CodingProvider,
   })
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
@@ -465,6 +459,7 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
         enabled: true,
         customPrompt: form.customPrompt.trim() || undefined,
         model: form.model || undefined,
+        provider: form.provider !== 'claude' ? form.provider : undefined,
       })
       onClose()
     } catch (err) {
@@ -515,6 +510,7 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
 
           {step === 3 && (
             <StepConfigure
+              token={token}
               form={form}
               onChange={updateForm}
             />

--- a/src/components/AddWorkflowModal.tsx
+++ b/src/components/AddWorkflowModal.tsx
@@ -371,6 +371,7 @@ function StepConfigure({
       {/* Provider + Model selection */}
       <ProviderModelSection
         token={token}
+        workingDir={form.repoPath || undefined}
         provider={form.provider}
         model={form.model}
         onProviderChange={provider => { onChange({ provider }); }}

--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -190,6 +190,7 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
           {/* Provider + Model selection */}
           <ProviderModelSection
             token={token}
+            workingDir={repo.repoPath}
             provider={form.provider}
             model={form.model}
             onProviderChange={provider => setForm(f => ({ ...f, provider }))}

--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -7,11 +7,13 @@ import { useState } from 'react'
 import { IconX, IconLoader2 } from '@tabler/icons-react'
 import type { ReviewRepoConfig } from '../lib/workflowApi'
 import {
-  WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL, MODEL_OPTIONS, isBiweeklyDow,
+  WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL, isBiweeklyDow,
   buildCron, parseCron, describeCron, kindLabel, isEventDriven, EVENT_CRON,
 } from '../lib/workflowHelpers'
+import type { CodingProvider } from '../types'
 import { CategoryBadge } from './WorkflowBadges'
 import TimePicker from './TimePicker'
+import { ProviderModelSection } from './workflows/ProviderModelSection'
 
 const btnClass = (selected: boolean) =>
   `rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors ${
@@ -21,6 +23,7 @@ const btnClass = (selected: boolean) =>
   }`
 
 interface Props {
+  token: string
   repo: ReviewRepoConfig
   schedules?: unknown[]
   recentRuns?: unknown[]
@@ -28,7 +31,7 @@ interface Props {
   onSave: (id: string, patch: Partial<ReviewRepoConfig>) => Promise<void>
 }
 
-export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
+export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
   const parsed = parseCron(repo.cronExpression)
   const [form, setForm] = useState({
     kind: repo.kind ?? 'coverage.daily',
@@ -37,6 +40,7 @@ export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
     cronDow: parsed.dow,
     customPrompt: repo.customPrompt ?? '',
     model: repo.model ?? '',
+    provider: (repo.provider ?? 'claude') as CodingProvider,
   })
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
@@ -56,6 +60,7 @@ export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
         cronExpression,
         customPrompt: form.customPrompt.trim() || undefined,
         model: form.model || undefined,
+        provider: form.provider !== 'claude' ? form.provider : undefined,
       })
       onClose()
     } catch (err) {
@@ -182,22 +187,14 @@ export function EditWorkflowModal({ repo, onClose, onSave }: Props) {
             </div>
           )}
 
-          {/* Model selection */}
-          <div>
-            <label className="block text-[13px] font-medium text-neutral-3 mb-2">Model</label>
-            <div className="flex gap-1.5">
-              {MODEL_OPTIONS.map(m => (
-                <button
-                  key={m.value}
-                  type="button"
-                  onClick={() => setForm(f => ({ ...f, model: m.value }))}
-                  className={btnClass(form.model === m.value)}
-                >
-                  {m.label}
-                </button>
-              ))}
-            </div>
-          </div>
+          {/* Provider + Model selection */}
+          <ProviderModelSection
+            token={token}
+            provider={form.provider}
+            model={form.model}
+            onProviderChange={provider => setForm(f => ({ ...f, provider }))}
+            onModelChange={model => setForm(f => ({ ...f, model }))}
+          />
 
           {/* Custom prompt */}
           <div>

--- a/src/components/WorkflowsView.tsx
+++ b/src/components/WorkflowsView.tsx
@@ -231,6 +231,7 @@ export function WorkflowsView({ token, onNavigateToSession }: Props) {
       {/* Edit Workflow Modal */}
       {editingRepo && (
         <EditWorkflowModal
+          token={token}
           repo={editingRepo}
           schedules={schedules.filter(s => s.id === editingRepo.id)}
           recentRuns={runs.filter(r =>

--- a/src/components/workflows/ProviderModelSection.tsx
+++ b/src/components/workflows/ProviderModelSection.tsx
@@ -1,0 +1,106 @@
+/**
+ * Combined provider selector + model picker for workflow modals.
+ *
+ * Fetches OpenCode models on mount to determine availability.
+ * Shows provider toggle only when OpenCode is available.
+ * Delegates model rendering to WorkflowModelPicker.
+ */
+
+import { useState, useEffect } from 'react'
+import { fetchOpenCodeModels } from '../../lib/ccApi'
+import { MODEL_OPTIONS } from '../../lib/workflowHelpers'
+import type { ModelOption, CodingProvider } from '../../types'
+import { WorkflowModelPicker } from './WorkflowModelPicker'
+
+const providerBtnClass = (selected: boolean) =>
+  `rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors ${
+    selected
+      ? 'border-accent-6 bg-accent-9/40 text-accent-2'
+      : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
+  }`
+
+/** Claude model options for the workflow picker (includes "Default" option). */
+const CLAUDE_WORKFLOW_MODELS: ModelOption[] = MODEL_OPTIONS.map(m => ({
+  id: m.value,
+  label: m.label,
+}))
+
+interface Props {
+  token: string
+  provider: CodingProvider
+  model: string
+  onProviderChange: (provider: CodingProvider) => void
+  onModelChange: (model: string) => void
+}
+
+export function ProviderModelSection({ token, provider, model, onProviderChange, onModelChange }: Props) {
+  const [openCodeAvailable, setOpenCodeAvailable] = useState<boolean | null>(null)
+  const [openCodeModels, setOpenCodeModels] = useState<ModelOption[]>([])
+  const [loadingOcModels, setLoadingOcModels] = useState(false)
+
+  // Check OpenCode availability on mount
+  useEffect(() => {
+    let cancelled = false
+    fetchOpenCodeModels(token).then(result => {
+      if (cancelled) return
+      if (result.models.length > 0) {
+        setOpenCodeAvailable(true)
+        setOpenCodeModels(result.models.map(m => ({ id: m.id, label: m.name || m.id })))
+      } else {
+        setOpenCodeAvailable(false)
+      }
+    }).catch(() => {
+      if (!cancelled) setOpenCodeAvailable(false)
+    })
+    return () => { cancelled = true }
+  }, [token])
+
+  // When switching provider, reset model to default if current model doesn't belong to new provider
+  const handleProviderChange = (newProvider: CodingProvider) => {
+    if (newProvider === provider) return
+    onProviderChange(newProvider)
+    // Reset model — the current model likely doesn't exist in the other provider
+    onModelChange('')
+  }
+
+  const currentModels: ModelOption[] = provider === 'opencode' ? openCodeModels : CLAUDE_WORKFLOW_MODELS
+  const isLoadingModels = provider === 'opencode' && loadingOcModels
+
+  return (
+    <>
+      {/* Provider selector — only show when OpenCode is available */}
+      {openCodeAvailable && (
+        <div>
+          <label className="block text-[13px] font-medium text-neutral-3 mb-2">Provider</label>
+          <div className="flex gap-1.5">
+            <button
+              type="button"
+              onClick={() => handleProviderChange('claude')}
+              className={providerBtnClass(provider === 'claude')}
+            >
+              Claude Code
+            </button>
+            <button
+              type="button"
+              onClick={() => handleProviderChange('opencode')}
+              className={providerBtnClass(provider === 'opencode')}
+            >
+              OpenCode
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Model picker */}
+      <div>
+        <label className="block text-[13px] font-medium text-neutral-3 mb-2">Model</label>
+        <WorkflowModelPicker
+          models={currentModels}
+          selected={model}
+          onSelect={onModelChange}
+          loading={isLoadingModels}
+        />
+      </div>
+    </>
+  )
+}

--- a/src/components/workflows/ProviderModelSection.tsx
+++ b/src/components/workflows/ProviderModelSection.tsx
@@ -41,6 +41,7 @@ export function ProviderModelSection({ token, provider, model, onProviderChange,
   // Check OpenCode availability on mount
   useEffect(() => {
     let cancelled = false
+    setLoadingOcModels(true)
     fetchOpenCodeModels(token).then(result => {
       if (cancelled) return
       if (result.models.length > 0) {
@@ -51,6 +52,8 @@ export function ProviderModelSection({ token, provider, model, onProviderChange,
       }
     }).catch(() => {
       if (!cancelled) setOpenCodeAvailable(false)
+    }).finally(() => {
+      if (!cancelled) setLoadingOcModels(false)
     })
     return () => { cancelled = true }
   }, [token])

--- a/src/components/workflows/ProviderModelSection.tsx
+++ b/src/components/workflows/ProviderModelSection.tsx
@@ -36,12 +36,11 @@ interface Props {
 export function ProviderModelSection({ token, provider, model, onProviderChange, onModelChange }: Props) {
   const [openCodeAvailable, setOpenCodeAvailable] = useState<boolean | null>(null)
   const [openCodeModels, setOpenCodeModels] = useState<ModelOption[]>([])
-  const [loadingOcModels, setLoadingOcModels] = useState(false)
+  const [loadingOcModels, setLoadingOcModels] = useState(true)
 
   // Check OpenCode availability on mount
   useEffect(() => {
     let cancelled = false
-    setLoadingOcModels(true)
     fetchOpenCodeModels(token).then(result => {
       if (cancelled) return
       if (result.models.length > 0) {

--- a/src/components/workflows/ProviderModelSection.tsx
+++ b/src/components/workflows/ProviderModelSection.tsx
@@ -27,13 +27,15 @@ const CLAUDE_WORKFLOW_MODELS: ModelOption[] = MODEL_OPTIONS.map(m => ({
 
 interface Props {
   token: string
+  /** Working directory (repo path) for scoping OpenCode model queries. */
+  workingDir?: string
   provider: CodingProvider
   model: string
   onProviderChange: (provider: CodingProvider) => void
   onModelChange: (model: string) => void
 }
 
-export function ProviderModelSection({ token, provider, model, onProviderChange, onModelChange }: Props) {
+export function ProviderModelSection({ token, workingDir, provider, model, onProviderChange, onModelChange }: Props) {
   const [openCodeAvailable, setOpenCodeAvailable] = useState<boolean | null>(null)
   const [openCodeModels, setOpenCodeModels] = useState<ModelOption[]>([])
   const [loadingOcModels, setLoadingOcModels] = useState(true)
@@ -41,7 +43,7 @@ export function ProviderModelSection({ token, provider, model, onProviderChange,
   // Check OpenCode availability on mount
   useEffect(() => {
     let cancelled = false
-    fetchOpenCodeModels(token).then(result => {
+    fetchOpenCodeModels(token, workingDir).then(result => {
       if (cancelled) return
       if (result.models.length > 0) {
         setOpenCodeAvailable(true)
@@ -55,7 +57,7 @@ export function ProviderModelSection({ token, provider, model, onProviderChange,
       if (!cancelled) setLoadingOcModels(false)
     })
     return () => { cancelled = true }
-  }, [token])
+  }, [token, workingDir])
 
   // When switching provider, reset model to default if current model doesn't belong to new provider
   const handleProviderChange = (newProvider: CodingProvider) => {

--- a/src/components/workflows/WorkflowModelPicker.tsx
+++ b/src/components/workflows/WorkflowModelPicker.tsx
@@ -93,8 +93,13 @@ function SearchablePicker({ models, selected, onSelect }: {
       )
     : models
 
+  // Exclude recents from the "All Models" section to avoid duplicates
+  const allWithoutRecents = (!query && recents.length > 0)
+    ? filtered.filter(m => !recents.includes(m.id))
+    : filtered
+
   const visibleList = (!query && recents.length > 0)
-    ? [...recents.map(id => models.find(m => m.id === id)).filter(Boolean) as ModelOption[], ...filtered]
+    ? [...recents.map(id => models.find(m => m.id === id)).filter(Boolean) as ModelOption[], ...allWithoutRecents]
     : filtered
 
   // Scroll active item into view
@@ -192,10 +197,10 @@ function SearchablePicker({ models, selected, onSelect }: {
               {!query && (
                 <div className="px-3 py-1 text-[11px] text-neutral-5 uppercase tracking-wide">All Models</div>
               )}
-              {filtered.length === 0 && (
+              {allWithoutRecents.length === 0 && (
                 <div className="px-3 py-2 text-[13px] text-neutral-5">No models match your search</div>
               )}
-              {filtered.map((m, idx) => {
+              {allWithoutRecents.map((m, idx) => {
                 const baseIndex = (!query && recents.length > 0) ? recents.length : 0
                 const index = baseIndex + idx
                 return (

--- a/src/components/workflows/WorkflowModelPicker.tsx
+++ b/src/components/workflows/WorkflowModelPicker.tsx
@@ -1,0 +1,249 @@
+/**
+ * Model picker for workflow modals.
+ *
+ * - ≤5 models: simple button row (same style as the existing picker)
+ * - >5 models: searchable dropdown with recent selections on top
+ *
+ * Mirrors the search + recents UX from the chat InputBar ModelDropdown.
+ */
+
+import { useState, useRef, useEffect } from 'react'
+import { IconSearch, IconChevronDown } from '@tabler/icons-react'
+import type { ModelOption } from '../../types'
+
+const RECENTS_KEY = 'codekin.workflowRecentModels'
+const MAX_RECENTS = 5
+
+function getRecents(): string[] {
+  try { return JSON.parse(localStorage.getItem(RECENTS_KEY) || '[]') } catch { return [] }
+}
+
+function addRecent(id: string) {
+  if (!id) return
+  const next = getRecents().filter(m => m !== id)
+  next.unshift(id)
+  localStorage.setItem(RECENTS_KEY, JSON.stringify(next.slice(0, MAX_RECENTS)))
+}
+
+const btnClass = (selected: boolean) =>
+  `rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors ${
+    selected
+      ? 'border-accent-6 bg-accent-9/40 text-accent-2'
+      : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
+  }`
+
+// ---------------------------------------------------------------------------
+// Inline button row (≤5 models)
+// ---------------------------------------------------------------------------
+
+function InlinePicker({ models, selected, onSelect }: {
+  models: ModelOption[]; selected: string; onSelect: (id: string) => void
+}) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {models.map(m => (
+        <button
+          key={m.id}
+          type="button"
+          onClick={() => onSelect(m.id)}
+          className={btnClass(selected === m.id)}
+        >
+          {m.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Searchable dropdown (>5 models)
+// ---------------------------------------------------------------------------
+
+function SearchablePicker({ models, selected, onSelect }: {
+  models: ModelOption[]; selected: string; onSelect: (id: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([])
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  // Focus search on open
+  useEffect(() => {
+    if (open) inputRef.current?.focus()
+  }, [open])
+
+  const recents = getRecents().filter(id => models.some(m => m.id === id))
+
+  const filtered = query
+    ? models.filter(m =>
+        m.id.toLowerCase().includes(query.toLowerCase()) ||
+        m.label.toLowerCase().includes(query.toLowerCase())
+      )
+    : models
+
+  const visibleList = (!query && recents.length > 0)
+    ? [...recents.map(id => models.find(m => m.id === id)).filter(Boolean) as ModelOption[], ...filtered]
+    : filtered
+
+  // Scroll active item into view
+  useEffect(() => {
+    const el = itemRefs.current[activeIndex]
+    if (el) el.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+
+  const handleSelect = (id: string) => {
+    addRecent(id)
+    onSelect(id)
+    setOpen(false)
+    setQuery('')
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!visibleList.length) return
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setActiveIndex(i => Math.min(i + 1, visibleList.length - 1))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setActiveIndex(i => Math.max(i - 1, 0))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      const m = visibleList[activeIndex]
+      if (m) handleSelect(m.id)
+    } else if (e.key === 'Escape') {
+      setOpen(false)
+    }
+  }
+
+  const selectedLabel = models.find(m => m.id === selected)?.label ?? selected ?? 'Default'
+
+  return (
+    <div className="relative" ref={containerRef}>
+      {/* Trigger button */}
+      <button
+        type="button"
+        onClick={() => { setOpen(o => !o); setActiveIndex(0) }}
+        className={`flex items-center gap-2 rounded-md border px-3 py-1.5 text-[13px] font-medium transition-colors ${
+          selected
+            ? 'border-accent-6 bg-accent-9/40 text-accent-2'
+            : 'border-neutral-7 bg-neutral-10 text-neutral-3 hover:border-neutral-6 hover:text-neutral-2'
+        }`}
+      >
+        {selectedLabel}
+        <IconChevronDown size={14} stroke={2} className={`transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {/* Dropdown */}
+      {open && (
+        <div className="absolute top-full mt-1 left-0 z-50 w-[280px] max-h-[320px] rounded-lg border border-neutral-6 bg-neutral-8 shadow-lg flex flex-col">
+          {/* Search */}
+          <div className="p-2 border-b border-neutral-7">
+            <div className="relative">
+              <IconSearch size={14} stroke={2} className="absolute left-2 top-1/2 -translate-y-1/2 text-neutral-5" />
+              <input
+                ref={inputRef}
+                value={query}
+                onChange={e => { setQuery(e.target.value); setActiveIndex(0) }}
+                onKeyDown={handleKeyDown}
+                placeholder="Search models..."
+                className="w-full bg-neutral-7 text-[13px] pl-7 pr-2 py-1.5 rounded-md outline-none text-neutral-2 placeholder:text-neutral-5"
+              />
+            </div>
+          </div>
+
+          {/* List */}
+          <div className="overflow-y-auto py-1">
+            {!query && recents.length > 0 && (
+              <div className="mb-1">
+                <div className="px-3 py-1 text-[11px] text-neutral-5 uppercase tracking-wide">Recent</div>
+                {recents.map((id, idx) => {
+                  const m = models.find(x => x.id === id)
+                  if (!m) return null
+                  return (
+                    <button
+                      key={`recent-${m.id}`}
+                      ref={el => { itemRefs.current[idx] = el }}
+                      type="button"
+                      onClick={() => handleSelect(m.id)}
+                      className={`w-full text-left px-3 py-1.5 text-[13px] transition-colors ${
+                        idx === activeIndex ? 'bg-neutral-7' : 'hover:bg-neutral-7'
+                      } ${m.id === selected ? 'text-accent-3' : 'text-neutral-2'}`}
+                    >
+                      {m.label}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+
+            <div>
+              {!query && (
+                <div className="px-3 py-1 text-[11px] text-neutral-5 uppercase tracking-wide">All Models</div>
+              )}
+              {filtered.length === 0 && (
+                <div className="px-3 py-2 text-[13px] text-neutral-5">No models match your search</div>
+              )}
+              {filtered.map((m, idx) => {
+                const baseIndex = (!query && recents.length > 0) ? recents.length : 0
+                const index = baseIndex + idx
+                return (
+                  <button
+                    key={m.id}
+                    ref={el => { itemRefs.current[index] = el }}
+                    type="button"
+                    onClick={() => handleSelect(m.id)}
+                    className={`w-full text-left px-3 py-1.5 text-[13px] transition-colors ${
+                      index === activeIndex ? 'bg-neutral-7' : 'hover:bg-neutral-7'
+                    } ${m.id === selected ? 'text-accent-3' : 'text-neutral-2'}`}
+                  >
+                    {m.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+interface WorkflowModelPickerProps {
+  models: ModelOption[]
+  selected: string
+  onSelect: (modelId: string) => void
+  loading?: boolean
+}
+
+/** Model picker that switches between inline buttons (≤5) and searchable dropdown (>5). */
+export function WorkflowModelPicker({ models, selected, onSelect, loading }: WorkflowModelPickerProps) {
+  if (loading) {
+    return <div className="text-[13px] text-neutral-5">Loading models...</div>
+  }
+
+  if (models.length === 0) {
+    return <div className="text-[13px] text-neutral-5">No models available</div>
+  }
+
+  if (models.length <= 5) {
+    return <InlinePicker models={models} selected={selected} onSelect={onSelect} />
+  }
+
+  return <SearchablePicker models={models} selected={selected} onSelect={onSelect} />
+}

--- a/src/lib/workflowApi.ts
+++ b/src/lib/workflowApi.ts
@@ -67,6 +67,8 @@ export interface ReviewRepoConfig {
   kind?: string
   customPrompt?: string
   model?: string
+  /** AI provider to use for this workflow ('claude' or 'opencode'). Defaults to 'claude'. */
+  provider?: 'claude' | 'opencode'
 }
 
 export interface WorkflowConfig {

--- a/src/lib/workflowHelpers.ts
+++ b/src/lib/workflowHelpers.ts
@@ -139,6 +139,7 @@ export function describeCron(expr: string): string {
 /** Look up the display label for a model value, e.g. `"claude-sonnet-4-6"` → `"Sonnet 4.6"`. Returns `null` for empty/default. */
 export function modelLabel(model: string | undefined): string | null {
   if (!model) return null
+  // Check known Claude model options first, then fall back to the raw model ID
   return MODEL_OPTIONS.find(m => m.value === model)?.label ?? model
 }
 


### PR DESCRIPTION
## Summary
- Add Claude Code / OpenCode provider toggle to workflow Add and Edit modals (only shown when OpenCode is available)
- Replace hardcoded 3-button model picker with adaptive `WorkflowModelPicker`: inline buttons for ≤5 models, searchable dropdown with recent selections for >5 models
- Add `provider` field to frontend `ReviewRepoConfig` type to match server schema

## Test plan
- [ ] Open Add Workflow modal → verify model picker shows 3 Claude buttons (inline mode) when OpenCode is unavailable
- [ ] With OpenCode running, verify provider toggle appears and switching to OpenCode loads models dynamically
- [ ] With >5 OpenCode models, verify searchable dropdown appears with search field and recent selections
- [ ] Edit an existing workflow → verify provider and model are pre-populated correctly
- [ ] Save workflow with OpenCode provider → verify `provider` field persists in config

🤖 Generated with [Claude Code](https://claude.com/claude-code)