### PR TITLE
fix: probe OpenCode availability on startup

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -207,6 +207,14 @@ export default function App() {
   const activeSessionProvider = sessions.find(s => s.id === activeSessionId)?.provider ?? currentProvider
   const availableModels = activeSessionProvider === 'opencode' ? openCodeModels : CLAUDE_MODELS
 
+  // Probe OpenCode availability on startup (regardless of active session provider)
+  useEffect(() => {
+    if (!settings.token || openCodeDisabled) return
+    fetchOpenCodeModels(settings.token).then(result => {
+      setOpenCodeConnected(result.models.length > 0)
+    }).catch(() => { setOpenCodeConnected(false) })
+  }, [settings.token, openCodeDisabled]) // eslint-disable-line react-hooks/exhaustive-deps -- one-time startup probe
+
   // Fetch OpenCode models when switching to an OpenCode session
   const currentModelRef = useRef(currentModel)
   useEffect(() => { currentModelRef.current = currentModel }, [currentModel])


### PR DESCRIPTION
## Summary
- The connection popup showed "Not configured" for OpenCode even when it was actually available and working
- Root cause: `openCodeConnected` was only set when switching to an active OpenCode session — no startup probe existed
- Added a one-time `useEffect` that calls `fetchOpenCodeModels` on mount to check availability regardless of active session provider
- This also fixes the workflow modal's `ProviderModelSection` which depends on the same endpoint — it was hiding the provider toggle because the probe was failing silently

## Test plan
- [ ] Open Codekin with OpenCode configured — connection popup should show "Connected" (green dot) instead of "Not configured"
- [ ] Open New Workflow modal — provider toggle (Claude Code / OpenCode) should appear
- [ ] With OpenCode not configured — connection popup should show "Not configured" as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)