### PR TITLE
fix: persist OpenCode provider when saving workflow config

### DIFF
--- a/server/workflow-routes.ts
+++ b/server/workflow-routes.ts
@@ -324,6 +324,7 @@ export function createWorkflowRouter(
       kind,
       customPrompt,
       model,
+      provider,
     })
 
     // Re-sync schedules and commit hooks with updated config

--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -33,6 +33,10 @@ interface Props {
 
 export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
   const parsed = parseCron(repo.cronExpression)
+  // Infer provider from model when provider field is missing (legacy configs)
+  const inferredProvider: CodingProvider =
+    repo.provider ?? (repo.model && !repo.model.startsWith('claude-') ? 'opencode' : 'claude')
+
   const [form, setForm] = useState({
     kind: repo.kind ?? 'coverage.daily',
     cronHour: parsed.hour,
@@ -40,7 +44,7 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
     cronDow: parsed.dow,
     customPrompt: repo.customPrompt ?? '',
     model: repo.model ?? '',
-    provider: (repo.provider ?? 'claude') as CodingProvider,
+    provider: inferredProvider,
   })
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)


### PR DESCRIPTION
## Summary

- The POST `/config/repos` endpoint destructured `provider` from the request body but never passed it to `addReviewRepo()`, silently dropping it — so workflows saved with OpenCode provider lost that setting
- Adds provider inference in `EditWorkflowModal` for legacy configs: if the model doesn't start with `claude-`, infer provider as `opencode`

## Test plan

- [ ] Create a new workflow with OpenCode provider — verify provider is persisted in `workflow-config.json`
- [ ] Edit an existing workflow that has an OpenCode model but no provider field — verify it opens with OpenCode selected
- [ ] Edit a Claude workflow — verify it still defaults to Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)