### PR TITLE
fix: preserve user input for session naming

### DIFF
--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -1125,6 +1125,7 @@ export class SessionManager {
           const combined = context + '\n\n' + data
           session._lastUserInput = combined
           session._lastUserInputAt = Date.now()
+          if (!session._namingUserInput) session._namingUserInput = data
           session._apiRetry.count = 0
           if (!session.isProcessing) {
             session.isProcessing = true
@@ -1144,6 +1145,7 @@ export class SessionManager {
       if (session.claudeProcess && !session.claudeProcess.isReady()) {
         session._lastUserInput = data
         session._lastUserInputAt = Date.now()
+        if (!session._namingUserInput) session._namingUserInput = data
         session._apiRetry.count = 0
         if (!session.isProcessing) {
           session.isProcessing = true
@@ -1164,6 +1166,7 @@ export class SessionManager {
 
     session._lastUserInput = data
     session._lastUserInputAt = Date.now()
+    if (!session._namingUserInput) session._namingUserInput = data
     session._apiRetry.count = 0
     if (!session.isProcessing) {
       session.isProcessing = true

--- a/server/session-naming.test.ts
+++ b/server/session-naming.test.ts
@@ -50,6 +50,7 @@ function fakeSession(overrides: Record<string, any> = {}): any {
     _namingTimer: undefined,
     _namingAttempts: 0,
     _lastUserInput: 'fix the login bug',
+    _namingUserInput: 'fix the login bug',
     outputHistory: [{ type: 'output', data: 'I will help fix the login bug.' }],
     ...overrides,
   }
@@ -67,7 +68,7 @@ describe('SessionNaming', () => {
   // 1. No context yet — retry scheduled
   it('re-schedules when no user input and no output history', async () => {
     vi.useFakeTimers()
-    const session = fakeSession({ _lastUserInput: '', outputHistory: [] })
+    const session = fakeSession({ _lastUserInput: '', _namingUserInput: '', outputHistory: [] })
     const deps = makeDeps({ getSession: vi.fn(() => session) })
     const naming = new SessionNaming(deps)
 
@@ -261,6 +262,27 @@ describe('SessionNaming', () => {
     vi.advanceTimersByTime(1)
     expect(vi.getTimerCount()).toBe(0)
     vi.useRealTimers()
+  })
+
+  // 12b. executeSessionNaming — uses _namingUserInput when _lastUserInput is cleared
+  it('uses _namingUserInput when _lastUserInput has been cleared', async () => {
+    // Simulates the bug scenario: finalizeResult clears _lastUserInput before naming runs
+    const session = fakeSession({
+      _lastUserInput: undefined,
+      _namingUserInput: 'add dark mode support',
+      outputHistory: [{ type: 'output', data: 'I will add dark mode.' }],
+    })
+    const deps = makeDeps({ getSession: vi.fn(() => session) })
+    const naming = new SessionNaming(deps)
+    mockSpawn.mockReturnValue(fakeProc('Add Dark Mode Support', 0))
+
+    await naming.executeSessionNaming('s1')
+
+    expect(deps.rename).toHaveBeenCalledWith('s1', 'Add Dark Mode Support')
+    // Verify the prompt included the user's message from _namingUserInput
+    const stdinWrite = mockSpawn.mock.results[0].value.stdin.write
+    const promptText = stdinWrite.mock.calls[0][0]
+    expect(promptText).toContain('add dark mode support')
   })
 
   // 13. executeSessionNaming — skips if session disappears mid-flight

--- a/server/session-naming.ts
+++ b/server/session-naming.ts
@@ -111,7 +111,7 @@ export class SessionNaming {
       .join('')
       .slice(0, 2000)
 
-    const userMsg = session._lastUserInput || ''
+    const userMsg = session._namingUserInput || session._lastUserInput || ''
     if (!userMsg && !latestContext) {
       // No context yet — schedule a retry
       this.scheduleSessionNaming(sessionId)

--- a/server/types.ts
+++ b/server/types.ts
@@ -91,6 +91,8 @@ export interface Session {
   _lastReportedModel?: string
   /** Last user input sent, stored for API error retry. */
   _lastUserInput?: string
+  /** First user input, preserved for session naming (not cleared by API retry). */
+  _namingUserInput?: string
   /** Timestamp of last user input, used to detect stale retries. */
   _lastUserInputAt?: number
   /** Transient API error retry state for the current turn. */


### PR DESCRIPTION
## Summary
- `finalizeResult()` cleared `_lastUserInput` before `executeSessionNaming()` ran, so the naming prompt always had an empty user message — causing all sessions to get generic/identical names based solely on assistant output
- Added a dedicated `_namingUserInput` field that captures the first user message and is **not** cleared by API retry cleanup
- The naming function now reads `_namingUserInput || _lastUserInput` so it always has the user's original request for context

## Test plan
- [x] New test: verifies naming uses `_namingUserInput` when `_lastUserInput` has been cleared (the exact bug scenario)
- [x] All 243 existing tests pass (session-naming + session-manager)
- [ ] Manual: create sessions with different prompts and verify they get distinct names

🤖 Generated with [Claude Code](https://claude.com/claude-code)