### PR TITLE
fix: prevent session restart loops from process lifecycle races

### DIFF
--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -213,11 +213,16 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
     ]
     // Kill any orphaned Claude process still holding this session ID's lock.
     // This can happen when the server restarts and old children survive (SIGKILL'd
-    // or reparented to init). Without this, --resume fails with "already in use".
-    // Uses the full binary path + exact session UUID to avoid matching unrelated processes.
+    // or reparented to init), or when startClaude() replaces a running process
+    // without waiting for the old one to exit.  Without this, --resume fails
+    // with "already in use".
+    // Match both --resume and --session-id because the orphan may have been
+    // started with either flag depending on whether it was a first start or
+    // a resume.  Uses the full binary path + exact session UUID to avoid
+    // matching unrelated processes.
     if (this.resume) {
       try {
-        const pattern = `${CLAUDE_BINARY} .*--resume ${this.sessionId}\\b`
+        const pattern = `${CLAUDE_BINARY} .*(--resume|--session-id) ${this.sessionId}(\\s|$)`
         execFileSync('pkill', ['-f', pattern], { timeout: 2000, stdio: 'ignore' })
       } catch {
         // pkill exits 1 when no matching process is found — that's the happy path

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -1112,8 +1112,11 @@ export class SessionManager {
       // Claude not running (e.g. after server restart or idle reap) — auto-start first.
       // Claude CLI in -p mode waits for first input before emitting init,
       // so we write directly to the stdin pipe buffer (no waiting for init).
-      this.startClaude(sessionId)
-      session._isStarting = false
+      try {
+        this.startClaude(sessionId)
+      } finally {
+        session._isStarting = false
+      }
 
       // If we have a saved claudeSessionId, Claude CLI resumes with full
       // conversation history from its own session storage — no need for our
@@ -1203,15 +1206,19 @@ export class SessionManager {
     if (session.provider === provider) return true
     session.provider = provider
     session.claudeSessionId = null
+    // Clear any pending restart timer from a prior crash to prevent a stale
+    // timer from spawning a second process after we restart below.
+    if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }
     this.persistToDiskDebounced()
     if (session.claudeProcess?.isAlive()) {
-      this.stopClaude(sessionId)
-      session._stoppedByUser = false
-      setTimeout(() => {
-        if (this.sessions.has(sessionId) && !session._stoppedByUser) {
+      // Use stopClaudeAndWait to ensure the old process fully exits before
+      // spawning a new one — avoids concurrent processes in the same worktree.
+      void this.stopClaudeAndWait(sessionId).then(() => {
+        if (this.sessions.has(sessionId)) {
+          session._stoppedByUser = false
           this.startClaude(sessionId)
         }
-      }, 500)
+      })
     }
     return true
   }
@@ -1221,6 +1228,9 @@ export class SessionManager {
     const session = this.sessions.get(sessionId)
     if (!session) return false
     session.model = model || undefined
+    // Clear any pending restart timer from a prior crash to prevent a stale
+    // timer from spawning a second process after we restart below.
+    if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }
     this.persistToDiskDebounced()
     // Restart Claude with the new model if it's running.
     // Use stopClaudeAndWait to ensure the old process fully exits before
@@ -1242,6 +1252,9 @@ export class SessionManager {
     if (!session) return false
     const previousMode = session.permissionMode
     session.permissionMode = permissionMode
+    // Clear any pending restart timer from a prior crash to prevent a stale
+    // timer from spawning a second process after we restart below.
+    if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }
     this.persistToDiskDebounced()
 
     // Audit log for dangerous mode changes


### PR DESCRIPTION
## Summary
- Broadened `pkill` orphan cleanup pattern to match both `--resume` and `--session-id` flags — orphaned processes started with `--session-id` were surviving and causing "already in use" conflicts on restart
- Switched `setProvider` from fire-and-forget `stopClaude` + 500ms delay to `stopClaudeAndWait`, preventing concurrent processes in the same worktree
- Added `_restartTimer` cleanup in `setModel`/`setProvider`/`setPermissionMode` — stale crash-recovery timers could fire after a config change and spawn duplicate processes
- Wrapped `_isStarting` flag in `try/finally` in `sendInput` to prevent permanent session lockout if `startClaude` throws

## Test plan
- [x] All 1590 existing tests pass
- [x] TypeScript compiles cleanly
- [ ] Deploy and verify sessions no longer enter SIGTERM restart loops
- [ ] Test model/provider/permission changes mid-session
- [ ] Test session recovery after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)