### PR TITLE
fix: prevent message loss when process exits before init

### DIFF
--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -186,23 +186,26 @@ export class SessionLifecycle {
    * session already has a claudeSessionId (process previously initialized).
    * Times out after `timeoutMs` (default 30s) to avoid hanging indefinitely.
    */
-  waitForReady(sessionId: string, timeoutMs = 30_000): Promise<void> {
+  waitForReady(sessionId: string, timeoutMs = 30_000): Promise<boolean> {
     const session = this.deps.getSession(sessionId)
-    if (!session?.claudeProcess) return Promise.resolve()
+    if (!session?.claudeProcess) return Promise.resolve(false)
     // If the process is already fully initialized, resolve immediately.
     // Uses isReady() which accounts for provider differences: Claude is ready
     // as soon as alive (stdin buffered), OpenCode needs alive + opencodeSessionId.
-    if (session.claudeProcess.isReady()) return Promise.resolve()
+    if (session.claudeProcess.isReady()) return Promise.resolve(true)
 
-    return new Promise<void>((resolve) => {
-      const done = () => { clearTimeout(timer); resolve() }
+    return new Promise<boolean>((resolve) => {
+      const onReady = () => { clearTimeout(timer); cp.removeListener('exit', onExit); resolve(true) }
+      const onExit = () => { clearTimeout(timer); cp.removeListener('system_init', onReady); resolve(false) }
+      const cp = session.claudeProcess!
       const timer = setTimeout(() => {
         console.warn(`[waitForReady] Timed out waiting for system_init on ${sessionId} after ${timeoutMs}ms`)
-        session.claudeProcess?.removeListener('exit', done)
-        resolve()
+        cp.removeListener('system_init', onReady)
+        cp.removeListener('exit', onExit)
+        resolve(false)
       }, timeoutMs)
-      session.claudeProcess!.once('system_init', done)
-      session.claudeProcess!.once('exit', done) // fail-fast if process dies during init
+      cp.once('system_init', onReady)
+      cp.once('exit', onExit) // fail-fast if process dies during init
     })
   }
 
@@ -407,13 +410,26 @@ export class SessionLifecycle {
         // Fallback: if claudeSessionId was already null (fresh session that
         // crashed before system_init), inject a context summary so the new
         // session has some awareness of prior conversation.
-        if (!session.claudeSessionId && session.claudeProcess && session.outputHistory.length > 0) {
+        if (!session.claudeSessionId && session.claudeProcess) {
+          const pendingInput = session._lastUserInput
+          const inputAge = session._lastUserInputAt ? Date.now() - session._lastUserInputAt : Infinity
+          const hasPendingInput = pendingInput && inputAge < 60_000
+
           session.claudeProcess.once('system_init', () => {
-            const context = this.deps.buildSessionContext(session)
-            if (context) {
-              session.claudeProcess?.sendMessage(
-                context + '\n\n[Session resumed after process restart. Continue where you left off. If you were in the middle of a task, resume it.]',
-              )
+            if (session.outputHistory.length > 0) {
+              const context = this.deps.buildSessionContext(session)
+              if (context) {
+                const msg = hasPendingInput
+                  ? context + '\n\n' + pendingInput
+                  : context + '\n\n[Session resumed after process restart. Continue where you left off. If you were in the middle of a task, resume it.]'
+                session.claudeProcess?.sendMessage(msg)
+                return
+              }
+            }
+            // No output history but pending input (brand new session that
+            // crashed before responding) — re-send the user's message.
+            if (hasPendingInput) {
+              session.claudeProcess?.sendMessage(pendingInput)
             }
           })
         }

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -872,7 +872,7 @@ export class SessionManager {
    * Wait for a session's Claude process to emit its system_init event.
    * Delegates to SessionLifecycle.
    */
-  waitForReady(sessionId: string, timeoutMs = 30_000): Promise<void> {
+  waitForReady(sessionId: string, timeoutMs = 30_000): Promise<boolean> {
     return this.sessionLifecycle.waitForReady(sessionId, timeoutMs)
   }
 
@@ -1135,7 +1135,11 @@ export class SessionManager {
             this._globalBroadcast?.({ type: 'sessions_updated' })
           }
           if (session.claudeProcess && !session.claudeProcess.isReady()) {
-            void this.waitForReady(sessionId).then(() => session.claudeProcess?.sendMessage(combined))
+            void this.waitForReady(sessionId).then((ready) => {
+              if (ready) session.claudeProcess?.sendMessage(combined)
+              // If not ready (process exited), message stays in _lastUserInput
+              // and will be re-sent on auto-restart
+            })
           } else {
             session.claudeProcess?.sendMessage(combined)
           }
@@ -1154,7 +1158,11 @@ export class SessionManager {
           session.isProcessing = true
           this._globalBroadcast?.({ type: 'sessions_updated' })
         }
-        void this.waitForReady(sessionId).then(() => session.claudeProcess?.sendMessage(data))
+        void this.waitForReady(sessionId).then((ready) => {
+          if (ready) session.claudeProcess?.sendMessage(data)
+          // If not ready (process exited), message stays in _lastUserInput
+          // and will be re-sent on auto-restart
+        })
         return
       }
     }

--- a/server/workflow-loader.test.ts
+++ b/server/workflow-loader.test.ts
@@ -105,7 +105,7 @@ function fakeSessionManager() {
     startClaude: vi.fn(),
     stopClaude: vi.fn(),
     sendInput: vi.fn(),
-    waitForReady: vi.fn(() => Promise.resolve()),
+    waitForReady: vi.fn(() => Promise.resolve(true)),
   } as any
 }
 


### PR DESCRIPTION
## Summary
- **Race condition**: `waitForReady()` resolved on process `exit`, so `sendInput()` would send the user's first message to a dead process — silently losing it. The auto-restart then showed a duplicate "Session started" with no response.
- `waitForReady()` now returns `Promise<boolean>` (`true` = ready, `false` = exited/timeout); callers only send when ready
- Restart handler re-sends pending `_lastUserInput` for fresh sessions that crashed before `system_init`

## Test plan
- [x] TypeScript build passes
- [x] All 1590 tests pass
- [ ] Manual: create a new session and send a message — verify single "Session started" and a response
- [ ] Manual: simulate process crash before init (e.g. invalid API key) — verify message is re-sent on auto-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)