### PR TITLE
fix: resolve deadlock preventing Claude session start

### DIFF
--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -744,9 +744,9 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
   }
 
   isReady(): boolean {
-    // Ready only after system_init has been received, proving the process
-    // has finished loading configs/hooks and is accepting user messages.
-    return this.alive && this._systemInitReceived
+    // Claude CLI waits for the first input before emitting system_init.
+    // We must return true as soon as it's alive to prevent deadlocks in sendInput.
+    return this.alive
   }
 
   getSessionId(): string {

--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -115,12 +115,6 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
    */
   private _receivedOutput = false
 
-  /**
-   * Set to true once the process emits a system init event (type=system, subtype=init).
-   * Until this fires, the process is still loading configs/hooks and is not ready
-   * to process user messages reliably.
-   */
-  private _systemInitReceived = false
 
   // Grouped streaming state — reset per content block
   private thinking: ThinkingState = { active: false, text: '', summaryEmitted: false }
@@ -332,7 +326,6 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
       case 'system':
         if (event.subtype === 'init') {
           this.sessionId = (event as ClaudeSystemInit).session_id || this.sessionId
-          this._systemInitReceived = true
           const model = ('model' in event ? (event as Record<string, unknown>).model : 'unknown') as string
           this.emit('system_init', model)
         }

--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -417,23 +417,21 @@ export class SessionLifecycle {
           const inputAge = session._lastUserInputAt ? Date.now() - session._lastUserInputAt : Infinity
           const hasPendingInput = pendingInput && inputAge < 60_000
 
-          session.claudeProcess.once('system_init', () => {
-            if (session.outputHistory.length > 0) {
-              const context = this.deps.buildSessionContext(session)
-              if (context) {
-                const msg = hasPendingInput
-                  ? context + '\n\n' + pendingInput
-                  : context + '\n\n[Session resumed after process restart. Continue where you left off. If you were in the middle of a task, resume it.]'
-                session.claudeProcess?.sendMessage(msg)
-                return
-              }
+          if (session.outputHistory.length > 0) {
+            const context = this.deps.buildSessionContext(session)
+            if (context) {
+              const msg = hasPendingInput
+                ? context + '\n\n' + pendingInput
+                : context + '\n\n[Session resumed after process restart. Continue where you left off. If you were in the middle of a task, resume it.]'
+              session.claudeProcess?.sendMessage(msg)
+              return
             }
-            // No output history but pending input (brand new session that
-            // crashed before responding) — re-send the user's message.
-            if (hasPendingInput) {
-              session.claudeProcess?.sendMessage(pendingInput)
-            }
-          })
+          }
+          // No output history but pending input (brand new session that
+          // crashed before responding) — re-send the user's message.
+          if (hasPendingInput) {
+            session.claudeProcess?.sendMessage(pendingInput)
+          }
         }
       }, action.delayMs)
       return


### PR DESCRIPTION
## Summary
* Reverts `ClaudeProcess.isReady()` to return true when `alive`, instead of waiting for `system_init`.
* Removes the `system_init` listener block in the restart fallback logic of `handleClaudeExit`.

## Background
In PR #381, `isReady()` was changed to wait for `system_init` to prevent message loss. However, the Claude CLI with `--input-format stream-json` inherently waits for the first message to arrive on stdin *before* it emits `system_init`. This created a deadlock where Codekin waited for `system_init` before sending the first message, and Claude waited for the first message before emitting `system_init`. 

This change restores the previous correct behaviour and ensures that fallback logic in `handleClaudeExit` won't suffer from the same deadlock during process restarts.