### PR TITLE
fix: only show model info once per session

### DIFF
--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -901,10 +901,12 @@ export class SessionManager {
 
   private onSystemInit(cp: CodingProcess, session: Session, model: string): void {
     session.claudeSessionId = cp.getSessionId()
+    const previousModel = session._lastReportedModel
     session._lastReportedModel = model
-    // Always broadcast — this is the single "session is ready" notification.
-    // The text includes the model so the user knows which model is active.
-    this.broadcastAndHistory(session, { type: 'system_message', subtype: 'init', text: `Model: ${model}`, model })
+    // Only show the model message on first init or when the model changes.
+    if (!previousModel || previousModel !== model) {
+      this.broadcastAndHistory(session, { type: 'system_message', subtype: 'init', text: `Model: ${model}`, model })
+    }
   }
 
   private onTextEvent(session: Session, sessionId: string, text: string): void {


### PR DESCRIPTION
## Summary
- The `system_init` event fires on every Claude turn, causing a repetitive "Model: claude-opus-4-6 (Opus 4.6)" message before each response
- Now only displays the model message on first init or when the model actually changes between turns

## Test plan
- [x] All 1591 existing tests pass
- [ ] Start a session — model message appears once at start
- [ ] Send multiple messages — no repeated model messages
- [ ] Switch model mid-session — model message appears again with new model

🤖 Generated with [Claude Code](https://claude.com/claude-code)