### PR TITLE
fix: prevent model/session message cascade on OpenCode start

### DIFF
--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -490,6 +490,9 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         if (!this.isOwnSession(properties)) break
         const field = properties.field as string | undefined
         const delta = properties.delta as string | undefined
+        if (process.env.CODEKIN_DEBUG_SSE) {
+          console.log(`[opencode-sse] delta field=${field} len=${delta?.length ?? 0} text=${delta?.slice(0, 80)}`)
+        }
         if (field === 'text' && delta) {
           this.receivedDeltas = true
           // Buffer initial deltas to detect and strip user echo prefix.
@@ -538,6 +541,10 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
 
         // Only process events for our session
         if (!this.isOwnSession(properties)) break
+
+        if (process.env.CODEKIN_DEBUG_SSE) {
+          console.log(`[opencode-sse] part.updated type=${part.type} len=${part.text?.length ?? 0} text=${part.text?.slice(0, 80)} receivedDeltas=${this.receivedDeltas} emittedPartText=${this.emittedPartText}`)
+        }
 
         switch (part.type) {
           case 'text': {
@@ -709,6 +716,12 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
           parts?: OpenCodeMessagePart[]
         } | undefined
         if (!info || info.role !== 'assistant' || !info.parts) break
+        if (process.env.CODEKIN_DEBUG_SSE) {
+          console.log(`[opencode-sse] message.updated parts=${info.parts.length} types=${info.parts.map(p => p.type).join(',')}`)
+          for (const p of info.parts) {
+            console.log(`[opencode-sse]   part type=${p.type} text=${p.text?.slice(0, 120)}`)
+          }
+        }
         for (const part of info.parts) {
           this.handleSSEEvent({ type: 'message.part.updated', properties: { ...properties, part } })
         }

--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -172,14 +172,16 @@ export class SessionLifecycle {
 
     cp.start()
     session.claudeProcess = cp
-    // Reset so the next system_init always broadcasts the model message,
-    // even if the model hasn't changed since the previous process.
-    session._lastReportedModel = undefined
     this.deps.globalBroadcast?.({ type: 'sessions_updated' })
 
+    // Only show "Session started" for the initial start, not for restarts
+    // triggered by model/permission changes — those already show a model message.
+    const isRestart = !!session._lastReportedModel
     const startMsg: WsServerMessage = { type: 'claude_started', sessionId }
     this.deps.addToHistory(session, startMsg)
-    this.deps.broadcast(session, startMsg)
+    if (!isRestart) {
+      this.deps.broadcast(session, startMsg)
+    }
     return true
   }
 

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -1211,7 +1211,10 @@ export class SessionManager {
   setModel(sessionId: string, model: string): boolean {
     const session = this.sessions.get(sessionId)
     if (!session) return false
-    session.model = model || undefined
+    const newModel = model || undefined
+    // Skip restart if the model hasn't actually changed.
+    if (session.model === newModel) return true
+    session.model = newModel
     // Clear any pending restart timer from a prior crash to prevent a stale
     // timer from spawning a second process after we restart below.
     if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }


### PR DESCRIPTION
## Summary

Fixes the cascade of "Session started" + "Model:" messages when starting an OpenCode session:

- **Skip redundant restarts**: `setModel` now checks if the model actually changed before restarting the process
- **Don't reset model tracking**: Removed `_lastReportedModel = undefined` on process start (from #386) — this was causing the model message to re-appear on every restart even with the same model  
- **Suppress restart banners**: Only broadcast "Session started" for the initial start, not for restarts triggered by model/permission changes
- **Debug logging**: Added SSE event logging behind `CODEKIN_DEBUG_SSE` env var to diagnose the thinking/text mixing issue with Kimi (needs live testing to see what OpenCode actually sends)

## Test plan

- [ ] Create a new OpenCode session — verify only ONE "Session started" and ONE "Model:" message appears
- [ ] Switch models within a session — verify restart shows new model without duplicate "Session started"
- [ ] Run with `CODEKIN_DEBUG_SSE=1` and send a message to Kimi — check server logs for SSE event details
- [ ] All 1591 tests pass, TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)