### PR TITLE
fix: use dedicated flag for restart detection in session lifecycle

### DIFF
--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -174,9 +174,10 @@ export class SessionLifecycle {
     session.claudeProcess = cp
     this.deps.globalBroadcast?.({ type: 'sessions_updated' })
 
-    // Only show "Session started" for the initial start, not for restarts
+    // Only show "Session started" for the very first start, not for restarts
     // triggered by model/permission changes — those already show a model message.
-    const isRestart = !!session._lastReportedModel
+    const isRestart = !!session._processStartedOnce
+    session._processStartedOnce = true
     const startMsg: WsServerMessage = { type: 'claude_started', sessionId }
     this.deps.addToHistory(session, startMsg)
     if (!isRestart) {

--- a/server/types.ts
+++ b/server/types.ts
@@ -89,6 +89,8 @@ export interface Session {
   _namingAttempts: number
   /** The model reported by the last system init event, used to suppress duplicate init messages. */
   _lastReportedModel?: string
+  /** Whether a process has been started at least once (to suppress "Session started" on restarts). */
+  _processStartedOnce?: boolean
   /** Last user input sent, stored for API error retry. */
   _lastUserInput?: string
   /** First user input, preserved for session naming (not cleared by API retry). */


### PR DESCRIPTION
## Summary

- Use `_processStartedOnce` flag instead of `_lastReportedModel` to detect process restarts
- Fixes double "Session started" when the first OpenCode process never emits `system_init` (because it starts without a model, then gets restarted when the frontend sets one)

## Test plan

- [ ] Create new OpenCode session — verify only ONE "Session started" message appears
- [ ] All 1591 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)