### PR TITLE
feat: auto-setup GitHub webhook for PR Review workflows

### DIFF
--- a/server/workflow-routes.test.ts
+++ b/server/workflow-routes.test.ts
@@ -1,0 +1,37 @@
+/** Tests for parseGitHubSlug — verifies GitHub slug extraction from various remote URL formats. */
+import { describe, it, expect } from 'vitest'
+import { parseGitHubSlug } from './workflow-routes.js'
+
+describe('parseGitHubSlug', () => {
+  it('parses HTTPS URL with .git suffix', () => {
+    expect(parseGitHubSlug('https://github.com/Multiplier-Labs/codekin.git')).toBe('Multiplier-Labs/codekin')
+  })
+
+  it('parses HTTPS URL without .git suffix', () => {
+    expect(parseGitHubSlug('https://github.com/owner/repo')).toBe('owner/repo')
+  })
+
+  it('parses SSH URL', () => {
+    expect(parseGitHubSlug('git@github.com:owner/repo.git')).toBe('owner/repo')
+  })
+
+  it('parses SSH URL without .git suffix', () => {
+    expect(parseGitHubSlug('git@github.com:owner/repo')).toBe('owner/repo')
+  })
+
+  it('handles trailing whitespace/newline', () => {
+    expect(parseGitHubSlug('git@github.com:owner/repo.git\n')).toBe('owner/repo')
+  })
+
+  it('returns null for non-GitHub remotes', () => {
+    expect(parseGitHubSlug('https://gitlab.com/owner/repo.git')).toBeNull()
+  })
+
+  it('returns null for empty string', () => {
+    expect(parseGitHubSlug('')).toBeNull()
+  })
+
+  it('handles repos with hyphens, underscores, and dots', () => {
+    expect(parseGitHubSlug('git@github.com:my-org/my_repo.name.git')).toBe('my-org/my_repo.name')
+  })
+})

--- a/server/workflow-routes.ts
+++ b/server/workflow-routes.ts
@@ -7,6 +7,8 @@
 
 import { Router } from 'express'
 import type { Request, Response } from 'express'
+import { execFile } from 'child_process'
+import { promisify } from 'util'
 import { getWorkflowEngine } from './workflow-engine.js'
 import {
   loadWorkflowConfig,
@@ -20,6 +22,79 @@ import { syncCommitHooks } from './commit-event-hooks.js'
 import type { CommitEventHandler } from './commit-event-handler.js'
 import type { SessionManager } from './session-manager.js'
 import { VALID_PROVIDERS } from './types.js'
+import {
+  previewWebhookSetup,
+  createRepoWebhook,
+  updateRepoWebhook,
+} from './webhook-github-setup.js'
+import { loadWebhookConfig, generateWebhookSecret, saveWebhookConfig } from './webhook-config.js'
+
+const execFileAsync = promisify(execFile)
+
+/**
+ * Derive the GitHub `owner/repo` slug from a local repo path
+ * by parsing the git remote origin URL.
+ */
+async function getGitHubSlug(repoPath: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote', 'get-url', 'origin'], { timeout: 5000 })
+    const url = stdout.trim()
+    // Match SSH (git@github.com:owner/repo.git) or HTTPS (https://github.com/owner/repo.git)
+    const match = url.match(/github\.com[:/]([^/]+\/[^/.]+?)(?:\.git)?$/)
+    return match?.[1] ?? null
+  } catch {
+    return null
+  }
+}
+
+export interface WebhookSetupResult {
+  status: 'created' | 'updated' | 'already_configured' | 'failed'
+  message: string
+  repo?: string
+}
+
+/**
+ * Auto-setup the GitHub webhook for a PR review workflow.
+ * Ensures the webhook config has a secret and is enabled, then
+ * creates/updates the webhook on the GitHub repo.
+ */
+async function autoSetupPrWebhook(repoPath: string, webhookUrl: string): Promise<WebhookSetupResult> {
+  const slug = await getGitHubSlug(repoPath)
+  if (!slug) {
+    return {
+      status: 'failed',
+      message: `Could not determine GitHub repository from ${repoPath}. Please set up the webhook manually in Settings.`,
+    }
+  }
+
+  const preview = await previewWebhookSetup(slug, webhookUrl)
+
+  if (preview.action === 'none') {
+    return { status: 'already_configured', message: 'GitHub webhook is already configured.', repo: slug }
+  }
+
+  // Ensure server webhook config has a secret and is enabled
+  let config = loadWebhookConfig()
+  const configUpdates: Record<string, unknown> = {}
+  if (!config.secret) configUpdates.secret = generateWebhookSecret()
+  if (!config.enabled) configUpdates.enabled = true
+  if (Object.keys(configUpdates).length > 0) {
+    saveWebhookConfig(configUpdates)
+    config = loadWebhookConfig()
+  }
+
+  if (preview.action === 'create') {
+    await createRepoWebhook(slug, webhookUrl, config.secret, preview.proposed.events)
+    return { status: 'created', message: `GitHub webhook created on ${slug}.`, repo: slug }
+  } else {
+    await updateRepoWebhook(slug, preview.existing!.id, {
+      events: preview.proposed.events,
+      active: true,
+      secret: config.secret,
+    })
+    return { status: 'updated', message: `GitHub webhook updated on ${slug}.`, repo: slug }
+  }
+}
 
 type VerifyFn = (token: string | undefined) => boolean
 type ExtractFn = (req: Request) => string | undefined
@@ -299,8 +374,9 @@ export function createWorkflowRouter(
     res.json({ config: loadWorkflowConfig() })
   })
 
-  router.post('/config/repos', (req, res) => {
-    const { id, name, repoPath, cronExpression, enabled, customPrompt, kind, model, provider } = req.body as Partial<ReviewRepoConfig>
+  router.post('/config/repos', async (req, res) => {
+    const { id, name, repoPath, cronExpression, enabled, customPrompt, kind, model, provider, webhookUrl } =
+      req.body as Partial<ReviewRepoConfig> & { webhookUrl?: string }
     if (!id || !name || !repoPath || !cronExpression) {
       return res.status(400).json({ error: 'Missing required fields: id, name, repoPath, cronExpression' })
     }
@@ -335,7 +411,25 @@ export function createWorkflowRouter(
       // Engine might not be ready yet
     }
 
-    res.json({ config })
+    // Auto-setup GitHub webhook for pr-review workflows
+    let webhookSetup: WebhookSetupResult | undefined
+    if (kind === 'pr-review' && webhookUrl) {
+      try {
+        webhookSetup = await autoSetupPrWebhook(repoPath, webhookUrl)
+      } catch (err) {
+        webhookSetup = {
+          status: 'failed',
+          message: err instanceof Error ? err.message : 'Webhook setup failed. Please configure it manually in Settings.',
+        }
+      }
+    } else if (kind === 'pr-review' && !webhookUrl) {
+      webhookSetup = {
+        status: 'failed',
+        message: 'Webhook URL not provided. Please configure the GitHub webhook manually in Settings.',
+      }
+    }
+
+    res.json({ config, webhookSetup })
   })
 
   router.patch('/config/repos/:id', (req, res) => {

--- a/server/workflow-routes.ts
+++ b/server/workflow-routes.ts
@@ -32,16 +32,23 @@ import { loadWebhookConfig, generateWebhookSecret, saveWebhookConfig } from './w
 const execFileAsync = promisify(execFile)
 
 /**
+ * Parse a GitHub `owner/repo` slug from a git remote URL.
+ * Supports SSH (git@github.com:owner/repo.git) and HTTPS (https://github.com/owner/repo.git).
+ * Returns null for non-GitHub remotes.
+ */
+export function parseGitHubSlug(remoteUrl: string): string | null {
+  const match = remoteUrl.trim().match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/)
+  return match?.[1] ?? null
+}
+
+/**
  * Derive the GitHub `owner/repo` slug from a local repo path
  * by parsing the git remote origin URL.
  */
 async function getGitHubSlug(repoPath: string): Promise<string | null> {
   try {
     const { stdout } = await execFileAsync('git', ['-C', repoPath, 'remote', 'get-url', 'origin'], { timeout: 5000 })
-    const url = stdout.trim()
-    // Match SSH (git@github.com:owner/repo.git) or HTTPS (https://github.com/owner/repo.git)
-    const match = url.match(/github\.com[:/]([^/]+\/[^/.]+?)(?:\.git)?$/)
-    return match?.[1] ?? null
+    return parseGitHubSlug(stdout)
   } catch {
     return null
   }

--- a/src/components/AddWorkflowModal.tsx
+++ b/src/components/AddWorkflowModal.tsx
@@ -467,8 +467,11 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
         model: form.model || undefined,
         provider: form.provider !== 'claude' ? form.provider : undefined,
       }, webhookUrl)
-      if (isPrReview && setupResult) {
-        setWebhookResult(setupResult)
+      if (isPrReview) {
+        setWebhookResult(setupResult ?? {
+          status: 'failed',
+          message: 'No webhook setup information returned. Please configure the GitHub webhook manually in Settings.',
+        })
       } else {
         onClose()
       }

--- a/src/components/AddWorkflowModal.tsx
+++ b/src/components/AddWorkflowModal.tsx
@@ -8,10 +8,10 @@
  */
 
 import { useState, useEffect } from 'react'
-import { IconX, IconLoader2, IconArrowLeft, IconArrowRight, IconCheck } from '@tabler/icons-react'
+import { IconX, IconLoader2, IconArrowLeft, IconArrowRight, IconCheck, IconAlertTriangle } from '@tabler/icons-react'
 import { useRepos } from '../hooks/useRepos'
 import { listKinds } from '../lib/workflowApi'
-import type { ReviewRepoConfig, WorkflowKindInfo } from '../lib/workflowApi'
+import type { ReviewRepoConfig, WorkflowKindInfo, WebhookSetupResult } from '../lib/workflowApi'
 import {
   WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL,
   buildCron, describeCron, slugify, kindCategory,
@@ -40,7 +40,7 @@ interface FormState {
 interface Props {
   token: string
   onClose: () => void
-  onAdd: (repo: ReviewRepoConfig) => Promise<void>
+  onAdd: (repo: ReviewRepoConfig, webhookUrl?: string) => Promise<WebhookSetupResult | undefined>
 }
 
 // ---------------------------------------------------------------------------
@@ -415,6 +415,7 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
   })
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string | null>(null)
+  const [webhookResult, setWebhookResult] = useState<WebhookSetupResult | null>(null)
 
   const eventDriven = isEventDriven(form.kind)
   const updateForm = (patch: Partial<FormState>) => { setForm(f => ({ ...f, ...patch })); }
@@ -451,7 +452,11 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
       const cronExpression = eventDriven
         ? EVENT_CRON
         : buildCron(form.cronHour, form.cronDow, form.cronMinute)
-      await onAdd({
+      const isPrReview = form.kind === 'pr-review'
+      const webhookUrl = isPrReview
+        ? `${location.protocol}//${location.host}/cc/api/webhooks/github`
+        : undefined
+      const setupResult = await onAdd({
         id: `${slugify(name)}-${slugify(form.kind)}`,
         name,
         repoPath: form.repoPath.trim(),
@@ -461,8 +466,12 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
         customPrompt: form.customPrompt.trim() || undefined,
         model: form.model || undefined,
         provider: form.provider !== 'claude' ? form.provider : undefined,
-      })
-      onClose()
+      }, webhookUrl)
+      if (isPrReview && setupResult) {
+        setWebhookResult(setupResult)
+      } else {
+        onClose()
+      }
     } catch (err) {
       setFormError(err instanceof Error ? err.message : 'Failed to add workflow')
     } finally {
@@ -484,99 +493,149 @@ export function AddWorkflowModal({ token, onClose, onAdd }: Props) {
           </button>
         </div>
 
-        {/* Step indicator */}
-        <StepIndicator current={step} eventDriven={eventDriven} />
-
-        {/* Step content */}
-        <div className="min-h-[200px]">
-          {step === 1 && (
-            <StepRepo
-              token={token}
-              selectedRepoId={selectedRepoId}
-              onSelect={(id, path, name) => {
-                setSelectedRepoId(id)
-                updateForm({ repoPath: path, repoName: name })
-              }}
-            />
-          )}
-
-          {step === 2 && (
-            <StepKind
-              token={token}
-              repoPath={form.repoPath}
-              selectedKind={form.kind}
-              onSelect={kind => { updateForm({ kind }); }}
-            />
-          )}
-
-          {step === 3 && (
-            <StepConfigure
-              token={token}
-              form={form}
-              onChange={updateForm}
-            />
-          )}
-        </div>
-
-        {/* Error */}
-        {formError && (
-          <div className="rounded-md bg-error-10/50 px-3 py-2 text-[13px] text-error-4 mt-3">{formError}</div>
-        )}
-
-        {/* Navigation */}
-        <div className="flex gap-2 mt-5 pt-4 border-t border-neutral-8/50">
-          {step > 1 ? (
-            <button
-              type="button"
-              onClick={handleBack}
-              className="flex items-center gap-1.5 rounded-md border border-neutral-7 bg-neutral-10 px-4 py-2 text-[15px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
-            >
-              <IconArrowLeft size={14} stroke={2} />
-              Back
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded-md border border-neutral-7 bg-neutral-10 px-4 py-2 text-[15px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
-            >
-              Cancel
-            </button>
-          )}
-
-          <div className="flex-1" />
-
-          {step < 3 ? (
-            <button
-              type="button"
-              onClick={handleNext}
-              disabled={!canNext()}
-              className="flex items-center gap-1.5 rounded-md bg-primary-8 px-4 py-2 text-[15px] font-medium text-neutral-1 hover:bg-primary-7 disabled:opacity-40 transition-colors"
-            >
-              Next
-              <IconArrowRight size={14} stroke={2} />
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={handleSubmit}
-              disabled={saving}
-              className="flex items-center gap-1.5 rounded-md bg-primary-8 px-4 py-2 text-[15px] font-medium text-neutral-1 hover:bg-primary-7 disabled:opacity-50 transition-colors"
-            >
-              {saving ? (
-                <>
-                  <IconLoader2 size={14} stroke={2} className="animate-spin" />
-                  Creating…
-                </>
+        {webhookResult ? (
+          /* Webhook setup result screen */
+          <>
+            <div className="min-h-[120px] py-2">
+              {webhookResult.status === 'failed' ? (
+                <div className="space-y-3">
+                  <div className="flex items-start gap-3 rounded-lg border border-warning-7/40 bg-warning-9/20 px-4 py-3">
+                    <IconAlertTriangle size={18} stroke={2} className="text-warning-4 mt-0.5 shrink-0" />
+                    <div>
+                      <p className="text-[14px] font-medium text-warning-3">Webhook setup required</p>
+                      <p className="text-[13px] text-neutral-4 mt-1">{webhookResult.message}</p>
+                    </div>
+                  </div>
+                  <div className="rounded-lg border border-neutral-7 bg-neutral-10 px-4 py-3">
+                    <p className="text-[13px] font-medium text-neutral-3 mb-2">To enable PR reviews, configure the webhook:</p>
+                    <ol className="text-[13px] text-neutral-4 space-y-1.5 list-decimal list-inside">
+                      <li>Go to <span className="text-neutral-2 font-medium">Settings</span> (gear icon in the sidebar)</li>
+                      <li>Scroll to <span className="text-neutral-2 font-medium">GitHub Webhooks</span></li>
+                      <li>Enter the repository name and click <span className="text-neutral-2 font-medium">Setup</span></li>
+                    </ol>
+                  </div>
+                </div>
               ) : (
-                <>
-                  <IconCheck size={14} stroke={2} />
-                  Create Workflow
-                </>
+                <div className="flex items-start gap-3 rounded-lg border border-success-7/40 bg-success-9/20 px-4 py-3">
+                  <IconCheck size={18} stroke={2} className="text-success-4 mt-0.5 shrink-0" />
+                  <div>
+                    <p className="text-[14px] font-medium text-success-3">Workflow created</p>
+                    <p className="text-[13px] text-neutral-4 mt-1">
+                      {webhookResult.message} PRs will be reviewed automatically when opened or updated.
+                    </p>
+                  </div>
+                </div>
               )}
-            </button>
-          )}
-        </div>
+            </div>
+
+            <div className="flex justify-end mt-5 pt-4 border-t border-neutral-8/50">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md bg-primary-8 px-4 py-2 text-[15px] font-medium text-neutral-1 hover:bg-primary-7 transition-colors"
+              >
+                Done
+              </button>
+            </div>
+          </>
+        ) : (
+          /* Wizard steps */
+          <>
+            {/* Step indicator */}
+            <StepIndicator current={step} eventDriven={eventDriven} />
+
+            {/* Step content */}
+            <div className="min-h-[200px]">
+              {step === 1 && (
+                <StepRepo
+                  token={token}
+                  selectedRepoId={selectedRepoId}
+                  onSelect={(id, path, name) => {
+                    setSelectedRepoId(id)
+                    updateForm({ repoPath: path, repoName: name })
+                  }}
+                />
+              )}
+
+              {step === 2 && (
+                <StepKind
+                  token={token}
+                  repoPath={form.repoPath}
+                  selectedKind={form.kind}
+                  onSelect={kind => { updateForm({ kind }); }}
+                />
+              )}
+
+              {step === 3 && (
+                <StepConfigure
+                  token={token}
+                  form={form}
+                  onChange={updateForm}
+                />
+              )}
+            </div>
+
+            {/* Error */}
+            {formError && (
+              <div className="rounded-md bg-error-10/50 px-3 py-2 text-[13px] text-error-4 mt-3">{formError}</div>
+            )}
+
+            {/* Navigation */}
+            <div className="flex gap-2 mt-5 pt-4 border-t border-neutral-8/50">
+              {step > 1 ? (
+                <button
+                  type="button"
+                  onClick={handleBack}
+                  className="flex items-center gap-1.5 rounded-md border border-neutral-7 bg-neutral-10 px-4 py-2 text-[15px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
+                >
+                  <IconArrowLeft size={14} stroke={2} />
+                  Back
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded-md border border-neutral-7 bg-neutral-10 px-4 py-2 text-[15px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
+                >
+                  Cancel
+                </button>
+              )}
+
+              <div className="flex-1" />
+
+              {step < 3 ? (
+                <button
+                  type="button"
+                  onClick={handleNext}
+                  disabled={!canNext()}
+                  className="flex items-center gap-1.5 rounded-md bg-primary-8 px-4 py-2 text-[15px] font-medium text-neutral-1 hover:bg-primary-7 disabled:opacity-40 transition-colors"
+                >
+                  Next
+                  <IconArrowRight size={14} stroke={2} />
+                </button>
+              ) : (
+                <button
+                  type="button"
+                  onClick={handleSubmit}
+                  disabled={saving}
+                  className="flex items-center gap-1.5 rounded-md bg-primary-8 px-4 py-2 text-[15px] font-medium text-neutral-1 hover:bg-primary-7 disabled:opacity-50 transition-colors"
+                >
+                  {saving ? (
+                    <>
+                      <IconLoader2 size={14} stroke={2} className="animate-spin" />
+                      {form.kind === 'pr-review' ? 'Setting up…' : 'Creating…'}
+                    </>
+                  ) : (
+                    <>
+                      <IconCheck size={14} stroke={2} />
+                      Create Workflow
+                    </>
+                  )}
+                </button>
+              )}
+            </div>
+          </>
+        )}
       </div>
     </div>
   )

--- a/src/hooks/useWorkflows.ts
+++ b/src/hooks/useWorkflows.ts
@@ -21,6 +21,7 @@ import {
   type CronSchedule,
   type WorkflowConfig,
   type ReviewRepoConfig,
+  type WebhookSetupResult,
 } from '../lib/workflowApi'
 
 const POLL_FAST_MS = 5_000
@@ -36,7 +37,7 @@ interface UseWorkflowsResult {
   triggerRun: (kind: string, input?: Record<string, unknown>) => Promise<void>
   cancelRun: (runId: string) => Promise<void>
   triggerSchedule: (id: string) => Promise<void>
-  addRepo: (repo: ReviewRepoConfig) => Promise<void>
+  addRepo: (repo: ReviewRepoConfig, webhookUrl?: string) => Promise<WebhookSetupResult | undefined>
   removeRepo: (id: string) => Promise<void>
   updateRepo: (id: string, patch: Partial<ReviewRepoConfig>) => Promise<void>
   toggleScheduleEnabled: (id: string, enabled: boolean) => Promise<void>
@@ -108,9 +109,10 @@ export function useWorkflows(token: string): UseWorkflowsResult {
     }
   }, [token, refresh])
 
-  const addRepo = useCallback(async (repo: ReviewRepoConfig) => {
-    await addRepoConfig(token, repo)
+  const addRepo = useCallback(async (repo: ReviewRepoConfig, webhookUrl?: string): Promise<WebhookSetupResult | undefined> => {
+    const result = await addRepoConfig(token, repo, webhookUrl)
     await refresh()
+    return result.webhookSetup
   }, [token, refresh])
 
   const removeRepo = useCallback(async (id: string) => {

--- a/src/lib/workflowApi.test.ts
+++ b/src/lib/workflowApi.test.ts
@@ -155,11 +155,20 @@ describe('workflowApi', () => {
     it('adds a repo config', async () => {
       mockFetch.mockResolvedValueOnce(jsonResponse({ config: { reviewRepos: [{ id: 'r1' }] } }))
       const repo = { id: 'r1', name: 'Repo', repoPath: '/tmp', cronExpression: '0 6 * * *', enabled: true }
-      const config = await addRepoConfig(token, repo)
-      expect(config.reviewRepos).toHaveLength(1)
+      const result = await addRepoConfig(token, repo)
+      expect(result.config.reviewRepos).toHaveLength(1)
       expect(mockFetch).toHaveBeenCalledWith('/cc/api/workflows/config/repos', expect.objectContaining({
         method: 'POST',
       }))
+    })
+
+    it('passes webhookUrl in request body when provided', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ config: { reviewRepos: [{ id: 'r1' }] }, webhookSetup: { status: 'created', message: 'ok' } }))
+      const repo = { id: 'r1', name: 'Repo', repoPath: '/tmp', cronExpression: 'event', enabled: true, kind: 'pr-review' }
+      const result = await addRepoConfig(token, repo, 'https://example.com/cc/api/webhooks/github')
+      expect(result.webhookSetup).toEqual({ status: 'created', message: 'ok' })
+      const callBody = JSON.parse(mockFetch.mock.calls[0][1].body as string)
+      expect(callBody.webhookUrl).toBe('https://example.com/cc/api/webhooks/github')
     })
 
     it('throws on non-ok response', async () => {

--- a/src/lib/workflowApi.ts
+++ b/src/lib/workflowApi.ts
@@ -189,19 +189,32 @@ export async function getConfig(token: string): Promise<WorkflowConfig> {
   return data.config
 }
 
-/** Add a new repo to the workflow configuration. Returns the updated config. */
+export interface WebhookSetupResult {
+  status: 'created' | 'updated' | 'already_configured' | 'failed'
+  message: string
+  repo?: string
+}
+
+export interface AddRepoResult {
+  config: WorkflowConfig
+  webhookSetup?: WebhookSetupResult
+}
+
+/** Add a new repo to the workflow configuration. Returns the updated config and optional webhook setup result. */
 export async function addRepoConfig(
   token: string,
-  repo: ReviewRepoConfig
-): Promise<WorkflowConfig> {
+  repo: ReviewRepoConfig,
+  webhookUrl?: string,
+): Promise<AddRepoResult> {
+  const body = webhookUrl ? { ...repo, webhookUrl } : repo
   const res = await fetch(`${BASE}/config/repos`, {
     method: 'POST',
     headers: headers(token),
-    body: JSON.stringify(repo),
+    body: JSON.stringify(body),
   })
   if (!res.ok) throw new Error(`Failed to add repo config: ${res.status}`)
   const data = await res.json()
-  return data.config
+  return { config: data.config, webhookSetup: data.webhookSetup }
 }
 
 /** Remove a repo from the workflow configuration. Returns the updated config. */


### PR DESCRIPTION
## Summary
- When creating a PR Review workflow, the server now automatically configures the GitHub webhook on the repo (derives `owner/repo` from git remote, generates secret, creates webhook via GitHub API)
- The Add Workflow modal shows setup results after creation — a success message if the webhook was configured, or step-by-step manual setup instructions if auto-setup failed
- Frontend passes the webhook URL to the server; API returns `webhookSetup` result alongside the config

## Test plan
- [ ] Create a new PR Review workflow for a repo — verify webhook is auto-created on GitHub
- [ ] Verify the modal shows a green success message with "Workflow created"
- [ ] Test with a repo that has no GitHub remote — verify the modal shows a yellow warning with manual setup instructions
- [ ] Verify existing non-PR-review workflows still create normally (immediate modal close)
- [ ] Run `npm test` — all 1592 tests pass
- [ ] Run `npm run build` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)