### PR TITLE
fix: security hardening — path traversal, trust proxy, image allowlist

### DIFF
--- a/server/session-routes.ts
+++ b/server/session-routes.ts
@@ -53,8 +53,22 @@ export function createSessionRouter(
   router.get('/api/opencode/models', async (req, res) => {
     const token = extractToken(req)
     if (!verifyToken(token)) return res.status(401).json({ error: 'Unauthorized' })
-    const workingDir = (req.query.workingDir as string) || osHomedir()
-    const result = await fetchOpenCodeModels(workingDir)
+    const rawDir = (req.query.workingDir as string) || osHomedir()
+
+    // Bounds-check: workingDir must be under home or REPOS_ROOT (same as /api/sessions/create)
+    const home = osHomedir()
+    const allowedRoots = [home, REPOS_ROOT]
+    let resolvedDir: string
+    try {
+      resolvedDir = fsRealpathSync(pathResolve(rawDir))
+    } catch {
+      return res.status(400).json({ error: 'workingDir could not be resolved (path does not exist or is inaccessible)' })
+    }
+    if (!allowedRoots.some(root => resolvedDir === root || resolvedDir.startsWith(root + '/'))) {
+      return res.status(403).json({ error: 'workingDir is outside allowed directories' })
+    }
+
+    const result = await fetchOpenCodeModels(resolvedDir)
     res.json(result)
   })
 

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -195,6 +195,12 @@ const commitEventState: { handler: CommitEventHandler | undefined } = { handler:
 // ---------------------------------------------------------------------------
 const app = express()
 
+// Trust X-Forwarded-For headers when behind a reverse proxy so that
+// req.ip returns the real client IP for rate limiters and logging.
+if (TRUST_PROXY) {
+  app.set('trust proxy', true)
+}
+
 // In Docker / standalone mode (FRONTEND_DIST set), the server is reached directly without nginx.
 // nginx normally strips the /cc prefix before proxying; we replicate that here so the frontend
 // (which hardcodes BASE = '/cc') works against the Node server without modification.

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -213,9 +213,12 @@ function AssistantMessage({ msg, fontSize, variant = 'default', repeatCount }: {
               return <a href={safeHref} target="_blank" rel="noopener noreferrer" {...props}>{children}</a>
             },
             img({ src, alt, ...props }) {
+              // Only allow https: and data: URIs to prevent tracking beacons and arbitrary protocol access
+              const safeSrc = src && /^(https:|data:image\/)/i.test(src) ? src : undefined
+              if (!safeSrc) return <span className="text-neutral-5">[image blocked: untrusted source]</span>
               return (
                 <img
-                  src={src}
+                  src={safeSrc}
                   alt={alt || 'Image'}
                   className="max-w-full max-h-96 rounded-lg border border-neutral-8 my-2"
                   loading="lazy"


### PR DESCRIPTION
## Summary

- **Path traversal in `/api/opencode/models`**: Added `realpathSync` + allowed-roots validation to `workingDir`, matching the existing guard in `/api/sessions/create`. Prevents reading arbitrary filesystem paths via the models endpoint.
- **Trust proxy for rate limiters**: Added `app.set('trust proxy', true)` early in Express setup (gated on `TRUST_PROXY` config). This ensures `req.ip` returns the real client IP behind nginx, so all rate limiters (API global, auth endpoint) work correctly.
- **Markdown image src allowlist**: The `img` renderer in `ChatView` now only allows `https:` and `data:image/` URIs. Other protocols (http, ftp, etc.) are blocked with a placeholder, preventing tracking beacons or protocol abuse from model-generated markdown.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm test` — 1600/1600 tests pass
- [ ] Verify `/api/opencode/models?workingDir=/etc` returns 403
- [ ] Verify rate limiting still works with `TRUST_PROXY=true` behind nginx
- [ ] Verify markdown images with `https://` src render normally
- [ ] Verify markdown images with `http://` src show blocked placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)