### PR TITLE
fix: add API rate limiter map cap and attachment file size limit

### DIFF
--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -19,7 +19,7 @@
 import { EventEmitter } from 'events'
 import { spawn, type ChildProcess } from 'child_process'
 import { randomUUID } from 'crypto'
-import { readFileSync, existsSync } from 'fs'
+import { readFileSync, existsSync, statSync } from 'fs'
 import { extname } from 'path'
 import type { ClaudeProcessEvents } from './claude-process.js'
 import { OPENCODE_CAPABILITIES, type CodingProcess, type CodingProvider, type ProviderCapabilities } from './coding-process.js'
@@ -877,6 +877,13 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       for (const filePath of filePaths) {
         if (!existsSync(filePath)) {
           console.warn(`[opencode] Attached file not found: ${filePath}`)
+          continue
+        }
+        const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024 // 10 MB
+        const fileSize = statSync(filePath).size
+        if (fileSize > MAX_ATTACHMENT_BYTES) {
+          console.warn(`[opencode] Attachment too large (${(fileSize / 1024 / 1024).toFixed(1)} MB, max 10 MB): ${filePath}`)
+          parts.push({ type: 'text', text: `[Attachment rejected: ${filePath.split('/').pop()} is ${(fileSize / 1024 / 1024).toFixed(1)} MB, exceeding the 10 MB limit]` })
           continue
         }
         const ext = extname(filePath).toLowerCase()

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -262,6 +262,8 @@ app.use(express.json())
 const apiRateBuckets = new Map<string, { count: number; resetAt: number }>()
 const API_RATE_WINDOW_MS = 60_000
 const API_RATE_MAX_REQUESTS = 300
+/** Maximum number of tracked IPs in the API rate-limiter map to prevent unbounded memory growth. */
+const API_RATE_MAP_MAX_SIZE = 10_000
 
 // Periodic cleanup to prevent unbounded map growth
 const apiRateCleanup = setInterval(() => {
@@ -277,6 +279,10 @@ app.use('/api/', (req, res, next) => {
   const now = Date.now()
   const entry = apiRateBuckets.get(ip)
   if (!entry || now >= entry.resetAt) {
+    // Reject new IPs if the map has grown too large (DoS protection)
+    if (!entry && apiRateBuckets.size >= API_RATE_MAP_MAX_SIZE) {
+      return res.status(429).json({ error: 'Too Many Requests', retryAfter: 60 })
+    }
     apiRateBuckets.set(ip, { count: 1, resetAt: now + API_RATE_WINDOW_MS })
     return next()
   }


### PR DESCRIPTION
## Summary

- **API rate limiter memory cap** (`server/ws-server.ts`): The `apiRateBuckets` map now has a hard max size of 10,000 entries (matching the existing `WS_RATE_MAP_MAX_SIZE` pattern). New IPs are rejected with HTTP 429 when the map is full, preventing unbounded memory growth under DoS conditions.
- **Attachment file size limit** (`server/opencode-process.ts`): Added a 10 MB per-file size check via `statSync` before reading attachments with `readFileSync`. Files exceeding the limit are rejected with a clear inline error message instead of being loaded into memory.

## Test plan

- [x] All 1600 existing tests pass
- [x] Lint passes (0 errors)
- [ ] Verify API rate limiter rejects new IPs when map is at capacity
- [ ] Verify attachments over 10 MB are rejected with a descriptive message
- [ ] Verify attachments under 10 MB continue to work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)