### PR TITLE
fix: unify workflow report commit/push across MD and Stepflow systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,7 @@ dist-ssr
 .codekin/settings.json
 .codekin/scripts/
 
-# Generated workflow outputs
-.codekin/outputs/
+# Legacy workflow output dirs (no longer used — reports go to .codekin/reports/)
 review logs/
 dependency-reports/
 coverage-reports/

--- a/server/orchestrator-reports.ts
+++ b/server/orchestrator-reports.ts
@@ -39,13 +39,16 @@ export interface ReportContent extends ReportMeta {
 
 const REPORTS_DIR = '.codekin/reports'
 
-/** Known report categories. */
+/** Known report categories — must include every subdirectory used by MD and Stepflow workflows. */
 const REPORT_CATEGORIES = [
   'code-review',
   'comments',
+  'commit-review',
   'complexity',
+  'coverage',
   'dependencies',
   'docs-audit',
+  'pr-review',
   'repo-health',
   'security',
   'test-coverage',

--- a/server/stepflow-handler.test.ts
+++ b/server/stepflow-handler.test.ts
@@ -17,6 +17,7 @@ vi.mock('./stepflow-prompt.js', () => ({
 vi.mock('./webhook-workspace.js', () => ({
   createWorkspace: vi.fn(async () => '/tmp/workspaces/session-1'),
   cleanupWorkspace: vi.fn(),
+  commitReportsFromWorkspace: vi.fn(),
 }))
 
 import { StepflowHandler, loadStepflowConfig } from './stepflow-handler.js'

--- a/server/stepflow-handler.ts
+++ b/server/stepflow-handler.ts
@@ -71,7 +71,7 @@ import type {
   StepflowWebhookPayload,
 } from './stepflow-types.js'
 import { buildStepflowPrompt } from './stepflow-prompt.js'
-import { createWorkspace, cleanupWorkspace } from './webhook-workspace.js'
+import { createWorkspace, cleanupWorkspace, commitReportsFromWorkspace } from './webhook-workspace.js'
 import { WebhookHandlerBase } from './webhook-handler-base.js'
 import { REPOS_ROOT } from './config.js'
 
@@ -152,6 +152,11 @@ export class StepflowHandler extends WebhookHandlerBase<StepflowEvent, StepflowE
           console.warn(`[stepflow] Callback POST failed for event ${event.id}:`, err)
         })
       }
+
+      // Commit any report files to the codekin/reports branch before cleanup.
+      // This ensures reports are persisted even if Claude didn't commit them.
+      const commitPrefix = `chore: ${event.kind || 'workflow'} report`
+      commitReportsFromWorkspace(sessionId, commitPrefix)
 
       cleanupWorkspace(sessionId)
     })

--- a/server/stepflow-prompt.ts
+++ b/server/stepflow-prompt.ts
@@ -22,18 +22,19 @@
 import type { StepflowSessionRequest } from './stepflow-types.js'
 
 /**
- * Maps workflow kinds that produce report artifacts to their `.codekin/outputs/` subdirectory.
- * When a session's kind matches, the prompt instructs Claude to write the report there.
+ * Maps workflow kinds that produce report artifacts to their `.codekin/reports/` subdirectory.
+ * Uses the same paths as the MD-based workflow engine and the orchestrator report scanner
+ * so that all reports are discoverable in a single location.
  */
 const KIND_OUTPUT_DIR: Record<string, string> = {
-  'code.review':          '.codekin/outputs/code-reviews',
-  'security.audit':       '.codekin/outputs/security-audits',
-  'complexity.analysis':  '.codekin/outputs/complexity-reports',
-  'complexity.report':    '.codekin/outputs/complexity-reports',
-  'coverage.assessment':  '.codekin/outputs/coverage-assessments',
-  'coverage.analysis':    '.codekin/outputs/coverage-assessments',
-  'comment.assessment':   '.codekin/outputs/comment-assessments',
-  'dependency.health':    '.codekin/outputs/dependency-health',
+  'code.review':          '.codekin/reports/code-review',
+  'security.audit':       '.codekin/reports/security',
+  'complexity.analysis':  '.codekin/reports/complexity',
+  'complexity.report':    '.codekin/reports/complexity',
+  'coverage.assessment':  '.codekin/reports/coverage',
+  'coverage.analysis':    '.codekin/reports/coverage',
+  'comment.assessment':   '.codekin/reports/comments',
+  'dependency.health':    '.codekin/reports/dependencies',
 }
 
 /**
@@ -119,7 +120,8 @@ export function buildStepflowPrompt(
   const outputDir = KIND_OUTPUT_DIR[kind]
   if (outputDir) {
     const slug = req.repo.replace('/', '-')
-    const filename = `${slug}-${runId.slice(0, 8)}.md`
+    const date = new Date().toISOString().slice(0, 10)
+    const filename = `${date}_${slug}-${runId.slice(0, 8)}.md`
     lines.push('')
     lines.push('## Report Output')
     lines.push('')
@@ -128,7 +130,9 @@ export function buildStepflowPrompt(
     lines.push(`\`${outputDir}/${filename}\``)
     lines.push('')
     lines.push('The report should summarise findings, issues, and recommendations.')
-    lines.push('Commit this file along with any code changes.')
+    lines.push('')
+    lines.push('**Important**: Do NOT commit this report on the current branch. The workflow engine will')
+    lines.push('automatically commit and push it to the `codekin/reports` branch after your session completes.')
   }
 
   return lines.join('\n')

--- a/server/webhook-workspace.ts
+++ b/server/webhook-workspace.ts
@@ -1,5 +1,5 @@
-import { execFile } from 'child_process'
-import { existsSync, mkdirSync, rmSync } from 'fs'
+import { execFile, execFileSync } from 'child_process'
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs'
 import { homedir } from 'os'
 import { join, resolve } from 'path'
 import { promisify } from 'util'
@@ -187,6 +187,122 @@ export async function createWorkspace(
         console.warn(`[webhook-workspace] Failed to clean up partial workspace ${workspacePath}:`, cleanupErr)
       }
     }
+  }
+}
+
+/**
+ * Scan a workspace for report files under `.codekin/reports/` and commit them
+ * to the `codekin/reports` branch of origin.
+ *
+ * Uses the same worktree-based approach as the MD workflow engine's save_report
+ * step so that reports from both systems end up in the same place.  This must
+ * be called BEFORE cleanupWorkspace() so the workspace still exists.
+ *
+ * @param sessionId    - Session ID (used for log context and temp worktree naming).
+ * @param commitPrefix - Commit message prefix (e.g. "chore: code review").
+ */
+export function commitReportsFromWorkspace(
+  sessionId: string,
+  commitPrefix: string,
+): void {
+  const workspacePath = join(WORKSPACES_DIR, sessionId)
+  const reportsDir = join(workspacePath, '.codekin', 'reports')
+  if (!existsSync(reportsDir)) return
+
+  // Collect all .md report files
+  const reportFiles: { relativePath: string; content: string }[] = []
+  try {
+    for (const category of readdirSync(reportsDir)) {
+      const categoryDir = join(reportsDir, category)
+      let entries: string[]
+      try { entries = readdirSync(categoryDir) } catch { continue }
+      for (const file of entries) {
+        if (!file.endsWith('.md')) continue
+        const fullPath = join(categoryDir, file)
+        reportFiles.push({
+          relativePath: `.codekin/reports/${category}/${file}`,
+          content: readFileSync(fullPath, 'utf-8'),
+        })
+      }
+    }
+  } catch (err) {
+    console.warn(`[webhook-workspace] Failed to scan reports in ${workspacePath}:`, err)
+    return
+  }
+
+  if (reportFiles.length === 0) return
+
+  const REPORTS_BRANCH = 'codekin/reports'
+  const dateStr = new Date().toISOString().slice(0, 10)
+
+  try {
+    // Ensure the reports branch exists on origin (create from HEAD if needed)
+    try {
+      execFileSync('git', ['rev-parse', '--verify', `origin/${REPORTS_BRANCH}`], {
+        cwd: workspacePath, timeout: 5_000, stdio: 'pipe',
+      })
+    } catch {
+      // Remote branch doesn't exist — create it locally first
+      try {
+        execFileSync('git', ['branch', REPORTS_BRANCH], {
+          cwd: workspacePath, timeout: 5_000,
+        })
+      } catch {
+        // May already exist locally
+      }
+    }
+
+    // Fetch the reports branch so we have the latest
+    try {
+      execFileSync(
+        'git', ['fetch', 'origin', `${REPORTS_BRANCH}:${REPORTS_BRANCH}`],
+        { cwd: workspacePath, timeout: 30_000, stdio: 'pipe', env: GIT_AUTH_ENV },
+      )
+    } catch {
+      // Branch may not exist on remote yet — that's OK
+    }
+
+    // Create a temporary worktree on the reports branch
+    const wtDir = join(WORKSPACES_DIR, `.report-wt-${sessionId.slice(0, 12)}`)
+    try {
+      execFileSync('git', ['worktree', 'add', wtDir, REPORTS_BRANCH], {
+        cwd: workspacePath, timeout: 10_000,
+      })
+
+      // Copy each report file into the worktree
+      for (const report of reportFiles) {
+        const destPath = join(wtDir, report.relativePath)
+        const destDir = join(destPath, '..')
+        if (!existsSync(destDir)) mkdirSync(destDir, { recursive: true })
+        writeFileSync(destPath, report.content, 'utf-8')
+      }
+
+      // Stage, commit, push
+      execFileSync('git', ['add', '.codekin/reports'], { cwd: wtDir, timeout: 10_000 })
+      execFileSync(
+        'git', ['commit', '-m', `${commitPrefix} ${dateStr}`],
+        { cwd: wtDir, timeout: 15_000 },
+      )
+      console.log(`[webhook-workspace] Committed ${reportFiles.length} report(s) on ${REPORTS_BRANCH}`)
+
+      try {
+        execFileSync(
+          'git', ['push', 'origin', REPORTS_BRANCH],
+          { cwd: wtDir, timeout: 30_000, stdio: 'pipe', env: GIT_AUTH_ENV },
+        )
+        console.log(`[webhook-workspace] Pushed ${REPORTS_BRANCH} to origin`)
+      } catch (pushErr) {
+        console.warn(`[webhook-workspace] Could not push ${REPORTS_BRANCH}: ${pushErr}`)
+      }
+    } finally {
+      try {
+        execFileSync('git', ['worktree', 'remove', '--force', wtDir], {
+          cwd: workspacePath, timeout: 10_000,
+        })
+      } catch { /* best-effort cleanup */ }
+    }
+  } catch (err) {
+    console.warn(`[webhook-workspace] Could not commit reports from workspace ${sessionId}: ${err}`)
   }
 }
 


### PR DESCRIPTION
## Summary

- **Stepflow reports now use `.codekin/reports/`** instead of the gitignored `.codekin/outputs/` directory, with category names matching the orchestrator scanner
- **Added `commitReportsFromWorkspace()`** in `webhook-workspace.ts` — deterministically commits reports to the `codekin/reports` branch via git worktree before workspace cleanup, same approach as the MD workflow engine
- **Added missing report categories** (`commit-review`, `coverage`, `pr-review`) to the orchestrator scanner so all report types are discoverable
- **Removed `.codekin/outputs/`** from `.gitignore` (no longer used)

## Test plan

- [x] All 1600 tests pass
- [x] Lint passes (0 errors)
- [ ] Verify stepflow workflow reports appear on `codekin/reports` branch after session completes
- [ ] Verify orchestrator can discover reports from all categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)