### PR TITLE
fix: streamline Edit Workflow modal layout

### DIFF
--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -82,14 +82,14 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
       <div
-        className="w-[720px] max-h-[90vh] overflow-y-auto rounded-xl border border-neutral-7 bg-neutral-11 p-6 shadow-2xl"
+        className="w-[700px] max-h-[90vh] overflow-y-auto rounded-xl border border-neutral-7 bg-neutral-11 p-5 shadow-2xl"
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center justify-between mb-4">
           <div>
             <h2 className="text-[19px] font-semibold text-neutral-1">Edit Workflow</h2>
-            <div className="flex items-center gap-2 mt-1">
+            <div className="flex items-center gap-2 mt-0.5">
               <span className="text-[13px] text-neutral-4">{repoShortName}</span>
               <span className="text-neutral-7">·</span>
               <span className="text-[13px] text-neutral-4">{kindLabel(repo.kind ?? '')}</span>
@@ -100,28 +100,28 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
           </button>
         </div>
 
-        <form onSubmit={handleSubmit} className="space-y-5">
-          {/* Two-column layout: Workflow type | Schedule + Provider */}
-          <div className="grid grid-cols-2 gap-5">
+        <form onSubmit={handleSubmit} className="space-y-3.5">
+          {/* Two-column layout: Workflow type | Schedule */}
+          <div className="grid grid-cols-2 gap-4">
             {/* Left column — Workflow kind */}
             <div>
-              <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center justify-between mb-1.5">
                 <label className="text-[13px] font-medium text-neutral-3">Workflow type</label>
                 <CategoryBadge kind={form.kind} />
               </div>
-              <div className="grid grid-cols-2 gap-2">
+              <div className="grid grid-cols-2 gap-1.5">
                 {WORKFLOW_KINDS.map(k => (
                   <button
                     key={k.value}
                     type="button"
                     onClick={() => setForm(f => ({ ...f, kind: k.value }))}
-                    className={`rounded-lg border px-3 py-2.5 text-left transition-colors ${
+                    className={`rounded-md border px-2.5 py-1.5 text-left transition-colors ${
                       form.kind === k.value
                         ? 'border-accent-6 bg-accent-9/30 ring-1 ring-accent-6/30'
                         : 'border-neutral-7 bg-neutral-10 hover:border-neutral-6'
                     }`}
                   >
-                    <span className={`block text-[13px] font-medium ${
+                    <span className={`block text-[12px] font-medium leading-tight ${
                       form.kind === k.value ? 'text-accent-2' : 'text-neutral-2'
                     }`}>
                       {k.label}
@@ -131,31 +131,47 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
               </div>
             </div>
 
-            {/* Right column — Schedule + Provider */}
-            <div className="space-y-4">
+            {/* Right column — Schedule */}
+            <div>
               {/* Schedule — hidden for event-driven workflows */}
               {eventDriven ? (
-                <div className="rounded-lg border border-purple-700/40 bg-purple-900/20 px-4 py-3">
-                  <span className="text-[14px] font-medium text-purple-400">
+                <div className="rounded-lg border border-purple-700/40 bg-purple-900/20 px-3 py-2.5">
+                  <span className="text-[13px] font-medium text-purple-400">
                     {form.kind === 'pr-review' ? 'Trigger: On pull request' : 'Trigger: On commit'}
                   </span>
-                  <p className="text-[13px] text-neutral-4 mt-1">
+                  <p className="text-[12px] text-neutral-4 mt-0.5">
                     {form.kind === 'pr-review'
-                      ? 'Each PR will be reviewed automatically when opened, updated, or reopened. No schedule needed.'
-                      : 'Each commit will be reviewed automatically. No schedule needed.'}
+                      ? 'Runs automatically when PRs are opened or updated.'
+                      : 'Runs automatically on each commit.'}
                   </p>
                 </div>
               ) : (
                 <div>
-                  <label className="block text-[13px] font-medium text-neutral-3 mb-2">Time</label>
-                  <TimePicker
-                    hour={form.cronHour}
-                    minute={form.cronMinute}
-                    onChange={(h, m) => setForm(f => ({ ...f, cronHour: h, cronMinute: m }))}
-                    className="mb-3"
-                  />
-                  <label className="block text-[13px] font-medium text-neutral-3 mb-2">Frequency</label>
-                  <div className="flex flex-wrap gap-1.5 mb-2">
+                  <div className="flex items-center gap-3 mb-2.5">
+                    <div>
+                      <label className="block text-[13px] font-medium text-neutral-3 mb-1">Time</label>
+                      <TimePicker
+                        hour={form.cronHour}
+                        minute={form.cronMinute}
+                        onChange={(h, m) => setForm(f => ({ ...f, cronHour: h, cronMinute: m }))}
+                      />
+                    </div>
+                    {isDay && (
+                      <div>
+                        <label className="block text-[13px] font-medium text-neutral-3 mb-1">Repeat</label>
+                        <div className="flex gap-1">
+                          <button type="button" onClick={() => setForm(f => ({ ...f, cronDow: baseDow }))} className={btnClass(!biweekly)}>
+                            Weekly
+                          </button>
+                          <button type="button" onClick={() => setForm(f => ({ ...f, cronDow: `biweekly-${baseDow}` }))} className={btnClass(biweekly)}>
+                            Biweekly
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  <label className="block text-[13px] font-medium text-neutral-3 mb-1">Frequency</label>
+                  <div className="flex flex-wrap gap-1 mb-1.5">
                     {DAY_PRESETS.map(p => (
                       <button
                         key={p.dow}
@@ -167,7 +183,7 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
                       </button>
                     ))}
                   </div>
-                  <div className="flex flex-wrap gap-1.5">
+                  <div className="flex flex-wrap gap-1">
                     {DAY_INDIVIDUAL.map(p => (
                       <button
                         key={p.dow}
@@ -179,37 +195,27 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
                       </button>
                     ))}
                   </div>
-                  {isDay && (
-                    <div className="flex gap-1.5 mt-2">
-                      <button type="button" onClick={() => setForm(f => ({ ...f, cronDow: baseDow }))} className={btnClass(!biweekly)}>
-                        Every week
-                      </button>
-                      <button type="button" onClick={() => setForm(f => ({ ...f, cronDow: `biweekly-${baseDow}` }))} className={btnClass(biweekly)}>
-                        Every 2 weeks
-                      </button>
-                    </div>
-                  )}
-                  <div className="mt-2 text-[13px] text-neutral-5">
+                  <div className="mt-1 text-[12px] text-neutral-5">
                     {describeCron(buildCron(form.cronHour, form.cronDow, form.cronMinute))}
                   </div>
                 </div>
               )}
-
-              {/* Provider + Model selection */}
-              <ProviderModelSection
-                token={token}
-                workingDir={repo.repoPath}
-                provider={form.provider}
-                model={form.model}
-                onProviderChange={provider => setForm(f => ({ ...f, provider }))}
-                onModelChange={model => setForm(f => ({ ...f, model }))}
-              />
             </div>
           </div>
 
+          {/* Provider + Model — full width, compact row */}
+          <ProviderModelSection
+            token={token}
+            workingDir={repo.repoPath}
+            provider={form.provider}
+            model={form.model}
+            onProviderChange={provider => setForm(f => ({ ...f, provider }))}
+            onModelChange={model => setForm(f => ({ ...f, model }))}
+          />
+
           {/* Custom prompt — full width */}
           <div>
-            <label className="block text-[13px] font-medium text-neutral-3 mb-1.5">
+            <label className="block text-[13px] font-medium text-neutral-3 mb-1">
               Focus areas <span className="text-neutral-5 font-normal">(optional)</span>
             </label>
             <textarea
@@ -217,7 +223,7 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
               onChange={e => setForm(f => ({ ...f, customPrompt: e.target.value }))}
               rows={2}
               placeholder="e.g. Focus on the auth module and payment flows"
-              className="w-full rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[15px] text-neutral-1 placeholder-neutral-5 focus:border-accent-6 focus:outline-none resize-none"
+              className="w-full rounded-md border border-neutral-7 bg-neutral-10 px-3 py-2 text-[14px] text-neutral-1 placeholder-neutral-5 focus:border-accent-6 focus:outline-none resize-none"
             />
           </div>
 
@@ -229,14 +235,14 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 rounded-md border border-neutral-7 bg-neutral-10 py-2 text-[15px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
+              className="flex-1 rounded-md border border-neutral-7 bg-neutral-10 py-2 text-[14px] text-neutral-3 hover:bg-neutral-9 hover:text-neutral-1 transition-colors"
             >
               Cancel
             </button>
             <button
               type="submit"
               disabled={saving}
-              className="flex-1 rounded-md bg-primary-8 py-2 text-[15px] font-medium text-neutral-1 hover:bg-primary-7 disabled:opacity-50 transition-colors flex items-center justify-center gap-1.5"
+              className="flex-1 rounded-md bg-primary-8 py-2 text-[14px] font-medium text-neutral-1 hover:bg-primary-7 disabled:opacity-50 transition-colors flex items-center justify-center gap-1.5"
             >
               {saving ? (
                 <>

--- a/src/components/workflows/ProviderModelSection.tsx
+++ b/src/components/workflows/ProviderModelSection.tsx
@@ -71,12 +71,12 @@ export function ProviderModelSection({ token, workingDir, provider, model, onPro
   const isLoadingModels = provider === 'opencode' && loadingOcModels
 
   return (
-    <>
+    <div className="flex flex-wrap items-end gap-4">
       {/* Provider selector — only show when OpenCode is available */}
       {openCodeAvailable && (
         <div>
-          <label className="block text-[13px] font-medium text-neutral-3 mb-2">Provider</label>
-          <div className="flex gap-1.5">
+          <label className="block text-[13px] font-medium text-neutral-3 mb-1">Provider</label>
+          <div className="flex gap-1">
             <button
               type="button"
               onClick={() => handleProviderChange('claude')}
@@ -97,7 +97,7 @@ export function ProviderModelSection({ token, workingDir, provider, model, onPro
 
       {/* Model picker */}
       <div>
-        <label className="block text-[13px] font-medium text-neutral-3 mb-2">Model</label>
+        <label className="block text-[13px] font-medium text-neutral-3 mb-1">Model</label>
         <WorkflowModelPicker
           models={currentModels}
           selected={model}
@@ -105,6 +105,6 @@ export function ProviderModelSection({ token, workingDir, provider, model, onPro
           loading={isLoadingModels}
         />
       </div>
-    </>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Tightened spacing, padding, and font sizes throughout the modal for a more compact layout
- Moved Provider + Model selection to a single inline row below the two-column area
- Placed Time picker and Weekly/Biweekly repeat toggle on the same line
- Reduced workflow type button sizes for a denser grid

## Test plan
- [ ] Open Edit Workflow modal and verify compact layout
- [ ] Confirm workflow type selection still works
- [ ] Verify schedule controls (time, frequency, repeat) function correctly
- [ ] Check Provider/Model row renders inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)