### PR TITLE
fix: polish Edit Workflow modal UI

### DIFF
--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -8,7 +8,7 @@ import { IconX, IconLoader2 } from '@tabler/icons-react'
 import type { ReviewRepoConfig } from '../lib/workflowApi'
 import {
   WORKFLOW_KINDS, DAY_PRESETS, DAY_INDIVIDUAL, isBiweeklyDow,
-  buildCron, parseCron, describeCron, kindLabel, isEventDriven, EVENT_CRON,
+  buildCron, parseCron, describeCron, kindLabel, isEventDriven, EVENT_CRON, normalizeModel,
 } from '../lib/workflowHelpers'
 import type { CodingProvider } from '../types'
 import { CategoryBadge } from './WorkflowBadges'
@@ -43,7 +43,7 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
     cronMinute: parsed.minute,
     cronDow: parsed.dow,
     customPrompt: repo.customPrompt ?? '',
-    model: repo.model ?? '',
+    model: normalizeModel(repo.model),
     provider: inferredProvider,
   })
   const [saving, setSaving] = useState(false)
@@ -172,18 +172,23 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
                   </div>
                   <label className="block text-[13px] font-medium text-neutral-3 mb-1">Frequency</label>
                   <div className="flex flex-wrap gap-1 mb-1.5">
-                    {DAY_PRESETS.map(p => (
-                      <button
-                        key={p.dow}
-                        type="button"
-                        onClick={() => setForm(f => ({ ...f, cronDow: p.dow }))}
-                        className={btnClass(form.cronDow === p.dow)}
-                      >
-                        {p.label}
-                      </button>
-                    ))}
+                    {DAY_PRESETS.map(p => {
+                      const isActive = form.cronDow === p.dow
+                        || (p.dow === '*' && isDay)
+                        || (p.dow === '1-5' && isDay && Number(baseDow) >= 1 && Number(baseDow) <= 5)
+                      return (
+                        <button
+                          key={p.dow}
+                          type="button"
+                          onClick={() => setForm(f => ({ ...f, cronDow: p.dow }))}
+                          className={btnClass(isActive)}
+                        >
+                          {p.label}
+                        </button>
+                      )
+                    })}
                   </div>
-                  <div className="flex flex-wrap gap-1">
+                  <div className="grid grid-cols-7 gap-1">
                     {DAY_INDIVIDUAL.map(p => (
                       <button
                         key={p.dow}

--- a/src/lib/workflowHelpers.ts
+++ b/src/lib/workflowHelpers.ts
@@ -44,6 +44,15 @@ export const MODEL_OPTIONS = [
   { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]
 
+/** Model IDs that map to the default (Opus). Stored explicitly by some configs but equivalent to empty. */
+const DEFAULT_MODEL_IDS = new Set(['claude-opus-4-6', 'claude-opus-4-5-20250918'])
+
+/** Normalize a model value: known Opus model IDs → empty string (server default). */
+export function normalizeModel(model: string | undefined): string {
+  if (!model) return ''
+  return DEFAULT_MODEL_IDS.has(model) ? '' : model
+}
+
 /** Cron day-of-week presets (Daily, Weekdays) for the schedule picker. `dow` is the cron field value. */
 export const DAY_PRESETS = [
   { label: 'Daily', dow: '*' },


### PR DESCRIPTION
## Summary
- Highlight **Weekdays** preset when an individual weekday (Mon-Fri) is selected, and **Daily** when any individual day is selected
- Use 7-column grid for day-of-week buttons so **Sunday stays on the same row** as Mon-Sat
- Normalize Opus model IDs (`claude-opus-4-6`) to empty string on load so **Default (Opus) is pre-selected**

## Test plan
- [ ] Open Edit Workflow modal, select Tue → verify Weekdays and Daily are highlighted
- [ ] Select Sat → verify only Daily is highlighted (not Weekdays)
- [ ] Verify all 7 day buttons (Mon-Sun) are on a single row
- [ ] Open a workflow that has model set to `claude-opus-4-6` → verify "Default (Opus)" button is highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)