### PR TITLE
fix: polish Edit Workflow modal - frequency highlights, day grid, model default

### DIFF
--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -174,7 +174,6 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
                   <div className="flex flex-wrap gap-1 mb-1.5">
                     {DAY_PRESETS.map(p => {
                       const isActive = form.cronDow === p.dow
-                        || (p.dow === '*' && isDay)
                         || (p.dow === '1-5' && isDay && Number(baseDow) >= 1 && Number(baseDow) <= 5)
                       return (
                         <button
@@ -188,7 +187,7 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
                       )
                     })}
                   </div>
-                  <div className="grid grid-cols-7 gap-1">
+                  <div className="flex gap-1">
                     {DAY_INDIVIDUAL.map(p => (
                       <button
                         key={p.dow}

--- a/src/components/workflows/ProviderModelSection.tsx
+++ b/src/components/workflows/ProviderModelSection.tsx
@@ -59,12 +59,13 @@ export function ProviderModelSection({ token, workingDir, provider, model, onPro
     return () => { cancelled = true }
   }, [token, workingDir])
 
-  // When switching provider, reset model to default if current model doesn't belong to new provider
+  // When switching provider, select a sensible default for the new provider
   const handleProviderChange = (newProvider: CodingProvider) => {
     if (newProvider === provider) return
     onProviderChange(newProvider)
-    // Reset model — the current model likely doesn't exist in the other provider
-    onModelChange('')
+    // Pick the first model from the new provider's list ('' = Default Opus for Claude)
+    const newModels = newProvider === 'opencode' ? openCodeModels : CLAUDE_WORKFLOW_MODELS
+    onModelChange(newModels[0]?.id ?? '')
   }
 
   const currentModels: ModelOption[] = provider === 'opencode' ? openCodeModels : CLAUDE_WORKFLOW_MODELS


### PR DESCRIPTION
## Summary
- Only highlight **Weekdays** preset when a weekday is selected — no longer highlights **Daily** too
- Use `flex` layout for day-of-week buttons instead of `grid-cols-7` to fix uneven button sizing
- Auto-select first available OpenCode model when switching provider (instead of resetting to empty)

## Test plan
- [ ] Select Wed → verify only Weekdays is highlighted, not Daily
- [ ] Select Sat → verify neither preset is highlighted
- [ ] Verify Mon-Sun buttons have natural, even sizing on one row
- [ ] Switch provider to OpenCode → verify first model is auto-selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)