### PR TITLE
fix: diagnose first-message-lost bug with lifecycle logging

### DIFF
--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -65,6 +65,8 @@ export class SessionLifecycle {
     const session = this.deps.getSession(sessionId)
     if (!session) return false
 
+    console.log(`[startClaude] session=${sessionId} model=${session.model} resume=${!!session.claudeSessionId} existingProcess=${!!session.claudeProcess} caller=${new Error().stack?.split('\n')[2]?.trim()}`)
+
     // Clear stopped flag and any pending restart timer on explicit start
     session._stoppedByUser = false
     if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -917,6 +917,7 @@ export class SessionManager {
   }
 
   private onSystemInit(cp: CodingProcess, session: Session, model: string): void {
+    console.log(`[onSystemInit] session=${session.id} model=${model} prevModel=${session._lastReportedModel ?? 'null'} claudeSessionId=${cp.getSessionId()}`)
     session.claudeSessionId = cp.getSessionId()
     const previousModel = session._lastReportedModel
     session._lastReportedModel = model
@@ -960,6 +961,7 @@ export class SessionManager {
    * session naming on first completed turn.
    */
   private handleClaudeResult(session: Session, sessionId: string, result: string, isError: boolean): void {
+    console.log(`[handleClaudeResult] session=${sessionId} isError=${isError} resultLen=${result.length} result=${result.slice(0, 100)}`)
     session.isProcessing = false
     session._claudeTurnCount++
     this._globalBroadcast?.({ type: 'sessions_updated' })
@@ -1126,6 +1128,8 @@ export class SessionManager {
     session._stoppedByUser = false
     session.coordinator.clearUserStopped()
 
+    console.log(`[sendInput] session=${sessionId} processAlive=${session.claudeProcess?.isAlive() ?? 'no-process'} model=${session.model} claudeSessionId=${session.claudeSessionId ?? 'null'} data=${data.slice(0, 80)}`)
+
     // --- Phase 1: ensure process is alive ---
     if (!session.claudeProcess?.isAlive()) {
       // Race guard: prevent concurrent startClaude calls when multiple sendInput
@@ -1172,13 +1176,17 @@ export class SessionManager {
     }
 
     // --- Phase 3: send, waiting for readiness if needed ---
+    console.log(`[sendInput] phase3 session=${sessionId} isReady=${session.claudeProcess?.isReady() ?? 'no-process'} messageLen=${messageToSend.length}`)
     if (session.claudeProcess && !session.claudeProcess.isReady()) {
+      console.log(`[sendInput] waiting for ready session=${sessionId}`)
       void this.waitForReady(sessionId).then((ready) => {
+        console.log(`[sendInput] waitForReady resolved session=${sessionId} ready=${ready}`)
         if (ready) session.claudeProcess?.sendMessage(messageToSend)
         // If not ready (process exited), message stays in _lastUserInput
         // and will be re-sent on auto-restart
       })
     } else {
+      console.log(`[sendInput] sending immediately session=${sessionId}`)
       session.claudeProcess?.sendMessage(messageToSend)
     }
   }
@@ -1228,6 +1236,7 @@ export class SessionManager {
     const session = this.sessions.get(sessionId)
     if (!session) return false
     const newModel = model || undefined
+    console.log(`[setModel] session=${sessionId} currentModel=${session.model} newModel=${newModel} processAlive=${session.claudeProcess?.isAlive() ?? 'no-process'} willReconfigure=${session.model !== newModel && !!session.claudeProcess?.isAlive()}`)
     if (session.model === newModel) return true
     if (session.claudeProcess?.isAlive()) {
       void session.coordinator.requestReconfigure(() => {


### PR DESCRIPTION
## Summary
- Adds targeted debug logging to trace the first-message-lost bug where users need to send their first message twice to get a response
- Logs cover: `sendInput` phases, `startClaude` calls (with caller stack), `onSystemInit`, `handleClaudeResult`, and `setModel` (including reconfigure detection)
- Suspected root cause: `create_session` omits model → useEffect fires `set_model` → triggers `requestReconfigure()` which kills the first process mid-flight

## Test plan
- [ ] Deploy with this logging
- [ ] Create a new session and send a message
- [ ] Check pm2 logs for the `[sendInput]`, `[startClaude]`, `[setModel]` sequence
- [ ] Confirm whether `setModel` triggers a reconfigure race that kills the first process

🤖 Generated with [Claude Code](https://claude.com/claude-code)