### PR TITLE
fix: prevent first message lost on new session

### DIFF
--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -65,7 +65,6 @@ export class SessionLifecycle {
     const session = this.deps.getSession(sessionId)
     if (!session) return false
 
-    console.log(`[startClaude] session=${sessionId} model=${session.model} resume=${!!session.claudeSessionId} existingProcess=${!!session.claudeProcess} caller=${new Error().stack?.split('\n')[2]?.trim()}`)
 
     // Clear stopped flag and any pending restart timer on explicit start
     session._stoppedByUser = false

--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -2799,8 +2799,8 @@ describe('SessionManager', () => {
       expect(s.model).toBeUndefined()
     })
 
-    it('restarts Claude when process is alive', async () => {
-      const s = sm.create('test', '/tmp')
+    it('restarts Claude when process is alive and model is changing', async () => {
+      const s = sm.create('test', '/tmp', { model: 'opus' })
       const cp = fakeClaudeProcess(true)
       s.claudeProcess = cp
 
@@ -2816,6 +2816,23 @@ describe('SessionManager', () => {
       // Verify the callback sets the model
       const applyFn = reconfigSpy.mock.calls[0][0]
       applyFn()
+      expect(s.model).toBe('sonnet')
+
+      reconfigSpy.mockRestore()
+    })
+
+    it('does NOT reconfigure when model was previously undefined (initial assignment)', () => {
+      const s = sm.create('test', '/tmp')
+      const cp = fakeClaudeProcess(true)
+      s.claudeProcess = cp
+
+      const reconfigSpy = vi.spyOn(s.coordinator, 'requestReconfigure')
+        .mockResolvedValue(true)
+
+      sm.setModel(s.id, 'sonnet')
+
+      // Should just assign without reconfiguring
+      expect(reconfigSpy).not.toHaveBeenCalled()
       expect(s.model).toBe('sonnet')
 
       reconfigSpy.mockRestore()

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -917,7 +917,6 @@ export class SessionManager {
   }
 
   private onSystemInit(cp: CodingProcess, session: Session, model: string): void {
-    console.log(`[onSystemInit] session=${session.id} model=${model} prevModel=${session._lastReportedModel ?? 'null'} claudeSessionId=${cp.getSessionId()}`)
     session.claudeSessionId = cp.getSessionId()
     const previousModel = session._lastReportedModel
     session._lastReportedModel = model
@@ -961,7 +960,6 @@ export class SessionManager {
    * session naming on first completed turn.
    */
   private handleClaudeResult(session: Session, sessionId: string, result: string, isError: boolean): void {
-    console.log(`[handleClaudeResult] session=${sessionId} isError=${isError} resultLen=${result.length} result=${result.slice(0, 100)}`)
     session.isProcessing = false
     session._claudeTurnCount++
     this._globalBroadcast?.({ type: 'sessions_updated' })
@@ -1128,8 +1126,6 @@ export class SessionManager {
     session._stoppedByUser = false
     session.coordinator.clearUserStopped()
 
-    console.log(`[sendInput] session=${sessionId} processAlive=${session.claudeProcess?.isAlive() ?? 'no-process'} model=${session.model} claudeSessionId=${session.claudeSessionId ?? 'null'} data=${data.slice(0, 80)}`)
-
     // --- Phase 1: ensure process is alive ---
     if (!session.claudeProcess?.isAlive()) {
       // Race guard: prevent concurrent startClaude calls when multiple sendInput
@@ -1176,17 +1172,13 @@ export class SessionManager {
     }
 
     // --- Phase 3: send, waiting for readiness if needed ---
-    console.log(`[sendInput] phase3 session=${sessionId} isReady=${session.claudeProcess?.isReady() ?? 'no-process'} messageLen=${messageToSend.length}`)
     if (session.claudeProcess && !session.claudeProcess.isReady()) {
-      console.log(`[sendInput] waiting for ready session=${sessionId}`)
       void this.waitForReady(sessionId).then((ready) => {
-        console.log(`[sendInput] waitForReady resolved session=${sessionId} ready=${ready}`)
         if (ready) session.claudeProcess?.sendMessage(messageToSend)
         // If not ready (process exited), message stays in _lastUserInput
         // and will be re-sent on auto-restart
       })
     } else {
-      console.log(`[sendInput] sending immediately session=${sessionId}`)
       session.claudeProcess?.sendMessage(messageToSend)
     }
   }
@@ -1236,16 +1228,18 @@ export class SessionManager {
     const session = this.sessions.get(sessionId)
     if (!session) return false
     const newModel = model || undefined
-    console.log(`[setModel] session=${sessionId} currentModel=${session.model} newModel=${newModel} processAlive=${session.claudeProcess?.isAlive() ?? 'no-process'} willReconfigure=${session.model !== newModel && !!session.claudeProcess?.isAlive()}`)
     if (session.model === newModel) return true
-    if (session.claudeProcess?.isAlive()) {
+    // When the session had no model set (e.g. just created), simply assign it
+    // without reconfiguring — the running process already defaults to this model
+    // and killing it mid-turn causes the first user message to be lost.
+    if (!session.model || !session.claudeProcess?.isAlive()) {
+      session.model = newModel
+      this.persistToDiskDebounced()
+    } else {
       void session.coordinator.requestReconfigure(() => {
         session.model = newModel
         this.persistToDiskDebounced()
       })
-    } else {
-      session.model = newModel
-      this.persistToDiskDebounced()
     }
     return true
   }


### PR DESCRIPTION
## Summary

- **Root cause found**: When a session is created without a model (default), `setModel` is called by the frontend's model validation effect after `onSystemInit` reports the actual model. `setModel` saw `undefined !== claude-opus-4-6` and triggered `requestReconfigure`, which **kills the Claude process mid-turn** — losing the first user message.
- **Fix**: Skip reconfigure in `setModel` when `session.model` is `undefined` — this is an initial assignment, not a model change. Just assign the model directly.
- Removes debug lifecycle logging from #406 (no longer needed).

## Debug log evidence

```
[startClaude]    model=undefined resume=false
[sendInput]      model=undefined data=hello
[sendInput]      sending immediately
[onSystemInit]   model=claude-opus-4-6 prevModel=null
[setModel]       currentModel=undefined newModel=claude-opus-4-6 willReconfigure=true  ← BUG
[startClaude]    model=claude-opus-4-6 resume=true                                     ← kills process
```

## Test plan

- [x] All 1639 tests pass
- [ ] Create new session, send first message — should not be swallowed
- [ ] Verify model switch (e.g. opus → sonnet) still triggers reconfigure correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)