### PR TITLE
fix: widen Edit Workflow modal to fit day labels

### DIFF
--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -82,7 +82,7 @@ export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" onClick={onClose}>
       <div
-        className="w-[700px] max-h-[90vh] overflow-y-auto rounded-xl border border-neutral-7 bg-neutral-11 p-5 shadow-2xl"
+        className="w-[740px] max-h-[90vh] overflow-y-auto rounded-xl border border-neutral-7 bg-neutral-11 p-5 shadow-2xl"
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}


### PR DESCRIPTION
## Summary
- Bumps modal width from 700px to 740px so 'Sun' label is no longer clipped

## Test plan
- [ ] Open Edit Workflow modal and verify all day labels (Mon–Sun) are fully visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)