### PR TITLE
fix: harden docs browser scope and persist canonical paths

### DIFF
--- a/server/docs-routes.ts
+++ b/server/docs-routes.ts
@@ -13,7 +13,6 @@ import { Router } from 'express'
 import type { Request } from 'express'
 import { readFileSync, readdirSync, statSync, realpathSync } from 'fs'
 import { join, resolve, relative, extname } from 'path'
-import { homedir } from 'os'
 import { REPOS_ROOT } from './config.js'
 
 type VerifyFn = (token: string | undefined) => boolean
@@ -106,9 +105,8 @@ export function createDocsRouter(
       return res.status(404).json({ error: 'Repo not found' })
     }
 
-    // Boundary check: restrict to allowed roots (home dir and REPOS_ROOT)
-    const home = homedir()
-    const allowedRoots = [home, REPOS_ROOT]
+    // Boundary check: restrict to REPOS_ROOT only (not arbitrary home-dir paths)
+    const allowedRoots = [REPOS_ROOT]
     const realRepo = realpathSync(resolve(repoPath))
     if (!allowedRoots.some(root => realRepo.startsWith(root + '/') || realRepo === root)) {
       return res.status(403).json({ error: 'Access denied' })
@@ -151,9 +149,8 @@ export function createDocsRouter(
       return res.status(400).json({ error: 'Missing repo or file query parameter' })
     }
 
-    // Boundary check: restrict to allowed roots (home dir and REPOS_ROOT)
-    const home = homedir()
-    const allowedRoots = [home, REPOS_ROOT]
+    // Boundary check: restrict to REPOS_ROOT only (not arbitrary home-dir paths)
+    const allowedRoots = [REPOS_ROOT]
     try {
       const realRepo = realpathSync(resolve(repoPath))
       if (!allowedRoots.some(root => realRepo.startsWith(root + '/') || realRepo === root)) {

--- a/server/session-routes.ts
+++ b/server/session-routes.ts
@@ -98,7 +98,7 @@ export function createSessionRouter(
     if (provider && !VALID_PROVIDERS.has(provider)) {
       return res.status(400).json({ error: `Invalid provider: ${provider}. Must be one of: ${[...VALID_PROVIDERS].join(', ')}` })
     }
-    const session = sessions.create(name, workingDir, { provider, model, permissionMode })
+    const session = sessions.create(name, resolvedDir, { provider, model, permissionMode })
     res.json({
       sessionId: session.id,
       session: {


### PR DESCRIPTION
## Summary

- **Fix canonical path persistence in session-routes.ts**: `sessions.create()` now receives `resolvedDir` (the realpath-resolved canonical path) instead of the raw user-supplied `workingDir`. This prevents symlink retargets from escaping the validated directory after session creation.

- **Restrict docs browser root scope in docs-routes.ts**: Both `/api/docs` and `/api/docs/file` endpoints now restrict allowed roots to `REPOS_ROOT` only, removing `homedir()` from the boundary check. This prevents reading arbitrary markdown files under the home directory on token compromise.

- **Debug console.logs from PR #406**: Already removed by PR #407 — no additional changes needed.

## Test plan
- [x] All 1639 tests pass
- [x] TypeScript build succeeds
- [ ] Verify docs browser still loads markdown from repos under REPOS_ROOT
- [ ] Verify session creation with symlinked paths persists the resolved path

🤖 Generated with [Claude Code](https://claude.com/claude-code)