### PR TITLE
docs: weekly repo health report + accumulated audit reports (2026-04-15)

### DIFF
--- a/.codekin/reports/code-review/2026-04-13_code-review-daily.md
+++ b/.codekin/reports/code-review/2026-04-13_code-review-daily.md
@@ -1,0 +1,90 @@
+# Daily Code Review: codekin
+
+**Date**: 2026-04-13T04:02:16.616Z
+**Repository**: /srv/repos/codekin
+**Branch**: feat/test-coverage-2026-04-13
+**Workflow Run**: 19566ea4-1f3c-4c23-b2a7-99726ba81c38
+**Session**: 3b6b3882-25c4-4576-852f-e764bc8169aa
+
+---
+
+Completed. I reviewed the structure, last 7 days of history, and critical runtime files, and saved the full report here:
+
+```text
+.codekin/reports/code-review/2026-04-13_code-review-daily.md
+```
+
+### 1) Project structure & architecture (quick assessment)
+- **Frontend:** React + Vite (`src/`)
+- **Backend:** Express + WebSocket (`server/`)
+- **Session core:** `server/session-manager.ts` + `server/session-lifecycle.ts`
+- **Provider abstraction:** Claude/OpenCode via coding-process layer
+- **Transport/UI state:** `src/hooks/useChatSocket.ts`
+- Overall architecture is sound, but complexity is concentrated in very large files:
+  - `server/session-manager.ts` (~1591 LOC)
+  - `server/opencode-process.ts` (~982 LOC)
+  - `server/ws-server.ts` (~662 LOC)
+
+### 2) Last 7 days git log (themes)
+Recent commits heavily focused on:
+- **Security hardening** (path traversal, ws origin/CSP/rate limits)
+- **Session reliability** (restart races, startup deadlocks, state persistence)
+- **OpenCode integration quality** (model/session handling, streaming fixes)
+- **Workflow/webhook features** (GitHub webhook setup + PR review flow)
+- **Test/report automation** (new tests + recurring reports)
+
+### 3) Findings by severity
+
+## Critical
+- **None found** in this pass.
+
+## Warning
+
+1. **Potential memory amplification in API limiter map**
+   - **File:** `server/ws-server.ts`
+   - **Lines:** 268–279, 281–294
+   - `apiRateBuckets` has cleanup but no hard max size (unlike WS limiter map). High-cardinality IP churn can grow memory.
+   - **Action:** Add max-cap + eviction/deny strategy.
+
+2. **Large synchronous attachment reads can block event loop / spike memory**
+   - **File:** `server/opencode-process.ts`
+   - **Lines:** 885, 889, 891–892
+   - `readFileSync` is used for full image/text attachment payloads without explicit size cap in this layer.
+   - **Action:** enforce per-file size limits and reject oversized files early.
+
+3. **Weak request-body typing/validation at route boundaries**
+   - **File:** `server/session-routes.ts`
+   - **Lines:** 79, 97–101, 358, 382, 439, 471 (and others)
+   - Extensive unsafe `req.body` usage; lint flags many `no-unsafe-*` issues.
+   - **Action:** add schema validation (zod/valibot) for all request payloads.
+
+4. **Synchronous recursive docs scan in request path**
+   - **File:** `server/docs-routes.ts`
+   - **Lines:** 41–73, 93–140
+   - Sync FS traversal can cause latency spikes on large repos.
+   - **Action:** add caching and traversal limits / async scan.
+
+5. **Coverage gap in critical route modules**
+   - No direct tests found for:
+     - `server/ws-server.ts`
+     - `server/session-routes.ts`
+     - `server/docs-routes.ts`
+   - **Action:** add focused auth/path/rate-limit tests for these endpoints.
+
+## Info
+
+1. **Quality debt from lint warnings in backend**
+   - `npm run lint` passes but with many warnings in core server files, especially unsafe assignments/arguments.
+   - High-signal files: `server/session-routes.ts`, `server/orchestrator-routes.ts`, `server/opencode-process.ts`, `server/claude-process.ts`.
+
+2. **Dependency freshness**
+   - `npm audit --omit=dev`: **0 vulnerabilities** (root + server)
+   - `npm outdated`:
+     - Root: `better-sqlite3` behind latest
+     - Server: `better-sqlite3`, `ws` behind latest
+   - **Action:** patch-update with regression run.
+
+3. **Test status**
+   - `npm test`: **59 files, 1600 tests, all passing**
+
+If you want, I can next produce a prioritized fix plan (top 3 changes with estimated effort/risk).

--- a/.codekin/reports/code-review/2026-04-14_code-review-daily.md
+++ b/.codekin/reports/code-review/2026-04-14_code-review-daily.md
@@ -1,0 +1,110 @@
+# Daily Code Review: codekin
+
+**Date**: 2026-04-14T04:02:37.690Z
+**Repository**: /srv/repos/codekin
+**Branch**: main
+**Workflow Run**: 8d40c9f1-241e-4e29-a6d1-eef65993664a
+**Session**: f5fabdb0-198c-49f8-a8d4-ba5dccc67a2b
+
+---
+
+Here’s the daily automated code review for `codekin`.
+
+## 1) Project structure & architecture (quick assessment)
+
+- **Frontend**: React/Vite (`src/`) with focused components + hooks architecture.
+- **Backend**: Node/Express + `ws` (`server/`) acting as:
+  - REST API gateway
+  - WebSocket transport
+  - session/process lifecycle manager for Claude/OpenCode
+  - webhook/workflow automation engine
+- **Design strength**: good modular decomposition in server (`session-lifecycle.ts`, `process-coordinator.ts`, route-level modules, handler base classes).
+- **Current risk concentration**: lifecycle/process orchestration and webhook/workflow automation paths (high complexity + high churn).
+
+## 2) Last 7 days of git activity (trend review)
+
+Major themes from `git log --since='7 days ago'`:
+- Heavy reliability/security work in:
+  - `server/session-manager.ts`
+  - `server/session-lifecycle.ts`
+  - `server/opencode-process.ts`
+  - `server/ws-server.ts`
+  - `server/webhook-*`
+- UI churn around workflow editing:
+  - `src/components/EditWorkflowModal.tsx`
+- Frequent hot files (count from recent history):
+  - `server/session-manager.ts` (27)
+  - `server/session-lifecycle.ts` (13)
+  - `server/opencode-process.ts` (11)
+  - `server/claude-process.ts` (11)
+  - `server/ws-server.ts` (9)
+
+Interpretation: project is actively improving, but these high-churn core files are the most regression-prone.
+
+---
+
+## 3) Findings by severity
+
+## Critical
+- **No critical issues confirmed** in this pass.
+
+## Warning
+
+1. **Canonical path validated but non-canonical path persisted (possible symlink-retarget escape)**
+   - **File**: `server/session-routes.ts`
+   - **Lines**: `84-95`, `101`
+   - **Issue**: `workingDir` is validated via `realpathSync(...)` (`resolvedDir`) but `sessions.create(...)` stores the original user-supplied `workingDir`.
+   - **Risk**: if a symlink path is accepted and later retargeted, subsequent process operations may execute outside the originally validated location.
+   - **Action**: persist `resolvedDir` instead of raw `workingDir`; optionally re-validate/canonicalize before each process start.
+
+2. **Docs browser can read markdown anywhere under home directory**
+   - **File**: `server/docs-routes.ts`
+   - **Lines**: `109-115`, `154-160`
+   - **Issue**: allowed roots include both `homedir()` and `REPOS_ROOT`.
+   - **Risk**: with token compromise, attacker can read arbitrary `*.md` under user home (notes, credentials docs, internal runbooks).
+   - **Action**: default to `REPOS_ROOT` only; optionally add explicit allowlist per configured repo path.
+
+3. **Coverage gaps in security/automation-critical server modules**
+   - **Files**:
+     - `server/workflow-routes.ts` (~1.53% statements covered)
+     - `server/webhook-handler.ts` (~50%)
+     - `server/webhook-workspace.ts` (~46.55%)
+   - **Evidence**: `npx vitest run --coverage`
+   - **Risk**: regressions likely in webhook setup, commit-event, and repo-mutating automation flows.
+   - **Action**: prioritize integration tests for:
+     - webhook setup/update/test endpoints
+     - commit-event auth + payload validation
+     - report branch/worktree commit/push paths
+
+## Info
+
+1. **Auth verification endpoint acts as token-validity oracle**
+   - **File**: `server/auth-routes.ts`
+   - **Lines**: `67-70`
+   - **Note**: rate-limited (good), but endpoint still gives explicit valid/invalid signal.
+   - **Suggestion**: consider generic response + stronger per-IP/account lockout behavior if exposed broadly.
+
+2. **Configuration docs lag security-relevant env vars**
+   - **Files**:
+     - `README.md` lines `95-99` (very minimal env var table)
+     - `server/config.ts` lines `22-33`, `95`, etc. (enforces `CORS_ORIGIN`, `TRUST_PROXY`, auth file behavior)
+   - **Gap**: runtime-critical security/network vars are under-documented.
+   - **Action**: expand README config matrix to include `AUTH_TOKEN[_FILE]`, `CORS_ORIGIN`, `TRUST_PROXY`, `DATA_DIR`, webhook envs.
+
+3. **Dependency health currently good**
+   - **Evidence**: `npm audit --json` shows **0 vulnerabilities** (prod + dev).
+   - **Action**: keep weekly audit in CI; no immediate dependency remediation needed.
+
+4. **Test suite health is strong overall**
+   - **Evidence**: `npm test` -> **60 files, 1639 tests, all passing**.
+   - **Action**: keep this baseline, but shift new test effort to low-coverage critical modules above.
+
+---
+
+## Recommended next actions (priority order)
+
+1. Fix canonical-path persistence in session creation (`session-routes.ts`).
+2. Restrict docs browsing root scope (or add explicit repo allowlist mode).
+3. Add targeted tests for `workflow-routes`, `webhook-handler`, `webhook-workspace`.
+4. Update README config documentation for security/runtime env vars.
+

--- a/.codekin/reports/code-review/2026-04-15_code-review-daily.md
+++ b/.codekin/reports/code-review/2026-04-15_code-review-daily.md
@@ -1,0 +1,86 @@
+# Daily Code Review: codekin
+
+**Date**: 2026-04-15T04:04:37.574Z
+**Repository**: /srv/repos/codekin
+**Branch**: feat/repo-health-2026-04-15
+**Workflow Run**: ffafb31c-88fa-458d-aa6b-ee2c690bc33f
+**Session**: b569a695-0945-4b08-a381-1752564c1449
+
+---
+
+Completed. I also saved the full daily report to:
+
+```text
+.codekin/reports/code-review/2026-04-15_code-review-daily.md
+```
+
+## 1) Project structure & architecture (quick assessment)
+
+- **Frontend:** `src/` (React + Vite + Tailwind), clear split between UI (`src/components/*`) and behavior hooks (`src/hooks/*`).
+- **Backend:** `server/` (Express + ws), modular routers + dedicated lifecycle/process modules (`session-manager.ts`, `session-lifecycle.ts`, `process-coordinator.ts`).
+- **Automation:** webhook/workflow stack (`webhook-*.ts`, `workflow-*.ts`, `commit-event-*.ts`) handles scheduled audits, CI, and PR automation.
+- **Risk concentration:** high in lifecycle + webhook/workflow modules due to complexity + high recent churn.
+
+## 2) Last 7 days of git activity
+
+Recent history is heavily focused on reliability/security hardening and OpenCode/session lifecycle fixes.
+
+Most frequently changed files (7d):
+1. `server/session-manager.ts` (26)
+2. `server/session-manager.test.ts` (14)
+3. `server/session-lifecycle.ts` (13)
+4. `server/claude-process.ts` (12)
+5. `server/opencode-process.ts` (11)
+6. `server/ws-server.ts` (9)
+
+## 3) Findings by severity
+
+### Critical
+- No confirmed critical issues in this pass.
+
+### Warning
+
+1. **CORS allow-methods don’t match API usage**
+   - `server/ws-server.ts:319`
+   - Allows `GET, POST, DELETE, OPTIONS` but API uses `PUT/PATCH` too.
+   - **Action:** add `PUT, PATCH` (and optionally `HEAD`) to `Access-Control-Allow-Methods`.
+
+2. **`repos_path` is validated expanded but stored raw**
+   - `server/session-routes.ts:318-324`
+   - Used downstream in `server/upload-routes.ts:151-157,299`
+   - `~/...` can validate but later break clone/list path handling.
+   - **Action:** persist canonical expanded (ideally realpath) value.
+
+3. **Docs listing may follow symlinked dirs outside repo boundary**
+   - `server/docs-routes.ts:56-63,115`
+   - Recursive listing uses `statSync` and follows symlink dirs without boundary check on descent.
+   - **Action:** use `lstatSync` and skip symlink directories, or enforce `realpath` boundary on each walk step.
+
+4. **Auth rate limiter map has no hard cap**
+   - `server/auth-routes.ts:13-24,27-33`
+   - Could grow under high-cardinality IP traffic.
+   - **Action:** cap map size / LRU eviction (similar to `ws-server.ts` limiter pattern).
+
+5. **WebSocket create-session validates canonical path but stores raw path**
+   - `server/ws-message-handler.ts:37,51`
+   - `resolvedDir` is checked; `sessions.create` still uses `msg.workingDir`.
+   - **Action:** pass `resolvedDir` for canonical consistency.
+
+### Info
+
+1. **Tests pass**
+   - `npm test`: 60 files, 1639 tests, all passing.
+
+2. **Coverage is decent overall, but weak in key automation areas**
+   - Overall (`coverage/index.html`): Statements 77.3%, Branches 69.69%, Functions 75.41%, Lines 78.45%.
+   - Low-coverage hot spots (`coverage/server/index.html`): `commit-event-hooks.ts`, `opencode-process.ts`, `webhook-workspace.ts`, `workflow-routes.ts`.
+   - **Action:** prioritize tests for webhook/workflow/report-commit flows and OpenCode lifecycle edges.
+
+3. **Dependencies are clean**
+   - `npm audit` (prod+dev): 0 vulnerabilities.
+
+4. **Lint debt remains large**
+   - `npm run lint` reports many warnings, including generated `coverage/*`.
+   - **Action:** ignore `coverage/` in ESLint config and then reduce high-signal runtime warnings.
+
+If you want, I can now convert the top 3 warnings into a concrete patch plan (or implement fixes directly).

--- a/.codekin/reports/complexity/2026-04-15_complexity-analysis.md
+++ b/.codekin/reports/complexity/2026-04-15_complexity-analysis.md
@@ -1,0 +1,180 @@
+# Code Complexity Analysis — 2026-04-15
+
+## Summary
+
+**Overall Complexity Rating: Medium-High**
+
+The codebase is a mature, well-structured TypeScript monorepo (~56,700 lines across 765 source files, excluding test files and worktrees). Most architectural concerns have been cleanly extracted into focused modules — `SessionManager` in particular has shed large responsibilities via `SessionLifecycle`, `PromptRouter`, `SessionNaming`, `ApprovalManager`, etc. However, several files remain substantially large and complex, and a handful of functions exhibit high cyclomatic complexity.
+
+| Metric | Value |
+|---|---|
+| Total source files (excl. tests, worktrees) | ~765 |
+| Total lines (excl. tests) | ~56,700 |
+| Largest source file | `server/session-manager.ts` (1,594 lines) |
+| Largest non-test single class | `OpenCodeProcess.handleSSEEvent` (~280 lines) |
+| Highest nesting depth observed | 6 levels (`opencode-process.ts:subscribeToEvents`) |
+| Files over 300 lines | 36 |
+| Files over 600 lines | 15 |
+
+---
+
+## Largest Files
+
+| File | Lines | Primary Responsibility | Refactor Priority |
+|---|---|---|---|
+| `server/session-manager.ts` | 1,594 | Session lifecycle orchestrator — CRUD, worktree ops, output history, context building, API retry, broadcasts | Medium |
+| `server/opencode-process.ts` | 988 | OpenCode HTTP/SSE adapter + module-level singleton server manager | High |
+| `src/App.tsx` | 802 | Root React component — wires all hooks, global state, keyboard shortcuts, routing | High |
+| `src/components/InputBar.tsx` | 784 | Chat input bar with skill menu, slash autocomplete, permission dropdown, drag handle | Medium |
+| `src/components/Settings.tsx` | 777 | Settings modal — auth, preferences, webhooks, integrations | Low |
+| `server/claude-process.ts` | 765 | Claude CLI child-process wrapper and NDJSON parser | Low |
+| `server/workflow-engine.ts` | 747 | SQLite-backed workflow execution engine with cron scheduling | Low |
+| `server/orchestrator-routes.ts` | 706 | REST endpoints for orchestrator status, children, memory, learning | Medium |
+| `server/orchestrator-learning.ts` | 705 | AI-powered memory extraction, aging, skill modeling, decision tracking | Medium |
+| `server/webhook-handler.ts` | 702 | GitHub webhook event handler (CI triage + PR review) | Low |
+| `server/prompt-router.ts` | 681 | Tool approval and prompt routing logic | Low |
+| `server/ws-server.ts` | 669 | Express/WebSocket server entry point — all service wiring | Medium |
+| `src/components/AddWorkflowModal.tsx` | 645 | Add/edit workflow modal with form fields and preview | Low |
+| `src/components/ChatView.tsx` | 620 | Session chat view — message rendering, diff panel, approvals | Low |
+| `server/stepflow-handler.ts` | 526 | Stepflow webhook integration for orchestrated sessions | Low |
+
+---
+
+## Most Complex Functions
+
+| File:Function | Estimated Complexity | Issue Description | Refactor Suggestion |
+|---|---|---|---|
+| `server/opencode-process.ts:handleSSEEvent` | Very High | ~280-line `switch` on event type, each case with nested `if` guards plus inner `switch`/`for` on part types; total ~6 levels of nesting | Split into per-event handler methods (e.g. `handleMessagePartDelta`, `handleSessionStatus`, `handlePermissionAsked`) that `handleSSEEvent` dispatches to |
+| `server/opencode-process.ts:subscribeToEvents` | High | Async SSE reconnect loop with three separate error paths (`!res.ok`, clean-EOF, catch), each duplicating the exponential-backoff/counter logic; 5–6 levels of nesting inside the `fetch` promise chain | Extract `handleSSEStream(res)` for the read loop and a shared `scheduleReconnect()` for the three identical backoff paths |
+| `server/session-manager.ts:constructor` | High | Wires 8 delegates by passing ~20 callback closures inline; the constructor body spans ~55 lines and mixes initialization with self-referential closure captures (`const self = this`) | Extract a factory function or builder pattern; inject `self` references via a `getThis()` accessor after construction |
+| `server/session-manager.ts:createWorktree` | High | ~130-line async function with 4 sequential try/catch blocks, worktree state mutated across branches, and 3 independent cleanup sub-steps before actual creation | Extract `cleanupStaleWorktree(repoRoot, worktreePath, branchName, isEphemeral)` and `createWorktreeDir(repoRoot, args)` helpers |
+| `src/App.tsx:(component body)` | High | Single React component with 20+ `useState`/`useEffect` calls, managing session switching, OpenCode model fetching, keyboard shortcuts, provider validation, and routing simultaneously; ~800 lines | Extract `useOpenCodeModelSync`, `useProviderValidation`, and `useGlobalKeyBindings` into dedicated hooks; this is already the pattern used elsewhere in the codebase |
+| `server/opencode-process.ts:sendMessage` | Medium-High | Builds attachment list with nested `statSync`/`readFileSync` calls and multi-branch encoding logic; handles text extraction, image detection, and base64 encoding in a single method | Extract `buildFileAttachments(paths)` returning `{text: string[], images: ...[] }` |
+| `server/session-manager.ts:sendInput` | Medium | Three distinct phases (start process, inject context, send message) with guard conditions spread across 60 lines; phase transitions are implicit | Decompose into `ensureAlive()`, `injectContextIfNeeded()`, and `deliverMessage()` helpers; call sequentially |
+| `server/session-manager.ts:buildSessionContext` | Medium | Stateful accumulator (`assistantText`) with flush-on-`result` logic duplicated twice at the end, inside a `switch` over message types; the context truncation loop mutates `lines` while reassigning `context` | Use a two-pass approach: collect turn objects first, then render to string with a single truncation step |
+| `server/ws-server.ts:(module body)` | Medium | 669-line server entry file mixes CLI arg parsing, auth setup, service instantiation, startup probes, route mounting, WebSocket handler, and process signal handlers; 34 imports | Extract `createServer(config)` factory and move signal handling to a `gracefulShutdown` module |
+| `server/orchestrator-routes.ts:createOrchestratorRouter` | Medium | Single router factory with ~600 lines of route definitions covering status, spawn, reports, memory CRUD, trust records, learning, and decision tracking — ~10 unrelated concerns | Split into sub-routers: `orchestrator-session-routes`, `orchestrator-memory-routes`, `orchestrator-learning-routes` |
+
+---
+
+## Coupling & Cohesion Issues
+
+### 1. `opencode-process.ts` — Module-level mutable singleton (`serverState`)
+
+The `serverState` object is a module-level variable that holds the shared OpenCode server process, port, and password. All `OpenCodeProcess` instances share it implicitly. This creates hidden global state that makes testing difficult (no way to inject a mock server), makes error recovery fragile (one failed instance can poison the shared state), and prevents running multiple OpenCode servers (e.g., for different repos).
+
+**Suggested fix:** Extract `OpenCodeServerManager` as an injectable class (or at minimum a factory that returns a scoped manager). `OpenCodeProcess` should receive an `OpenCodeServerManager` reference via constructor injection, making the dependency explicit and testable.
+
+---
+
+### 2. `src/App.tsx` — God component for global state
+
+`App.tsx` accumulates all cross-cutting global state that doesn't fit cleanly into a focused hook. It currently owns: active session ID + routing sync, OpenCode model fetching + validation, provider selection, permission mode + ref sync, keyboard shortcuts, error notification timers, diff panel callbacks, and file-change tracking. This makes the component difficult to test and refactor in isolation.
+
+**Suggested fix:** The codebase already decomposes hooks well elsewhere. The remaining concerns in `App.tsx` should move to purpose-built hooks: `useOpenCodeModelSync` (model fetch + set on session switch), `useGlobalKeyBindings` (Cmd+K/Cmd+Shift+D), `useProviderValidation` (CLAUDE_MODELS fallback), and `useErrorNotification` (5s auto-dismiss). The component body should shrink to ~200 lines of JSX wiring.
+
+---
+
+### 3. `server/session-manager.ts` — Mixed responsibilities in private methods
+
+Despite extensive delegation to sub-modules, `SessionManager` retains: `buildSessionContext`, `extractCurrentTurnText`, `stripCurrentTurnOutput`, `handleApiRetry`, `checkContextWarning`, `finalizeResult`, `addToHistory`, `broadcast`, and `archiveSessionIfWorthSaving`. The boundary between what belongs in `SessionManager` and what belongs in `SessionLifecycle` is unclear — some of these private methods are called only from `SessionLifecycle` callbacks, which means `SessionLifecycle` is calling back into `SessionManager` for logic that `SessionLifecycle` itself initiated.
+
+**Suggested fix:** Move `handleApiRetry`, `checkContextWarning`, `finalizeResult`, and the `buildSessionContext` / history helper methods into a new `TurnResultHandler` module, consistent with the existing delegation pattern. `SessionManager` becomes a thinner coordinator.
+
+---
+
+### 4. `server/orchestrator-routes.ts` + `server/orchestrator-learning.ts` — Wide function surface import
+
+`orchestrator-routes.ts` imports 11 named exports from `orchestrator-learning.ts` (`extractMemoryCandidates`, `smartUpsert`, `runAgingCycle`, `recordFindingOutcome`, `getTriageRecommendation`, `loadSkillProfile`, `updateSkillLevel`, `getGuidanceStyle`, `recordDecision`, `assessDecisionOutcome`, `getPendingOutcomeAssessments`) — the entire public API of that module. This tight coupling means any change to `orchestrator-learning.ts` types forces a change in the route handlers. There is no abstraction layer between the HTTP surface and the learning internals.
+
+**Suggested fix:** Introduce an `OrchestratorLearning` class or facade object that encapsulates the module functions. The router imports only this facade, and route handlers call `learning.recordFindingOutcome(...)` rather than importing the function directly. This also enables straightforward mocking in tests.
+
+---
+
+### 5. `server/ws-server.ts` — Entry point as God module
+
+`ws-server.ts` performs startup checks (Claude CLI probe, auth detection), creates all service singletons (`SessionManager`, `WebhookHandler`, `StepflowHandler`, `CommitEventHandler`, `WorkflowEngine`, `OrchestratorMonitor`), mounts all routers, creates the WebSocket server, registers the WS `connection` handler, and installs `SIGTERM`/`SIGINT` process signal handlers — all in a single 669-line file with 34 imports. This makes it impossible to unit-test the server startup logic or mock individual services.
+
+**Suggested fix:** Extract `createExpressApp(sessions, ...)` to a testable factory function in a separate `app.ts`. Keep `ws-server.ts` as a thin bootstrap that calls the factory, picks a port, and starts listening.
+
+---
+
+## Refactoring Candidates
+
+**1. Extract `OpenCodeServerManager` class from `opencode-process.ts`**
+- **Location:** `server/opencode-process.ts` lines 63–224
+- **Problem:** Module-level singleton `serverState` is implicit global state shared by all `OpenCodeProcess` instances. Cannot be injected, mocked, or reset between tests. `startOpenCodeServer` and `ensureOpenCodeServer` are module-scope functions with no clear owner.
+- **Approach:** Create `class OpenCodeServerManager { start(), stop(), getBaseUrl(), authHeaders() }`. Pass an instance to `OpenCodeProcess` constructor. Export a default singleton for production use. This unblocks testing and enables future multi-server support.
+- **Effort:** Medium
+
+---
+
+**2. Split `OpenCodeProcess.handleSSEEvent` into per-event methods**
+- **Location:** `server/opencode-process.ts:handleSSEEvent` (~lines 492–769)
+- **Problem:** ~280 lines in a single method; 6 levels of nesting in the `message.part.updated` branch; the `message.updated` case recursively calls `handleSSEEvent` (implicit recursion that can be confusing); the `session.idle`/`session.status`/`session.updated` cases share identical 4-line bodies duplicated three times.
+- **Approach:** Extract `handleMessagePartDelta`, `handleMessagePartUpdated`, `handleSessionIdle`, `handlePermissionAsked` private methods. Deduplicate the three idle-status paths into a single `handleSessionBecameIdle()` call.
+- **Effort:** Medium
+
+---
+
+**3. Decompose `App.tsx` into focused hooks**
+- **Location:** `src/App.tsx` lines 96–400 (state declarations and `useEffect`s)
+- **Problem:** Single component manages provider validation, OpenCode model lifecycle, error notification timers, keyboard bindings, and session-ID persistence — in addition to its legitimate role as JSX orchestrator.
+- **Approach:** Extract `useOpenCodeModelSync({ token, activeSessionId, activeSessionProvider, setModel })`, `useGlobalKeyBindings({ setPaletteOpen, setDiffPanelOpen })`, and `useErrorNotification()`. The pattern already exists in `useSessionOrchestration`, `useDocsBrowser`, etc.
+- **Effort:** Small
+
+---
+
+**4. Extract `TurnResultHandler` from `SessionManager`**
+- **Location:** `server/session-manager.ts` — `handleClaudeResult`, `handleApiRetry`, `checkContextWarning`, `finalizeResult`, `extractCurrentTurnText`, `stripCurrentTurnOutput`, `buildSessionContext` (lines ~962–1390)
+- **Problem:** These seven private methods (~430 lines) are all concerned with "what happens when a Claude turn ends". They are called from `SessionLifecycle` callbacks injected into `SessionManager`, making them a separate concern that happens to live in the manager.
+- **Approach:** Extract a `TurnResultHandler` class, consistent with how `SessionLifecycle`, `PromptRouter`, and `SessionNaming` were previously extracted. `SessionManager` delegates `handleClaudeResult` to it.
+- **Effort:** Medium
+
+---
+
+**5. Split `orchestrator-routes.ts` into sub-routers**
+- **Location:** `server/orchestrator-routes.ts` (706 lines)
+- **Problem:** A single router file covers 10+ conceptually distinct areas: session status/start, child session management, report scanning, memory CRUD, trust records, notifications, learning (finding outcomes, skill levels, decisions), and agent name config. The file has 12 imports from `orchestrator-learning.ts` alone.
+- **Approach:** Split into `orchestrator-session-router.ts`, `orchestrator-memory-router.ts`, and `orchestrator-learning-router.ts`. Mount all three via `createOrchestratorRouter()` at the same path prefix.
+- **Effort:** Small
+
+---
+
+**6. Replace `SessionManager.constructor` inline closures with post-construction wiring**
+- **Location:** `server/session-manager.ts` lines 132–185
+- **Problem:** The constructor passes 20 callback closures to `SessionLifecycle` and `PromptRouter`, including a `const self = this` alias to work around stale closure captures on mutable properties. This pattern is a code smell for "too many things need `this`".
+- **Approach:** Wire dependencies after construction using explicit setter/registry calls (e.g. `lifecycle.setContext(context)`), or adopt a dependency-injection container. Short-term: collect all callbacks into a `SessionManagerContext` struct and pass a single object.
+- **Effort:** Small
+
+---
+
+**7. Deduplicate reconnect backoff in `opencode-process.ts:subscribeToEvents`**
+- **Location:** `server/opencode-process.ts:subscribeToEvents` lines 367–458
+- **Problem:** The exponential backoff + attempt-count check is duplicated 3× across the `!res.ok`, clean-EOF, and `catch` paths. Any change to the reconnect policy must be made in all three places.
+- **Approach:** Extract `scheduleReconnect(reason: string): boolean` that handles the counter check, warning log, `setTimeout`, and backoff mutation. Return `false` when the limit is exceeded (caller returns early).
+- **Effort:** Small
+
+---
+
+**8. Extract `createExpressApp` factory from `ws-server.ts`**
+- **Location:** `server/ws-server.ts` (669 lines, 34 imports)
+- **Problem:** As the server entry point, `ws-server.ts` combines startup probes, service creation, route mounting, WebSocket setup, and signal handling. There is no way to import the server configuration without side effects (spawning processes, registering routes, etc.).
+- **Approach:** Extract `createExpressApp(sessions: SessionManager, services: ServerServices): express.Application` into `app.ts`. Keep `ws-server.ts` as a ~50-line bootstrap. This enables integration tests to call `createExpressApp()` without binding a port.
+- **Effort:** Medium
+
+---
+
+**9. Convert `orchestrator-learning.ts` free functions to an injectable class facade**
+- **Location:** `server/orchestrator-learning.ts` (705 lines) and its callers
+- **Problem:** 11 free functions are imported directly by `orchestrator-routes.ts`. No abstraction layer exists between the HTTP handlers and the learning internals, and the functions access the filesystem and SQLite directly, making route-level tests require real storage.
+- **Approach:** Wrap the 11 functions in an `OrchestratorLearning` class that accepts an `OrchestratorMemory` instance via constructor. Existing callers switch from `import { fn }` to `learning.fn()`. Enables mock injection in tests.
+- **Effort:** Small
+
+---
+
+**10. Inline `session.idle` / `session.status` / `session.updated` triple duplication**
+- **Location:** `server/opencode-process.ts:handleSSEEvent` lines 652–737
+- **Problem:** Three separate `case` blocks (`session.status`, `session.updated`, `session.idle`) each contain the same 4-line body: check own session, check `turnComplete`, set `turnComplete=true`, call `flushDeltaBuffer()`, emit `result`. Any fix to turn-completion logic must be applied three times.
+- **Approach:** Extract `private handleSessionIdle(): void` and call it from all three cases. This is the lowest-effort, highest-reliability fix for a subtle production bug risk.
+- **Effort:** Small

--- a/.codekin/reports/complexity/2026-04-15_complexity-report.md
+++ b/.codekin/reports/complexity/2026-04-15_complexity-report.md
@@ -1,0 +1,32 @@
+# Complexity Report: codekin
+
+**Date**: 2026-04-15T04:33:37.551Z
+**Repository**: /srv/repos/codekin
+**Branch**: feat/repo-health-2026-04-15
+**Workflow Run**: 95cc04f7-9fe3-4836-8247-06302d3e05fc
+**Session**: 57b6d285-79ee-499c-98dd-15387e72ae53
+
+---
+
+Now I have enough data to write the report.Now I have enough data to write the report. Let me compose it:The report has been written to `.codekin/reports/complexity/2026-04-15_complexity-analysis.md`.
+
+Here's a brief summary of the findings:
+
+**Overall rating: Medium-High complexity**
+
+- **~56,700 lines** across ~765 source files (excluding tests and worktrees)
+- **15 files over 600 lines**, with `session-manager.ts` (1,594 lines) as the largest
+
+**Top complexity hotspots:**
+1. `opencode-process.ts:handleSSEEvent` — 280-line switch/case with 6 nesting levels
+2. `opencode-process.ts:subscribeToEvents` — triply-duplicated backoff logic, deep async nesting
+3. `App.tsx` — 20+ useState/useEffect hooks, multiple unrelated concerns in one component
+4. `session-manager.ts:constructor` — 20 inline callback closures, `const self = this` alias
+
+**Key structural issues:**
+- Module-level singleton `serverState` in `opencode-process.ts` (untestable, hidden global)
+- `orchestrator-routes.ts` handles 10+ unrelated concerns in one 706-line router
+- `ws-server.ts` is the entry point *and* god module (34 imports, no testable factory)
+- 3× duplicated idle-completion logic in `opencode-process.ts`
+
+**Highest-ROI refactors (small effort):** extract `OrchestratorLearning` facade, deduplicate backoff in `subscribeToEvents`, collapse the triple `session.idle` duplication, and split `App.tsx` useEffect concerns into hooks.

--- a/.codekin/reports/dependencies/2026-04-14_dependency-health.md
+++ b/.codekin/reports/dependencies/2026-04-14_dependency-health.md
@@ -1,0 +1,21 @@
+# Dependency Health Report: codekin
+
+**Date**: 2026-04-14T04:16:50.582Z
+**Repository**: /srv/repos/codekin
+**Branch**: main
+**Workflow Run**: a08248eb-1b52-4cb7-b93c-77758a4bcbe1
+**Session**: b71c69a0-a55e-489c-a42e-95820a4e642f
+
+---
+
+Now I have all the data needed. Let me write the report.Report written to `.codekin/reports/dependencies/2026-04-14_dependency-health.md`.
+
+**TL;DR findings:**
+
+- **0 vulnerabilities** — `npm audit` is clean across all severity levels
+- **1 outdated package** — `better-sqlite3` is one minor version behind (12.8.0 → 12.9.0)
+- **1 maintenance concern** — `refractor` v5.0.0 wraps PrismJS, which is in maintenance-only mode upstream; no active CVEs but slow to patch
+- **Notable**: `undici` is overridden in `package.json` as a proactive CVE guard — should be kept current
+- **Stack currency**: Very modern — React 19, Vite 8, TypeScript 6, Express 5, Tailwind 4; essentially leading-edge across the board
+
+Top action items: update `better-sqlite3`, document the `undici` override reason, and evaluate migrating off PrismJS/refractor long-term.

--- a/.codekin/reports/docs-audit/2026-04-15_docs-audit-weekly.md
+++ b/.codekin/reports/docs-audit/2026-04-15_docs-audit-weekly.md
@@ -1,0 +1,208 @@
+# Documentation Audit — 2026-04-15
+
+## Summary
+
+The Codekin repository contains **28 documentation files** across root level, `docs/`, `server/workflows/`, and `.github/` template directories. Overall documentation health is **Well-maintained** — the core reference docs are accurate and current, having been updated in step with recent feature releases (PR Review webhooks, OpenCode provider, Agent Joe orchestrator). The main areas needing attention are: (1) a large spec file (`GITHUB-WEBHOOKS-SPEC.md`) that prominently describes unimplemented future phases without clear delineation; (2) two legacy report output directories (`review logs/`, `coverage-reports/`) that predate the current `.codekin/reports/` structure and are gitignored but still present on disk; (3) minor omission in `WORKFLOWS.md` of the `pr-review` workflow; and (4) `SECURITY.md` is the oldest unchanged file and lacks mention of webhook and orchestrator trust-model security.
+
+**Health rating: Well-maintained** — no broken links, no missing file references, no incorrect install instructions. Targeted cleanup needed in 3–4 areas.
+
+---
+
+## Documentation Inventory
+
+| Path | Lines | Last Modified | Purpose | Status |
+|------|------:|--------------|---------|--------|
+| `README.md` | 110 | 2026-04-11 | Project overview, features, quickstart, configuration | Current |
+| `CHANGELOG.md` | 461 | 2026-04-11 | Version history v0.1.7 → v0.6.3 | Current |
+| `CLAUDE.md` | 58 | 2026-04-10 | Codebase conventions and audit report rules for AI agent | Current |
+| `CONTRIBUTING.md` | 114 | 2026-04-08 | Dev setup, env vars table, contribution workflow | Current |
+| `CODE_OF_CONDUCT.md` | 31 | 2026-03-08 | Community standards | Current |
+| `SECURITY.md` | 43 | 2026-03-08 | Security policy, vulnerability disclosure | Stale |
+| `install.sh` | 143 | 2026-03-10 | One-liner install script | Current |
+| `docs/API-REFERENCE.md` | 684 | 2026-04-08 | REST + WebSocket API endpoints, session management | Current |
+| `docs/FEATURES.md` | 402 | 2026-03-16 | Comprehensive feature list linking to spec docs | Current |
+| `docs/GITHUB-WEBHOOKS-SPEC.md` | 813 | 2026-03-16 | Webhook architecture; Phase 1 implemented, Phases 2–4 unimplemented roadmap | Stale |
+| `docs/INSTALL-DISTRIBUTION.md` | 184 | 2026-04-09 | npm distribution model, CLI commands, service install | Current |
+| `docs/ORCHESTRATOR-SPEC.md` | 669 | 2026-04-04 | Agent Joe orchestrator architecture and lifecycle | Current |
+| `docs/PR-REVIEW-WEBHOOK.md` | 218 | 2026-04-10 | PR automated code review via webhooks | Current |
+| `docs/SETUP.md` | 420 | 2026-04-08 | Advanced self-hosted deployment (nginx, Authelia, systemd) | Current |
+| `docs/stream-json-protocol.md` | 566 | 2026-04-08 | Claude CLI streaming protocol integration details | Current |
+| `docs/WORKFLOWS.md` | 186 | 2026-04-01 | Automated workflow system, frontmatter format, built-in list | Stale |
+| `server/workflows/code-review.daily.md` | 22 | 2026-03-08 | Daily code review workflow prompt | Current |
+| `server/workflows/security-audit.weekly.md` | 66 | 2026-03-08 | Weekly security audit workflow prompt | Current |
+| `server/workflows/complexity.weekly.md` | 54 | 2026-03-08 | Weekly complexity analysis workflow prompt | Current |
+| `server/workflows/coverage.daily.md` | 41 | 2026-03-08 | Daily test coverage workflow prompt | Current |
+| `server/workflows/comment-assessment.daily.md` | 41 | 2026-03-08 | Daily comment assessment workflow prompt | Current |
+| `server/workflows/dependency-health.daily.md` | 46 | 2026-03-08 | Daily dependency health workflow prompt | Current |
+| `server/workflows/docs-audit.weekly.md` | 97 | 2026-03-14 | Weekly documentation audit workflow prompt | Current |
+| `server/workflows/repo-health.weekly.md` | 111 | 2026-03-09 | Weekly repo health check workflow prompt | Current |
+| `server/workflows/commit-review.md` | 22 | 2026-03-11 | Event-driven commit review workflow prompt | Current |
+| `server/workflows/pr-review.md` | 27 | 2026-04-10 | Event-driven PR review workflow prompt | Current |
+| `.github/ISSUE_TEMPLATE/bug_report.md` | 40 | 2026-03-08 | Bug report template | Current |
+| `.github/ISSUE_TEMPLATE/feature_request.md` | 23 | 2026-03-08 | Feature request template | Current |
+| `.github/PULL_REQUEST_TEMPLATE.md` | 17 | 2026-03-08 | Pull request template | Current |
+
+**Not included in this audit** (gitignored, not distributed):
+- `review logs/2026-03-08_code-review-daily.md` — legacy report directory, gitignored
+- `coverage-reports/2026-03-08_coverage-assessment.md` — legacy report directory, gitignored
+
+---
+
+## Staleness Findings
+
+### 1. `docs/GITHUB-WEBHOOKS-SPEC.md` — Phases 2–4 sections are unimplemented roadmap content presented as specification
+
+Last modified: **2026-03-16** — well before `docs/PR-REVIEW-WEBHOOK.md` was written (2026-04-10). The spec's status line reads "Phase 1 implemented and in production. Phases 2-4 are roadmap." However, 813 lines of spec intermix implemented and unimplemented content throughout, making it difficult to tell at a glance what is available today:
+
+- **Line 133–145**: "Phase 2 — Expanded Events (Future)" — `check_run`, `check_suite` events not implemented
+- **Lines 207, 223, 238**: Phase 2+ operating modes (`autonomous`, `notify-only`) — not implemented; Phase 1 is always `supervised`
+- **Line 334–339**: `GITHUB_WEBHOOK_MODE` env var documented as "Phase 2" — not active yet
+- **Lines 421, 441**: Manual retry API, auto-close timer — Phase 2 only
+- **Lines 502–504**: Full pipeline with event queue and worker pool — Phase 2+
+- **Lines 751–793**: Phases 2, 3, 4 — "Planned — Not Yet Implemented" but listed under "Implementation Phases"
+- **Line 117**: "Future (Phase 2+): Migrate to direct GitHub REST API calls with `GITHUB_TOKEN`" — `GITHUB_TOKEN` appears in env table marked Phase 2 but is not in `server/config.ts`
+
+Additionally, the PR Review webhook (shipped 2026-04-10) is a sibling feature to the CI failure webhook described here, but is documented entirely separately in `PR-REVIEW-WEBHOOK.md` with no cross-reference from this file.
+
+### 2. `docs/WORKFLOWS.md` — `pr-review.md` omitted from built-in workflows table
+
+Last modified: **2026-04-01**. The built-in workflows table (lines 68–78) lists 9 workflows. However, `server/workflows/pr-review.md` (added 2026-04-10) also exists in the same directory and is not listed. Because `pr-review` is event-driven rather than scheduled, its absence from the table is arguably intentional, but no note explains this distinction, leaving the table incomplete.
+
+### 3. `SECURITY.md` — Oldest unchanged doc; predates major feature additions
+
+Last modified: **2026-03-08** — before the Agent Joe orchestrator (v0.5.0), GitHub webhook integration, PR review automation, and the trust-escalation model were shipped. The file is not factually wrong (the general guidance remains valid) but is missing security considerations relevant to:
+- Webhook HMAC validation (`GITHUB_WEBHOOK_SECRET` env var)
+- Orchestrator trust escalation model and the `ASK/NOTIFY+DO/SILENT` permission levels
+- The scope of actions the orchestrator can take autonomously
+
+### 4. `docs/FEATURES.md` — Last modified 2026-03-16 but marked as updated to 2026-04-06 in git
+
+Git log shows this file was last touched **2026-03-16** (not 2026-04-06 as the prior explore run suggested — audit is treating the git date as authoritative). PR Review (2026-04-10) is the most recently shipped feature and is not listed in the features file.
+
+---
+
+## Accuracy Issues
+
+### 1. `docs/GITHUB-WEBHOOKS-SPEC.md` — `GITHUB_TOKEN` env var documented but not implemented
+
+Line 334–339 documents a `GITHUB_TOKEN` environment variable as a Phase 2 addition. This variable does not appear in `server/config.ts`. A reader setting up webhooks today might search for this configuration and be confused by its absence. The Phase 2 label exists but is easy to miss in a long table.
+
+### 2. `docs/GITHUB-WEBHOOKS-SPEC.md` — `GITHUB_WEBHOOK_MODE` env var not yet active
+
+Line 339 documents `GITHUB_WEBHOOK_MODE` with default `supervised` and notes it is "ignored until Phase 2." The variable is not in `server/config.ts`. This is not wrong, but is potentially misleading for operators checking what env vars the server reads.
+
+### 3. `docs/ORCHESTRATOR-SPEC.md` — One roadmap item unmarked
+
+Line 5 states: "One Phase 3 item (auto-suggest workflow setup) remains roadmap." The spec's Phase 3 section (lines 503–510) lists this item with a `✓` alongside shipped items without distinguishing it clearly as the single remaining unshipped piece. A reader scanning the checkboxes would not notice this nuance without reading the status header.
+
+### 4. `docs/WORKFLOWS.md` — `pr-review` omission creates an incomplete picture
+
+As noted in Staleness, `server/workflows/pr-review.md` exists but is not in the table. A developer listing workflow kinds in code would find 10 files; the doc says 9. The table header "Built-in Workflows" does not clarify whether it covers all files in `server/workflows/` or only scheduled ones.
+
+### 5. `docs/FEATURES.md` — PR Review feature missing
+
+`docs/PR-REVIEW-WEBHOOK.md` describes a fully shipped feature (2026-04-10) but `docs/FEATURES.md` — the main feature index — does not list it. A user reading FEATURES.md to understand what Codekin can do would not discover the PR Review automation.
+
+---
+
+## Overlap & Redundancy
+
+### Group A — Environment Variable Documentation (CONTRIBUTING.md vs SETUP.md)
+
+Both files document server environment variables:
+
+- **`CONTRIBUTING.md`** (lines 38–50): Definitive table of all 11 env vars with defaults and whether they are required in production.
+- **`docs/SETUP.md`** (lines 221–240 and scattered): Documents env vars in the context of the self-hosted nginx+systemd deployment, with partial repetition of the same table.
+
+**Assessment**: Overlap is intentional and appropriate — CONTRIBUTING.md targets developers, SETUP.md targets self-hosted operators. However, SETUP.md could link to CONTRIBUTING.md's table as the source of truth rather than partially reproducing it, reducing maintenance surface.
+
+**More complete/current version**: `CONTRIBUTING.md`.
+
+### Group B — Installation Instructions (README.md vs INSTALL-DISTRIBUTION.md vs SETUP.md)
+
+Three files cover installation:
+
+- **`README.md`**: One-liner quickstart (`curl … | bash`), brief config overview.
+- **`docs/INSTALL-DISTRIBUTION.md`**: Full npm distribution model, CLI subcommands, service install, first-run wizard, release process.
+- **`docs/SETUP.md`**: Advanced self-hosted bare-metal deployment with nginx, Authelia, systemd.
+
+**Assessment**: Overlap is minimal and each file targets a clearly distinct audience. `SETUP.md` even opens with a note directing standard users to `INSTALL-DISTRIBUTION.md`. No merge needed.
+
+### Group C — Webhook Documentation (GITHUB-WEBHOOKS-SPEC.md vs PR-REVIEW-WEBHOOK.md)
+
+- **`docs/GITHUB-WEBHOOKS-SPEC.md`**: CI failure webhook — triggers Claude sessions to investigate and fix failing CI runs.
+- **`docs/PR-REVIEW-WEBHOOK.md`**: PR review webhook — triggers Claude to post code review comments on pull requests.
+
+Both cover GitHub webhooks, share infrastructure (signature validation, deduplication, workspace isolation), and describe overlapping configuration patterns. Neither cross-references the other. A reader arriving at either file gets an incomplete picture of the webhook system.
+
+**Assessment**: Conceptually related but covers distinct use cases. They should not be merged, but `GITHUB-WEBHOOKS-SPEC.md` should reference `PR-REVIEW-WEBHOOK.md` and vice versa. Consider a top-level webhook index section in `docs/API-REFERENCE.md` or `FEATURES.md`.
+
+---
+
+## Fragmentation
+
+### 1. Webhook architecture split across two separate spec files
+
+`GITHUB-WEBHOOKS-SPEC.md` and `PR-REVIEW-WEBHOOK.md` share significant architectural ground (HMAC validation, rate limiting, workspace isolation, deduplication logic) documented redundantly. A developer trying to understand the webhook system must read both files. A short "Webhook System Overview" section at the top of one — linking to the other — would reduce the navigation burden without requiring a full merge.
+
+### 2. `GITHUB-WEBHOOKS-SPEC.md` mixes shipped and roadmap content without clear visual separation
+
+813 lines of implementation phases, of which ~300 lines describe Phases 2–4 (unimplemented). These roadmap sections are distributed throughout the document rather than isolated in a trailing "Roadmap" section, making it hard to skim for "what works today." A clear structural separation (e.g., "## Current Implementation" vs "## Roadmap") would help without removing useful future-planning content.
+
+### 3. `server/workflows/` files are docs but not surfaced in the developer guide
+
+The 10 workflow prompt files in `server/workflows/` are effectively documentation (they define AI behavior). `docs/WORKFLOWS.md` describes the format and lists most of them, but a developer looking for "what does the daily code-review prompt actually say?" has no pointer from the main docs to the `server/workflows/` directory.
+
+### 4. Legacy report directories outside the canonical structure
+
+`review logs/` (space in name) and `coverage-reports/` are gitignored directories containing single March 2026 report files that predate the current `.codekin/reports/<category>/` structure adopted in CLAUDE.md. They are not distributed and are not referenced by any documentation. They represent output from the old structure but their presence on disk can confuse contributors expecting all reports to live under `.codekin/reports/`.
+
+---
+
+## Action Items
+
+### Delete
+
+| File | Reason Safe to Delete |
+|------|-----------------------|
+| `review logs/2026-03-08_code-review-daily.md` *(gitignored)* | Legacy artifact from before `.codekin/reports/` structure; gitignored, not distributed, single file from 2026-03-08; content superseded by 25+ subsequent reports in `.codekin/reports/code-review/`. The directory name (space in path) is also non-standard. |
+| `coverage-reports/2026-03-08_coverage-assessment.md` *(gitignored)* | Same reasoning as above — predates current reporting structure; content superseded by reports in `.codekin/reports/`. Only one file exists. |
+
+> Note: Both directories are gitignored so deletion only affects the local working tree.
+
+### Consolidate
+
+| Source Files | Target File | What to Keep / Drop |
+|---|---|---|
+| `docs/GITHUB-WEBHOOKS-SPEC.md` Phases 2–4 sections + `docs/PR-REVIEW-WEBHOOK.md` | No merge needed, but **add cross-references** | In `GITHUB-WEBHOOKS-SPEC.md`: add a "See also" note at the top pointing to `PR-REVIEW-WEBHOOK.md`. Move all Phase 2–4 content to a clearly labelled `## Roadmap` section at the end of the file. In `PR-REVIEW-WEBHOOK.md`: add a link back to `GITHUB-WEBHOOKS-SPEC.md` for shared infrastructure context. |
+| `docs/SETUP.md` env var table | Consolidate into `CONTRIBUTING.md` | Replace the partial env var table in `SETUP.md` with a link to the definitive table in `CONTRIBUTING.md`. Keeps SETUP.md focused on nginx/systemd configuration. |
+
+### Update
+
+| File | Sections Needing Update | What Changed in Code |
+|---|---|---|
+| `docs/WORKFLOWS.md` | Built-in Workflows table (lines 68–78) | Add `pr-review.md` to the table. Add a note clarifying it is event-driven (webhook-triggered) rather than scheduled, explaining why it operates differently from the other 9 workflows. |
+| `docs/FEATURES.md` | Feature list | Add an entry for PR Review Automation (shipped 2026-04-10) with a link to `docs/PR-REVIEW-WEBHOOK.md`. |
+| `docs/GITHUB-WEBHOOKS-SPEC.md` | Throughout — Phase 2–4 sections | (1) Add a status callout at the top clarifying which env vars are currently active vs. Phase 2+. (2) Move all Phase 2–4 subsections under a single `## Roadmap` section at the end. (3) Add a cross-reference to `PR-REVIEW-WEBHOOK.md`. |
+| `SECURITY.md` | Security Considerations section | Add a paragraph on webhook security (HMAC signature validation via `GITHUB_WEBHOOK_SECRET`, importance of keeping the secret out of logs). Add a note on the orchestrator trust-escalation model and the permissions it can exercise autonomously. |
+| `docs/ORCHESTRATOR-SPEC.md` | Phase 3 section (lines 503–510) | Mark the remaining unshipped item (auto-suggest workflow setup) with a clear `(roadmap)` label so it is visually distinct from the `✓` shipped items. |
+
+---
+
+## Recommendations
+
+1. **Restructure `GITHUB-WEBHOOKS-SPEC.md` to separate current from roadmap.** The single highest-value change: move all Phase 2–4 content into a clearly labelled `## Roadmap` section at the end of the file. This makes the 813-line spec immediately readable for operators and prevents confusion about which env vars and features are active today. Estimated effort: 30 min.
+
+2. **Add PR Review to `FEATURES.md` and `WORKFLOWS.md`.** Two small additions that close the gap between shipped functionality and its documentation. PR Review is the most recently shipped feature (2026-04-10) and is missing from both the feature index and the workflow table. Estimated effort: 15 min.
+
+3. **Add cross-references between the two webhook spec files.** `GITHUB-WEBHOOKS-SPEC.md` and `PR-REVIEW-WEBHOOK.md` describe sibling subsystems. A single "See also" line at the top of each file significantly reduces navigation friction for developers working on the webhook layer. Estimated effort: 5 min.
+
+4. **Refresh `SECURITY.md`.** The file is unchanged since the initial commit (2026-03-08) and the project has since shipped webhook HMAC validation and an orchestrator that can autonomously execute shell commands and file edits. Both warrant a security-considerations paragraph. Estimated effort: 20 min.
+
+5. **Delink the env var table in `SETUP.md` from its current partial duplication.** Replace the partial env var listing in `SETUP.md` with a link to the authoritative table in `CONTRIBUTING.md`. Reduces future drift risk when env vars change. Estimated effort: 10 min.
+
+6. **Delete the legacy `review logs/` and `coverage-reports/` directories.** These gitignored directories serve no ongoing purpose — their content is superseded and their existence on disk creates confusion about where reports should live. A one-time local `rm -rf` cleans this up. Estimated effort: 2 min.
+
+7. **Add a pointer in `docs/WORKFLOWS.md` to `server/workflows/`.**  A single line telling developers where the actual workflow prompt files live would close the gap between the workflow system documentation and the implementation. Currently, a developer who reads WORKFLOWS.md and wants to inspect or customise a prompt has no pointer to `server/workflows/`. Estimated effort: 5 min.
+
+8. **Consider a webhook system index page.** As the webhook surface grows (CI failures, PR review, with more planned), a lightweight `docs/WEBHOOKS.md` index linking to both `GITHUB-WEBHOOKS-SPEC.md` and `PR-REVIEW-WEBHOOK.md` — with a one-paragraph "how webhooks work" overview — would give the webhook docs a clear entry point. Medium priority; implement when a third webhook type is added.

--- a/.codekin/reports/docs-audit/2026-04-15_docs-audit.md
+++ b/.codekin/reports/docs-audit/2026-04-15_docs-audit.md
@@ -1,0 +1,27 @@
+# Documentation Audit: codekin
+
+**Date**: 2026-04-15T01:21:33.523Z
+**Repository**: /srv/repos/codekin
+**Branch**: main
+**Workflow Run**: cfaea1d9-7e73-442f-9265-d07712448773
+**Session**: 325dd8f7-ec61-4e83-a065-e44cd1b31ac0
+
+---
+
+Now I have all the information needed. Let me write the report.Now I have everything I need. Let me write the report.Report written to `.codekin/reports/docs-audit/2026-04-15_docs-audit-weekly.md`.
+
+Here's a summary of the key findings:
+
+**Overall: Well-maintained** — all file references resolve, install instructions match `package.json`, and the core API/architecture docs are accurate and current.
+
+**Top issues found:**
+
+1. **`docs/GITHUB-WEBHOOKS-SPEC.md`** (813 lines, last updated 2026-03-16) — the biggest problem. ~300 lines describe Phases 2–4 (unimplemented roadmap) scattered throughout the document, making it hard to tell what works today. Also doesn't reference `PR-REVIEW-WEBHOOK.md`, which covers a sibling webhook feature shipped six weeks later.
+
+2. **`docs/FEATURES.md` + `docs/WORKFLOWS.md`** — both are missing the PR Review feature (shipped 2026-04-10). The `pr-review.md` workflow file exists but isn't listed in the WORKFLOWS.md built-in table.
+
+3. **`SECURITY.md`** — unchanged since 2026-03-08, predates the orchestrator and webhook systems; missing security guidance on HMAC validation and orchestrator autonomous permissions.
+
+4. **Legacy report directories** — `review logs/` and `coverage-reports/` are gitignored remnants of the old reporting structure; safe to delete locally.
+
+5. **Minor ORCHESTRATOR-SPEC.md nit** — one unshipped Phase 3 item isn't visually distinguished from the `✓` shipped items.

--- a/.codekin/reports/repo-health/2026-04-14_repo-health-daily.md
+++ b/.codekin/reports/repo-health/2026-04-14_repo-health-daily.md
@@ -1,0 +1,315 @@
+# Repository Health Assessment — 2026-04-14
+
+**Assessed by:** Automated health agent  
+**Branch at assessment:** `main` (HEAD: `aee990a`)  
+**Last tag:** `v0.6.3` (2026-04-12)
+
+---
+
+## Summary
+
+**Overall Health Rating: Good**
+
+The codebase is in solid shape. TypeScript strict mode is fully enforced across all configs, there are zero outstanding TODO/FIXME comments, all dependency license concerns are pre-acknowledged in `package.json`, and CI is active. The main areas needing attention are: (1) a debug-labelled commit on `main` that added lifecycle logging and has not been cleaned up, (2) a runaway `codekin/reports` branch that is 467 commits behind `main`, (3) 75 unmerged remote branches creating clutter, (4) 6 open doc-only PRs awaiting merge, and (5) a handful of ESLint type-unsafe rules configured as warnings rather than errors.
+
+| Category | Status | Key Stat |
+|---|---|---|
+| Dead code | ✅ Clean | Build enforces `noUnusedLocals`/`noUnusedParameters`; 1 debug commit flagged |
+| TODO/FIXME | ✅ Clean | 0 items found |
+| Config drift | ⚠️ Minor | 5 ESLint `warn`-level rules could be `error`; no prettier/ESLint bridge |
+| License compliance | ✅ Clean | MPL-2.0 deps pre-documented; all others permissive |
+| Documentation | ⚠️ Minor | `ProcessCoordinator` (#404) and rate-limiter changes (#397) not reflected in docs |
+| Stale branches | ⚠️ Moderate | 75 unmerged; 7 merged-but-not-deleted; `codekin/reports` massively diverged |
+| Open PRs | ⚠️ Minor | 6 open (all docs); #402 has merge conflicts |
+| Merge conflict risk | ⚠️ Moderate | `codekin/reports` is 62 ahead/467 behind main |
+
+---
+
+## Dead Code
+
+The TypeScript compiler enforces `noUnusedLocals: true` and `noUnusedParameters: true` in all three tsconfigs, which eliminates most local dead code at compile time. No orphan files or clearly unreachable code were identified in the source tree. However, one concern warrants review:
+
+| File | Export / Symbol | Type | Recommendation |
+|---|---|---|---|
+| `server/claude-process.ts` (and related) | Lifecycle debug `console.log` calls added in #406 | Debug code in production | Remove or gate behind `DEBUG` flag after the first-message-lost bug is resolved |
+
+**Note on exported symbols:** Cross-module unused exports are not caught by `noUnusedLocals`. A tool like `ts-prune` or `knip` would provide a definitive scan; running one is recommended as a follow-up (see Recommendations #3).
+
+---
+
+## TODO/FIXME Tracker
+
+**Scan coverage:** `src/**/*.{ts,tsx}`, `server/**/*.ts`
+
+No actionable `TODO`, `FIXME`, `HACK`, `XXX`, or `WORKAROUND` comments were found in any source file. The only occurrences of these tokens appear inside test string fixtures testing grep-pattern logic (not actual code debt markers).
+
+| Type | Count |
+|---|---|
+| TODO | 0 |
+| FIXME | 0 |
+| HACK | 0 |
+| XXX | 0 |
+| WORKAROUND | 0 |
+| **Total** | **0** |
+| Stale (>30 days) | 0 |
+
+---
+
+## Config Drift
+
+### TypeScript (`tsconfig.app.json`, `tsconfig.node.json`, `server/tsconfig.json`)
+
+All three configs are modern and well-configured. No significant drift.
+
+| Config file | Setting | Current value | Assessment |
+|---|---|---|---|
+| `tsconfig.app.json` | `strict` | `true` | ✅ |
+| `tsconfig.app.json` | `noUnusedLocals` / `noUnusedParameters` | `true` | ✅ |
+| `tsconfig.app.json` | `target` | `ES2022` | ✅ Modern |
+| `tsconfig.app.json` | `erasableSyntaxOnly` | `true` | ✅ Forward-looking (Node 22 native TS) |
+| `tsconfig.app.json` | `verbatimModuleSyntax` | `true` | ✅ Prevents type-import pollution |
+| `server/tsconfig.json` | `moduleResolution` | `NodeNext` | ✅ Correct for Node |
+| All | `skipLibCheck` | `true` | ⚠️ Suppresses errors in `node_modules` — acceptable but masks bad type declarations |
+
+### ESLint (`eslint.config.js`)
+
+ESLint uses modern flat config with `typescript-eslint strictTypeChecked` — excellent baseline. However, several type-safety rules are downgraded to warnings:
+
+| Rule | Current level | Recommended level | Rationale |
+|---|---|---|---|
+| `@typescript-eslint/no-unsafe-assignment` | `warn` | `error` | Unsafe assignments silently pass in CI |
+| `@typescript-eslint/no-unsafe-argument` | `warn` | `error` | Same concern |
+| `@typescript-eslint/no-unsafe-member-access` | `warn` | `error` | Same concern |
+| `@typescript-eslint/no-unsafe-return` | `warn` | `error` | Same concern |
+| `@typescript-eslint/no-non-null-assertion` | `warn` | `error` or code review | Non-null assertions in production paths are runtime risks |
+
+Additionally, `eslint-config-prettier` is not installed. Without it, Prettier and ESLint formatting rules can conflict silently. Not a blocker today, but a `prettier --check` pre-commit hook or the bridge package would eliminate the ambiguity.
+
+Test files use `tseslint.configs.recommended` (weaker) rather than `strictTypeChecked` — this is a common and reasonable trade-off.
+
+### Prettier (`.prettierrc`)
+
+```json
+{ "semi": false, "singleQuote": true, "trailingComma": "all", "printWidth": 120, "tabWidth": 2 }
+```
+
+All settings are consistent with the declared stack. `printWidth: 120` is wider than the community default (80) but an explicit project preference. No drift detected.
+
+---
+
+## License Compliance
+
+Project license: **MIT**
+
+| License | Package count | Permissive? | Notes |
+|---|---|---|---|
+| MIT | 465 | ✅ | |
+| ISC | 22 | ✅ | Functionally equivalent to MIT |
+| Apache-2.0 | 18 | ✅ | Compatible with MIT distribution |
+| BSD-3-Clause | 9 | ✅ | |
+| BSD-2-Clause | 8 | ✅ | |
+| MPL-2.0 | 12 | ⚠️ See note | All are `lightningcss` platform packages |
+| (MPL-2.0 OR Apache-2.0) | 1 | ✅ | `dompurify` — Apache-2.0 elected |
+| BlueOak-1.0.0 | 4 | ✅ | Permissive |
+| MIT-0 | 2 | ✅ | No-attribution variant of MIT |
+| CC-BY-4.0 | 1 | ✅ | Documentation only |
+| CC0-1.0 | 1 | ✅ | Public domain |
+| 0BSD | 1 | ✅ | |
+| (MIT OR WTFPL) | 1 | ✅ | MIT elected |
+| (BSD-2-Clause OR MIT OR Apache-2.0) | 1 | ✅ | |
+
+**Flagged dependencies:**
+
+| Package | License | Issue | Status |
+|---|---|---|---|
+| `lightningcss` + 11 platform packages | MPL-2.0 | File-level copyleft | ✅ Pre-documented in `package.json#licenseNotes` as build-time only; not shipped in distributed artifacts |
+| `dompurify` | MPL-2.0 OR Apache-2.0 | Dual-license | ✅ Pre-documented; Apache-2.0 is permissive and compatible |
+
+**Conclusion:** All MPL-2.0 dependencies are either build-time-only tools or carry a permissive alternative. The `licenseNotes` field in `package.json` explicitly acknowledges both. No compliance action required.
+
+---
+
+## Documentation Freshness
+
+### API Docs / Feature Docs
+
+Recent code changes were compared against `docs/` content to identify potential staleness:
+
+| Code change | PR/commit | Docs file likely affected | Status |
+|---|---|---|---|
+| `ProcessCoordinator` — new unified session lifecycle class | #404 (2026-04-13) | `docs/API-REFERENCE.md`, `docs/FEATURES.md` | ⚠️ Docs predate this refactor; session lifecycle section may be stale |
+| Rate limiter map cap + attachment file size limit | #397 (2026-04-13) | `docs/API-REFERENCE.md` (rate limiting section) | ⚠️ New limits not documented |
+| Auto-setup GitHub webhook for PR Review workflows | #391 (2026-04-12) | `docs/GITHUB-WEBHOOKS-SPEC.md`, `docs/PR-REVIEW-WEBHOOK.md` | ⚠️ Wizard behaviour may not be reflected |
+| Security hardening: path traversal, trust proxy, image src allowlist | #394 (2026-04-12) | `docs/API-REFERENCE.md` (security headers) | ⚠️ `trust proxy` and allowlist not documented |
+| Provider selection + searchable model picker in workflows | #375 (2026-04-12) | `docs/WORKFLOWS.md` | ⚠️ Provider field addition likely missing |
+
+### README Drift
+
+The README was reviewed against `package.json` scripts and the current project structure:
+
+| README claim | Actual state | Status |
+|---|---|---|
+| `npm run dev` | Matches `package.json` → `"dev": "vite"` | ✅ |
+| `npm run build` | Matches → `"build": "tsc -b && vite build"` | ✅ |
+| `npm test` | Matches → `"test": "vitest run"` | ✅ |
+| `npm run lint` | Matches → `"lint": "eslint ."` | ✅ |
+| `npm run test:watch` | Matches → `"test:watch": "vitest"` | ✅ |
+| Port 32352 | Matches server default | ✅ |
+| Screenshot (`docs/screenshot.png`) | Updated 2026-04-12 | ✅ |
+| `CLAUDE.md` description ("Web-based terminal UI for Claude Code sessions") | README now references both Claude Code and OpenCode | ⚠️ CLAUDE.md description is slightly stale (does not mention OpenCode) — low impact |
+
+No broken install steps, paths, or script references found. README is in good shape.
+
+---
+
+## Draft Changelog
+
+### Since `v0.6.3` (2026-04-12) — Unreleased
+
+#### Fixes
+- **Edit Workflow modal:** widen modal to prevent day-label clipping (#408)
+- **Session lifecycle:** prevent spurious `reconfigure` call when model is first assigned to a new session (#407)
+
+#### Debug / In-progress
+- Add lifecycle logging to diagnose first-message-lost bug (#406) — **note: debug code, not production-ready**
+
+---
+
+### `v0.6.3` period — 2026-04-07 to 2026-04-12
+
+#### Features
+- **ProcessCoordinator:** unified session lifecycle coordinator replacing ad-hoc per-process management (#404)
+- **Auto-webhook setup:** automatically configure GitHub webhook when creating a PR Review workflow (#391)
+- **Workflow model picker:** provider selection (Claude / OpenCode) and searchable model picker in workflow editor (#375)
+- **Webhook health checks:** GitHub webhook integration health indicators and setup wizard (#373)
+
+#### Fixes
+- Polish Edit Workflow modal: frequency highlights, day grid, model default (#403, #405)
+- Improve/streamline Edit Workflow modal layout — two-column design (#393, #401)
+- Address GPT review feedback on report commit robustness (#400)
+- Unify workflow report commit/push across MD and Stepflow systems (#398)
+- Add API rate limiter map cap and attachment file size limit (#397)
+- Harden path traversal, trust proxy, and image src allowlist (#394)
+- Show 'Session started' immediately on startup, not empty chat (#386)
+- Separate reasoning from text in OpenCode streaming for Kimi models
+- Prevent model/session message cascade on OpenCode session start
+- Resolve duplicate model messages and mixed thinking text for OpenCode (#385)
+- Persist OpenCode model selection across sessions (#384)
+- Show model info only once per session, not every turn (#383)
+- Resolve deadlock preventing Claude session start (#382)
+- Overhaul session lifecycle: fix crashes, message loss, duplicate notifications (#381)
+- Prevent message loss when Claude process exits before `system_init` (#380)
+- Prevent session restart loops from process lifecycle races (#379)
+- Preserve user input for session naming (#378)
+- Persist OpenCode provider when saving workflow config (#377)
+- Probe OpenCode availability on startup for accurate connection status (#376)
+- Tighten retry regex patterns and deduplicate model dropdown entries (#372)
+- Set `NODE_ENV=test` in vitest config to prevent `act-is-not-a-function` failures (#371)
+- Resolve eslint template literal error in `claude-process` (#369)
+- Address 5 small issues from audit reports (#366)
+- Validate model when switching between claude and opencode sessions (#363)
+- Prevent symlink-based path traversal in docs and reports endpoints (#358)
+- Address 4 server correctness bugs from code review (#359)
+- Harden server security: auth, rate limiting, CSP, WebSocket origin (#355)
+
+#### Documentation
+- Session initiation audit report (#399)
+- Update changelog and README to feature OpenCode support (#357)
+
+#### Chores
+- Release `v0.6.3`
+- Bump version to `v0.6.1` (#364)
+
+---
+
+## Stale Branches
+
+**Stale threshold:** 30 days (cutoff: 2026-03-15)
+
+**Result: No branches are older than 30 days.** The oldest branches date to 2026-04-09. The repository is in a period of very high activity.
+
+However, the following **merged** branches are still present on the remote and can be safely deleted:
+
+| Branch | Last commit date | Author | Merged into main? | Recommendation |
+|---|---|---|---|---|
+| `origin/docs/changelog-readme-v0.5.5` | 2026-04-10 | alari | ✅ Yes | Delete |
+| `origin/feat/model-picker-search` | 2026-04-12 | alari | ✅ Yes | Delete |
+| `origin/feat/oc-tag-position` | 2026-04-11 | alari | ✅ Yes | Delete |
+| `origin/fix/apr11-reliability-security` | 2026-04-11 | alari | ✅ Yes | Delete |
+| `origin/fix/enforce-report-file-output` | 2026-04-10 | alari | ✅ Yes | Delete |
+| `origin/fix/opencode-model-and-thinking` | 2026-04-12 | alari | ✅ Yes | Delete |
+| `origin/fix/security-hardening-apr12` | 2026-04-12 | alari | ✅ Yes | Delete |
+
+**Total remote branches: 83** (75 unmerged, 7 merged-not-deleted, 1 main)
+
+The number of short-lived feature/fix branches is high (expected for this workflow), but the accumulation will become harder to navigate. A periodic cleanup cadence (e.g., delete merged branches weekly) is recommended.
+
+---
+
+## PR Hygiene
+
+All open PRs as of 2026-04-14:
+
+| PR# | Title | Author | Days open | Reviews | Mergeable | Stuck? |
+|---|---|---|---|---|---|---|
+| #374 | docs: Add audit report for PR #373 | alari76 | 2 | 0 | ✅ MERGEABLE | No |
+| #390 | docs: PR code review audit (2026-04-12) | alari76 | 2 | 0 | ✅ MERGEABLE | No |
+| #392 | docs: add daily code review report 2026-04-12 | alari76 | 2 | 0 | ✅ MERGEABLE | No |
+| #395 | docs: repo health report 2026-04-13 | alari76 | 1 | 0 | ✅ MERGEABLE | No |
+| #396 | docs: test coverage report 2026-04-13 | alari76 | 1 | 0 | ✅ MERGEABLE | No |
+| #402 | docs: session restart root cause audit | alari76 | 1 | 0 | ⛔ CONFLICTING | No (age) |
+
+**None are stuck** (>7 days with no activity). All are documentation-only PRs.
+
+**Action needed on #402:** Merge conflict must be resolved before this PR can land.
+
+**Observation:** All 6 open PRs are docs/audit reports generated by automated agents. They are accumulating faster than they are being merged. Establishing a regular merge cadence for these (e.g., batch-merge weekly) would reduce PR queue noise.
+
+---
+
+## Merge Conflict Forecast
+
+Active branches (commits within last 14 days) compared against `main`:
+
+| Branch | Last commit | Commits ahead | Commits behind | Risk level | Notes |
+|---|---|---|---|---|---|
+| `origin/codekin/reports` | 2026-04-13 | 62 | 467 | 🔴 Critical | Long-running reports accumulation branch; massively diverged. High conflict risk if rebased or merged |
+| `origin/feat/process-coordinator` | 2026-04-13 | 6 | 6 | 🟡 Medium | Session lifecycle changes; may overlap with #407/#406 on main |
+| `origin/feat/test-coverage-2026-04-13` | 2026-04-13 | 3 | 11 | 🟡 Medium | 11 commits behind; test files may conflict with recent server changes |
+| `origin/feat/repo-health-2026-04-13` | 2026-04-13 | 2 | 11 | 🟡 Low-medium | Report files only; low code conflict risk but merge needed |
+| `origin/docs/session-initiation-audit` | 2026-04-13 | 2 | 9 | 🟢 Low | Docs only |
+| `origin/fix/first-message-lost` | 2026-04-13 | 1 | 4 | 🟢 Low | May be superseded by #407 already merged to main |
+| `origin/fix/first-message-lost-reconfigure` | 2026-04-13 | 1 | 2 | 🟢 Low | May be superseded by #407 |
+| `origin/fix/edit-workflow-polish-2` | 2026-04-13 | 1 | 4 | 🟢 Low | Likely superseded by #408 |
+| `origin/fix/workflow-modal-width` | 2026-04-13 | 1 | 1 | 🟢 Low | Likely superseded by #408 |
+| All other branches | 2026-04-12 | 0–2 | 12–27 | 🟢 Low | Merged or superseded |
+
+**Key concern:** `origin/codekin/reports` at 62 ahead / 467 behind is the highest-risk entry. This branch appears to be a long-running accumulation of report commits that diverged from main early and has never been reconciled. It should either be rebased/reset to main or treated as an independent archive branch and never merged. Attempting a merge as-is would produce hundreds of conflicts.
+
+**Secondary concern:** `origin/feat/process-coordinator` (6 ahead, 6 behind) addresses the same session lifecycle area as recent main commits (#406, #407). If this branch is still active it should be rebased before merging.
+
+---
+
+## Recommendations
+
+Ordered by impact:
+
+1. **Clean up debug commit #406** — The commit `debug: add lifecycle logging to diagnose first-message-lost bug` was merged to `main` with lifecycle `console.log` calls for diagnostic purposes. Once the root cause is confirmed (or fixed), these logs should be removed or gated behind a `DEBUG` environment variable to avoid leaking internal state in production.
+
+2. **Resolve or abandon `origin/codekin/reports`** — This branch is 467 commits behind `main` and 62 ahead. It cannot be cleanly merged. Decide: (a) reset it to current `main` and cherry-pick the 62 report commits, or (b) close it as a historical archive and stop using it as a target branch.
+
+3. **Run `knip` or `ts-prune` for unused export detection** — TypeScript's `noUnusedLocals` does not catch exported symbols that are never imported. A one-time run of a dead-export scanner would confirm whether the codebase is truly free of unused public API surface.
+
+4. **Merge or close the 6 open doc PRs** — PRs #374, #390, #392, #395, #396 are all mergeable. PR #402 needs conflict resolution. Batching these docs merges weekly rather than letting them accumulate would keep the PR queue clean.
+
+5. **Delete 7 merged remote branches** — `docs/changelog-readme-v0.5.5`, `feat/model-picker-search`, `feat/oc-tag-position`, `fix/apr11-reliability-security`, `fix/enforce-report-file-output`, `fix/opencode-model-and-thinking`, `fix/security-hardening-apr12` are all merged into main and safe to delete.
+
+6. **Elevate 4 ESLint `no-unsafe-*` rules from `warn` to `error`** — `no-unsafe-assignment`, `no-unsafe-argument`, `no-unsafe-member-access`, and `no-unsafe-return` being warnings means CI passes despite type-unsafe code. Elevating these would harden the type safety guarantee.
+
+7. **Update `docs/WORKFLOWS.md` and `docs/API-REFERENCE.md` for recent features** — The `ProcessCoordinator` refactor (#404), rate limiter caps (#397), and provider/model picker in workflows (#375) changed observable behaviour but docs were not updated alongside. These sections should be brought current.
+
+8. **Document the auto-webhook setup wizard in `docs/GITHUB-WEBHOOKS-SPEC.md`** — Feature added in #391 (2026-04-12). The spec predates it.
+
+9. **Add `eslint-config-prettier`** — Without it, ESLint formatting rules (e.g. spacing, quotes) can silently conflict with Prettier. Adding the bridge package disables ESLint rules that Prettier owns and removes the ambiguity.
+
+10. **Establish a branch cleanup policy** — With 83 remote branches all created in 5 days, the remote is growing quickly. A policy of auto-deleting merged branches (GitHub has a "Automatically delete head branches" repository setting) would prevent the current accumulation from recurring.

--- a/.codekin/reports/repo-health/2026-04-14_repo-health.md
+++ b/.codekin/reports/repo-health/2026-04-14_repo-health.md
@@ -1,0 +1,11 @@
+# Repository Health: codekin
+
+**Date**: 2026-04-14T03:19:46.618Z
+**Repository**: /srv/repos/codekin
+**Branch**: main
+**Workflow Run**: 5486633e-3d57-42d7-b305-1ba68adfcf86
+**Session**: 6ee360fa-27b1-4af6-8d2d-5e8730d97593
+
+---
+
+Now I have sufficient data to write the comprehensive report. Let me compile it.Now I have all the data needed. Let me write the report.The report has been written to `.codekin/reports/repo-health/2026-04-14_repo-health-daily.md`.

--- a/.codekin/reports/repo-health/2026-04-15_repo-health-weekly.md
+++ b/.codekin/reports/repo-health/2026-04-15_repo-health-weekly.md
@@ -1,0 +1,269 @@
+# Codekin Repository Health Report — 2026-04-15
+
+**Assessment date:** 2026-04-15  
+**Branch assessed:** `main` (HEAD `66d6e37`)  
+**Last tag:** `v0.6.3`
+
+---
+
+## Summary
+
+**Overall health rating: Good**
+
+The codebase is in solid condition: strict TypeScript enforced everywhere, no TODO/FIXME debt, no orphan source files, and clean licence posture. The main action items are a cluster of unmerged report branches accumulating behind `main`, one PR with a merge conflict, and two minor documentation gaps from recently landed features.
+
+| Metric | Count |
+|---|---|
+| Dead code items | 0 (no orphan files, no unused exports detected) |
+| Stale TODOs (>30 days) | 0 |
+| Config issues | 1 minor (see Config Drift) |
+| License concerns | 2 transitive deps missing licence metadata |
+| Doc drift items | 2 (ProcessCoordinator, GitHub webhook auto-setup) |
+| Stale branches (>30 days) | 0 |
+| Branches with pending PRs | 6 (all docs reports) |
+| Stuck PRs (>7 days, no review) | 0 |
+
+---
+
+## Dead Code
+
+A full import-graph sweep found no orphaned source files and no exported symbols that are entirely unimported across the project. All server modules (`opencode-process.ts`, `orchestrator-learning.ts`, `orchestrator-memory.ts`, `orchestrator-monitor.ts`, etc.) are imported by at least one other module. All frontend hooks and components are wired into `App.tsx` or sibling components.
+
+| File | Symbol | Type | Finding |
+|---|---|---|---|
+| — | — | — | No dead code detected |
+
+**Note on debug logging:** Commit `4a6ed13` (`debug: add lifecycle logging — #406`) added nine `console.log` trace calls to `session-manager.ts` and `session-lifecycle.ts`. All nine were subsequently removed in `8767041` (#407) and `1f93348` (#404). No residual debug logging from that commit remains.
+
+---
+
+## TODO/FIXME Tracker
+
+A search for `TODO`, `FIXME`, `HACK`, `XXX`, and `WORKAROUND` across all `.ts` / `.tsx` files in `src/` and `server/` returned **zero hits** (matches in `node_modules/` and test-fixture strings excluded).
+
+| file:line | type | comment | author | date | stale? |
+|---|---|---|---|---|---|
+| — | — | No items found | — | — | — |
+
+**Summary:** 0 total · 0 by type · 0 stale
+
+---
+
+## Config Drift
+
+### `tsconfig.app.json` (frontend)
+
+| Setting | Current value | Assessment |
+|---|---|---|
+| `strict` | `true` | ✅ Correct |
+| `noUnusedLocals` | `true` | ✅ Correct |
+| `noUnusedParameters` | `true` | ✅ Correct |
+| `noFallthroughCasesInSwitch` | `true` | ✅ Correct |
+| `noUncheckedSideEffectImports` | `true` | ✅ Correct |
+| `erasableSyntaxOnly` | `true` | ✅ Valid (requires TS ≥ 5.5, project uses 6.0.2) |
+| `skipLibCheck` | `true` | ⚠️ Suppresses declaration-file errors; acceptable for Vite apps but hides upstream type regressions |
+| `target` | `ES2022` | ✅ Appropriate for modern-browser target |
+
+### `tsconfig.node.json` (Vite config)
+
+| Setting | Current value | Assessment |
+|---|---|---|
+| `strict` | `true` | ✅ Correct |
+| `target` | `ES2023` | ✅ Appropriate |
+| `skipLibCheck` | `true` | Same note as above |
+
+### `server/tsconfig.json`
+
+| Setting | Current value | Assessment |
+|---|---|---|
+| `strict` | `true` | ✅ Correct |
+| `module` / `moduleResolution` | `NodeNext` / `NodeNext` | ✅ Correct for ESM Node.js server |
+| `isolatedModules` | `true` | ✅ Correct |
+| `skipLibCheck` | `true` | Same note as above |
+
+### `eslint.config.js`
+
+| Finding | Detail |
+|---|---|
+| ✅ Flat config (ESLint 9+) | Uses modern flat config format; no deprecated `.eslintrc` files present |
+| ✅ `@typescript-eslint/no-deprecated: 'error'` | Both frontend and server rule groups enforce this |
+| ✅ `@typescript-eslint/no-unsafe-*` rules enforced | Strict unsafe-operation rules added in PR #410 |
+| ⚠️ `@typescript-eslint/no-explicit-any: 'off'` in test config | Intentional relaxation for test files; acceptable but worth documenting as a deliberate choice |
+
+### `.prettierrc`
+
+| Setting | Current value | Assessment |
+|---|---|---|
+| `semi` | `false` | ✅ Consistent with project style |
+| `singleQuote` | `true` | ✅ Consistent |
+| `trailingComma` | `"all"` | ✅ Consistent |
+| `printWidth` | `120` | ✅ Reasonable for wide-screen development |
+
+**Overall config verdict:** Excellent. All three tsconfig targets enforce `strict`, `noUnusedLocals`, and `noUnusedParameters`. No deprecated ESLint rules detected. The only minor note is `skipLibCheck: true` across all configs — a common Vite project default, but worth revisiting if upstream type errors become a concern.
+
+---
+
+## License Compliance
+
+Project licence: **MIT** (permissive)
+
+### Licence summary table
+
+| Licence | Dependency count | Risk |
+|---|---|---|
+| MIT | 465 | ✅ None |
+| ISC | 22 | ✅ None (permissive) |
+| Apache-2.0 | 18 | ✅ None |
+| MPL-2.0 | 12 | ℹ️ Weak copyleft (file-level); safe for MIT projects when source files not modified |
+| BSD-3-Clause | 9 | ✅ None |
+| BSD-2-Clause | 8 | ✅ None |
+| BlueOak-1.0.0 | 4 | ✅ None (permissive) |
+| MIT-0 | 2 | ✅ None |
+| CC-BY-4.0 | 1 | ✅ Documentation/attribution only |
+| CC0-1.0 | 1 | ✅ Public domain |
+| (BSD-2-Clause OR MIT OR Apache-2.0) | 1 | ✅ None |
+| (MIT OR WTFPL) | 1 | ✅ None |
+| (MPL-2.0 OR Apache-2.0) | 1 | ✅ None |
+| 0BSD | 1 | ✅ None |
+| **MISSING** | **2** | ⚠️ See below |
+
+### Flagged dependencies
+
+| Package | Issue | Notes |
+|---|---|---|
+| `busboy` | No `license` field in `package-lock.json` | Transitive dependency of `multer`. Package source carries MIT licence but metadata is absent from the lock file. Low risk; verify with `npm view busboy license`. |
+| `streamsearch` | No `license` field in `package-lock.json` | Transitive dependency of `busboy` (→ `multer`). Same situation. Low risk. |
+
+No GPL, AGPL, or LGPL dependencies detected. MPL-2.0 packages (`source-map`, `mozilla-*` utilities) are used unmodified so copyleft does not propagate.
+
+---
+
+## Documentation Freshness
+
+### API Docs drift
+
+| Area | Change | Doc status |
+|---|---|---|
+| `ProcessCoordinator` (PR #404 — 2026-04-13) | New `server/process-coordinator.ts` module unifying session lifecycle | ⚠️ Not reflected in `docs/API-REFERENCE.md` or `docs/FEATURES.md` |
+| GitHub webhook auto-setup (PR #391 — 2026-04-08) | `POST /api/integrations/github/pr-review/setup` auto-configures webhook | ⚠️ `docs/GITHUB-WEBHOOKS-SPEC.md` and `docs/PR-REVIEW-WEBHOOK.md` should describe the new auto-setup flow |
+| Strict `@typescript-eslint/no-unsafe-*` rules (PR #410 — 2026-04-14) | ESLint config tightened | ✅ Internal change; no user-facing doc update needed |
+| Edit Workflow modal layout fixes (#401, #403, #405, #408) | UI polish only | ✅ No doc update needed |
+
+### README drift
+
+The `README.md` was updated in the same release cycle (screenshot refreshed with PR `445bb49`). All commands listed under "Usage" and "Install" were verified against `package.json` scripts and `bin/codekin.mjs`. No drift detected.
+
+| README item | Actual state | Status |
+|---|---|---|
+| `npm run dev` | Present in `package.json` | ✅ |
+| `npm run build` | Present in `package.json` | ✅ |
+| `npm test` | Mapped to `vitest run` | ✅ |
+| `npm run lint` | Mapped to `eslint` | ✅ |
+| `PORT=32352` default | Matches `server/config.ts` | ✅ |
+| `REPOS_ROOT=~/repos` | Matches `server/config.ts` | ✅ |
+| OpenCode listed as optional prerequisite | Accurate | ✅ |
+
+---
+
+## Draft Changelog
+
+### v0.6.4 (unreleased) — since v0.6.3
+
+#### Features
+- **Unified ProcessCoordinator** — new `server/process-coordinator.ts` centralises session lifecycle management across Claude and OpenCode providers, replacing ad-hoc start/stop calls scattered across session handlers (#404)
+- **GitHub webhook auto-setup** — PR Review workflows now auto-configure the GitHub webhook via the setup wizard; no manual token entry required (#391)
+
+#### Fixes
+- Harden docs browser root scope and persist canonical paths to prevent path traversal edge cases (#409)
+- Widen Edit Workflow modal to prevent day-label clipping on narrow viewports (#408)
+- Prevent spurious model reconfiguration when a model is first assigned to a new session (#407)
+- Polish Edit Workflow modal: frequency highlights, day grid, model default (#403, #405)
+- Streamline Edit Workflow modal two-column layout (#401, #393)
+- Address robustness issues in report commit flow identified in GPT review (#400)
+- Unify workflow report commit/push logic across Markdown and Stepflow paths (#398)
+- Cap API rate-limiter map size and add attachment file size limit (#397)
+- Harden path traversal, trust-proxy config, and image-src allowlist (#394)
+
+#### Chores
+- Enforce strict `@typescript-eslint/no-unsafe-*` rules across the entire codebase (#410)
+
+#### Documentation
+- Session initiation audit report (#399)
+
+#### Debug (temporary — already cleaned up)
+- *(internal)* Added lifecycle trace logging to diagnose first-message-lost race condition (#406); removed in #407 and #404
+
+---
+
+## Stale Branches
+
+No branches with last commit older than 30 days were found. All remote branches are within the past 14 days.
+
+| Branch | Last commit | Author | Merged into main? | Recommendation |
+|---|---|---|---|---|
+| `origin/chore/eslint-strict-unsafe` | 2026-04-14 | alari | No (pre-merge shadow) | **Delete** — content already merged via PR #410; this branch has an identical commit 1-ahead that creates a confusing duplicate |
+| `origin/fix/security-and-cleanup-apr14` | 2026-04-14 | alari | No | Review and merge or close; 1 commit ahead, modifies `session-routes.ts` and `docs-routes.ts` |
+| `origin/docs/session-restart-audit` | 2026-04-13 | alari | No | Corresponds to open PR #402 (merge conflict); resolve conflict and merge |
+| `origin/feat/repo-health-2026-04-13` | 2026-04-13 | alari | No | Corresponds to open PR #395; merge |
+| `origin/feat/test-coverage-2026-04-13` | 2026-04-13 | alari | No | Corresponds to open PR #396; merge |
+| `origin/feat/daily-code-review-2026-04-12` | 2026-04-12 | alari | No | Corresponds to open PR #392; merge |
+| `origin/chore/pr-audit-2026-04-12` | 2026-04-12 | alari | No | Corresponds to open PR #390; merge |
+| `origin/feat/pr-373-audit-report` | 2026-04-12 | alari | No | Corresponds to open PR #374; merge |
+| `origin/feat/connection-status-popup` | 2026-04-11 | alari | No | No open PR; 5 commits ahead, 61 behind — stale feature branch; create PR or delete |
+| `origin/test/coverage-gaps-apr10` | 2026-04-10 | Claude (Webhook) | No | 2 commits ahead, 87 behind — very stale; merge or abandon |
+| `origin/codekin/reports` | 2026-04-15 | alari | No | Automated reports branch; 66 ahead / 469 behind — extreme divergence (see Merge Conflict Forecast) |
+
+---
+
+## PR Hygiene
+
+All 6 open PRs are doc-report branches created by automated workflows. None has been open for more than 3 days.
+
+| PR# | Title | Author | Days open | Review status | Conflicts? | Stuck? |
+|---|---|---|---|---|---|---|
+| #402 | docs: session restart root cause audit | alari76 | 2 | None | ⚠️ CONFLICTING | No |
+| #396 | docs: test coverage report 2026-04-13 | alari76 | 2 | None | No | No |
+| #395 | docs: repo health report 2026-04-13 | alari76 | 2 | None | No | No |
+| #392 | docs: add daily code review report for 2026-04-12 | alari76 | 3 | None | No | No |
+| #390 | docs: PR code review audit (2026-04-12, last 7 merged) | alari76 | 3 | None | No | No |
+| #374 | docs: Add audit report for PR #373 | alari76 | 3 | None | No | No |
+
+No PRs meet the "stuck" threshold (>7 days open, no review). PR #402 requires conflict resolution before it can merge.
+
+---
+
+## Merge Conflict Forecast
+
+Active branches (commits within last 14 days) assessed against `main`.
+
+| Branch | Ahead main | Behind main | Modified files | Overlap with main? | Risk |
+|---|---|---|---|---|---|
+| `origin/codekin/reports` | 66 | 469 | Report files in `.codekin/reports/` | Low (report files only) | 🟡 Medium — extreme divergence but reports-only edits; merge will produce a large diff but likely no code conflicts |
+| `origin/fix/security-and-cleanup-apr14` | 1 | 2 | `server/docs-routes.ts`, `server/session-routes.ts` | `session-routes.ts` also touched by PR #410 (eslint-strict, now merged into main) | 🟠 High — overlapping `session-routes.ts`; line-level conflicts likely when merging |
+| `origin/chore/eslint-strict-unsafe` | 1 | 1 | `eslint.config.js`, 10 server `.ts` files | All touched files are identical to PR #410 already in main | 🔴 Critical — this branch IS a duplicate of the merged PR; it will conflict on every file it touches |
+| `origin/feat/connection-status-popup` | 5 | 61 | `ConnectionPopup.tsx` and related frontend files | No recent main-branch changes to those files | 🟡 Medium — 61 commits behind but likely isolated to its own files; needs rebase |
+| `origin/test/coverage-gaps-apr10` | 2 | 87 | Test files | No recent main-branch test changes to same files | 🟡 Medium — 87 commits behind; low code overlap but needs rebase |
+
+---
+
+## Recommendations
+
+1. **Delete `origin/chore/eslint-strict-unsafe`** — Its single commit is a duplicate of PR #410, which was already merged into `main`. The branch is not associated with any open PR and will cause conflict noise if left around. Run: `git push origin --delete chore/eslint-strict-unsafe`.
+
+2. **Resolve and merge PR #402 (session restart audit)** — It is the only open PR with a merge conflict. Rebase the branch onto current `main` and resolve the conflict so the audit report lands in history.
+
+3. **Batch-merge or close the five pending docs-report PRs (#374, #390, #392, #395, #396)** — These are automated report branches created by workflows. They are mergeable and have no review requirements. Merging them clears the open-PR queue and keeps the report history up to date.
+
+4. **Triage `origin/feat/connection-status-popup`** — 5 commits, 61 commits behind `main`, no open PR. Either open a PR, rebase, and merge, or delete the branch if the work was superseded.
+
+5. **Address `origin/codekin/reports` divergence** — This automated branch is 469 commits behind `main`. Decide whether it should be periodically rebased or whether reports should always be committed directly to dated feature branches (current practice). If the branch exists only as an artefact, delete it.
+
+6. **Document `ProcessCoordinator` in `docs/API-REFERENCE.md` and `docs/FEATURES.md`** — PR #404 introduced a significant architectural change (unified session lifecycle coordinator) that is not yet reflected in any documentation file.
+
+7. **Update `docs/GITHUB-WEBHOOKS-SPEC.md` and `docs/PR-REVIEW-WEBHOOK.md` for auto-setup flow** — PR #391 added a one-click webhook auto-setup endpoint. The existing spec docs describe a manual configuration path and should be updated to reflect the new wizard.
+
+8. **Verify `busboy` and `streamsearch` licence metadata** — Both packages have missing `license` fields in `package-lock.json`. Run `npm view busboy license` and `npm view streamsearch license` to confirm they are MIT and update the lock file via a `npm install` refresh if needed.
+
+9. **Review `fix/security-and-cleanup-apr14` for `session-routes.ts` conflicts** — This branch touches the same file as the recently merged PR #410. Pull it up, rebase onto `main`, resolve conflicts, and either merge or close before the divergence widens further.
+
+10. **Consider enabling `skipLibCheck: false` in a follow-up refactor** — All three tsconfig files use `skipLibCheck: true`, which is a Vite scaffolding default. Now that strict mode and `no-unsafe-*` rules are fully enforced, enabling `skipLibCheck: false` would catch upstream type regressions at build time. Low urgency, but worth scheduling as a future hardening step.

--- a/.codekin/reports/repo-health/2026-04-15_repo-health.md
+++ b/.codekin/reports/repo-health/2026-04-15_repo-health.md
@@ -1,0 +1,30 @@
+# Repository Health: codekin
+
+**Date**: 2026-04-15T03:21:19.564Z
+**Repository**: /srv/repos/codekin
+**Branch**: main
+**Workflow Run**: 932b2407-c219-4ee5-8d49-e42b5ebc627d
+**Session**: 9aed0fb6-da28-4cb6-a90f-3089051b1f83
+
+---
+
+Now I have all the data I need. Let me write the comprehensive report.Now I have all the data. Let me write the report.The report has been written to `.codekin/reports/repo-health/2026-04-15_repo-health-weekly.md`.
+
+Here's the executive summary of findings:
+
+---
+
+**Overall health: Good**
+
+**Key findings across the 10 checks:**
+
+- **Dead code** — Zero orphan files, zero unused exports. Debug `console.log` calls from commit `4a6ed13` were already cleaned up in subsequent PRs.
+- **TODO/FIXME** — Zero items in any source file. The codebase is debt-free on this metric.
+- **Config drift** — All three tsconfig targets enforce `strict`, `noUnusedLocals`, and `noUnusedParameters`. One minor note: `skipLibCheck: true` everywhere is standard Vite scaffolding but worth revisiting.
+- **Licence compliance** — Clean. Only `busboy` and `streamsearch` (both transitive `multer` deps) are missing licence metadata in the lock file — low risk, worth a quick `npm view` to confirm.
+- **Doc freshness** — Two gaps: `ProcessCoordinator` (PR #404) and the GitHub webhook auto-setup wizard (PR #391) are not yet documented in `docs/`.
+- **README drift** — No drift. All scripts and config vars match the actual codebase.
+- **Draft changelog** — 2 features, 10 fixes, 1 chore since v0.6.3.
+- **Stale branches** — No branches older than 30 days, but `origin/chore/eslint-strict-unsafe` is a duplicate of the already-merged PR #410 and should be deleted.
+- **PR hygiene** — 6 open docs-report PRs, all ≤3 days old, none stuck. PR #402 has a merge conflict.
+- **Merge conflict forecast** — `fix/security-and-cleanup-apr14` overlaps `session-routes.ts` with recently merged changes (🟠 High risk). `codekin/reports` is 469 commits behind main (🟡 Medium).All reports committed and pushed. PR Multiplier-Labs/codekin#413 is open with all 8 report files.

--- a/.codekin/reports/repo-health/2026-04-16_repo-health.md
+++ b/.codekin/reports/repo-health/2026-04-16_repo-health.md
@@ -1,0 +1,285 @@
+# Repository Health Report — 2026-04-16
+
+> **Scope:** Full housekeeping, documentation, and git hygiene assessment.
+> **Branch assessed:** `main` (at commit `274298e`) + active remote branches.
+> **Date:** 2026-04-16
+
+---
+
+## Summary
+
+**Overall health: Good**
+
+The codebase is in solid shape with strict TypeScript, comprehensive ESLint coverage, clean licensing, and zero TODO/FIXME debt in production code. The main concerns are a handful of unused exports in `orchestrator-learning.ts` and two frontend utility files, a TypeScript version mismatch between root and server workspaces, a clutch of 7 stale-ish ESLint `warn` rules flagged for future promotion, an accumulation branch (`codekin/reports`) that is severely diverged from `main`, and a growing queue of open docs/report PRs with no reviews.
+
+| Category | Status | Detail |
+|---|---|---|
+| Dead code items | 8 | Unused exports in `orchestrator-learning`, `ccApi`, `workflowApi`, `workflowHelpers` |
+| Stale TODOs | 0 | No TODO/FIXME/HACK/XXX in production source |
+| Config issues | 3 | TS version mismatch, 7 `warn`→`error` promotions pending, no Prettier |
+| License concerns | 0 | All dependencies MIT/ISC/Apache/BSD |
+| Doc drift items | 2 | Debug lifecycle logs in `main`, open docs PRs accumulating |
+| Stale branches | 1 | `codekin/reports` (69 ahead, 473 behind main) |
+| Stuck PRs (>7 days) | 0 | All 7 open PRs are 1–4 days old |
+
+---
+
+## Dead Code
+
+### Unused Exports
+
+| File | Export | Type | Recommendation |
+|---|---|---|---|
+| `server/orchestrator-learning.ts` | `findDuplicate` | Unused export (function) | Remove or add caller; no references outside defining file |
+| `server/orchestrator-learning.ts` | `getSkillLevel` | Unused export (function) | Remove or add caller; no references outside defining file |
+| `server/orchestrator-learning.ts` | `saveSkillProfile` | Unused export (function) | Remove or add caller; `loadSkillProfile` is called but save is not |
+| `src/lib/ccApi.ts` | `HealthCheckDetail` | Unused export (type) | Remove type export; type appears unused by any component |
+| `src/lib/workflowApi.ts` | `RunStatus` | Unused export (type) | Internal type; remove export if not part of public API |
+| `src/lib/workflowApi.ts` | `StepStatus` | Unused export (type) | Internal type; remove export if not part of public API |
+| `src/lib/workflowHelpers.ts` | `EVENT_DRIVEN_KINDS` | Unused export (const) | No importers found; remove or use in `workflowApi` filtering |
+| `src/lib/workflowHelpers.ts` | `biweeklyDay` | Unused export (function) | No importers found; likely superseded by newer frequency logic |
+
+### Unreachable Functions
+
+No unreachable private functions were detected in a spot-check of high-complexity modules.
+
+### Orphan Files
+
+`server/vitest.config.ts` is excluded from the server `tsconfig.json` and not imported by any module — this is intentional (vitest's own config pickup); not a concern.
+
+`server/ws-server.ts` is the main server entry point. The import-chain check correctly shows 0 *inbound* imports — it is the root, not an orphan.
+
+---
+
+## TODO/FIXME Tracker
+
+A full scan of `src/` and `server/` (all `.ts`/`.tsx` files, excluding `node_modules`) found **zero** `TODO`, `FIXME`, `HACK`, `XXX`, or `WORKAROUND` comments in production source code. The only matches were inside test assertion strings (e.g. `expect(summarizeToolInput('Grep', { pattern: 'TODO' }))`).
+
+| Type | Count | Stale (>30 days) |
+|---|---|---|
+| TODO | 0 | 0 |
+| FIXME | 0 | 0 |
+| HACK | 0 | 0 |
+| XXX | 0 | 0 |
+| WORKAROUND | 0 | 0 |
+| **Total** | **0** | **0** |
+
+**Notable observation:** Debug lifecycle logging committed in PR #406 (`debug: add lifecycle logging to diagnose first-message-lost bug`) — including `console.log` calls tagged `[startClaude]`, `[sendInput]`, `[onSystemInit]`, and `[setModel]` — was merged to `main` as a diagnostic measure. The associated bug fix (PR #407) did not remove this logging. These are not `TODO` comments, but they represent temporary diagnostic code that has lingered. See **Recommendations** §1.
+
+---
+
+## Config Drift
+
+### TypeScript Version Mismatch
+
+| Config file | Setting | Current value | Recommended |
+|---|---|---|---|
+| `package.json` (root/frontend) | `devDependencies.typescript` | `"^6.0.2"` | Align with server |
+| `server/package.json` | `devDependencies.typescript` | `"~5.9.3"` | Upgrade to `^6.0.2` or pin both to same major |
+
+**Risk:** The frontend and server TypeScript compilers are on different major versions. This can cause inconsistent `tsc` behavior, different lib types, and unexpected compile errors during upgrades.
+
+### ESLint: `warn` Rules Scheduled for Promotion
+
+The ESLint config (`eslint.config.js`) includes an explicit comment: *"These should be promoted to errors as the codebase is cleaned up."* Seven rules are currently `warn` in both the `src/` and `server/` rule sets:
+
+| Rule | Current | Target |
+|---|---|---|
+| `@typescript-eslint/restrict-template-expressions` | `warn` | `error` |
+| `@typescript-eslint/no-confusing-void-expression` | `warn` | `error` |
+| `@typescript-eslint/no-unnecessary-condition` | `warn` | `error` |
+| `@typescript-eslint/no-base-to-string` | `warn` | `error` |
+| `@typescript-eslint/no-non-null-assertion` | `warn` | `error` |
+| `@typescript-eslint/no-misused-promises` | `warn` | `error` |
+| `@typescript-eslint/use-unknown-in-catch-callback-variable` | `warn` | `error` |
+| `@typescript-eslint/require-await` | `warn` | `error` |
+
+The recent chore (#410) already promoted all `no-unsafe-*` rules to `error`. Promoting the remaining `warn` rules incrementally would further harden CI gates.
+
+### ESLint: Test Files Use Relaxed Config
+
+| Config file | Setting | Current | Recommended |
+|---|---|---|---|
+| `eslint.config.js` (test glob) | `extends` | `tseslint.configs.recommended` | Consider `strictTypeChecked` with targeted overrides |
+
+Test files currently opt out of `strictTypeChecked` entirely. While `@typescript-eslint/no-explicit-any: off` is reasonable for test stubs, using `recommended` loses several useful safety rules in test code.
+
+### Missing Prettier Config
+
+No `.prettierrc`, `prettier.config.*`, or `prettier` key in `package.json` was found. Code style is enforced by TSC and ESLint only. Not a blocking issue, but adding a Prettier config would prevent whitespace/formatting churn in PRs.
+
+---
+
+## License Compliance
+
+**Project license:** MIT
+
+All production and dev dependencies use permissively compatible licenses. The project's `package.json` includes explicit notes for the two borderline cases.
+
+| License | Count |
+|---|---|
+| MIT | 100 |
+| ISC | 7 |
+| Apache-2.0 | 2 |
+| BSD-3-Clause | 2 |
+| (MIT OR WTFPL) | 1 |
+| (BSD-2-Clause OR MIT OR Apache-2.0) | 1 |
+| **Total** | **113** |
+
+**Flagged for awareness (not blocking):**
+
+- **`dompurify`** — Dual-licensed MPL-2.0 OR Apache-2.0. The `package.json` `licenseNotes` field correctly documents that library use under Apache-2.0 is permissively compatible with MIT. No action required.
+- **`lightningcss`** — MPL-2.0, used by TailwindCSS at build time only (not distributed in output artifacts). The `licenseNotes` field documents this. No action required.
+
+No GPL, AGPL, or LGPL dependencies detected.
+
+---
+
+## Documentation Freshness
+
+### API Docs vs Recent Code Changes
+
+`docs/API-REFERENCE.md` covers the primary REST endpoints and was last meaningfully updated to reflect the session-lifecycle overhaul and orchestrator API changes. Recent feature additions that may warrant doc updates:
+
+| Area | Last Code Change | Doc Status |
+|---|---|---|
+| GitHub webhook auto-setup (`feat: auto-setup GitHub webhook`, PR #391) | 2026-04-12 | `docs/GITHUB-WEBHOOKS-SPEC.md` last updated ~Apr 5; PR #414 (merged Apr 15 via `docs/cleanup-apr15`) may have addressed this — confirm post-merge |
+| PR Review webhook (`docs/PR-REVIEW-WEBHOOK.md`) | Code: Apr 12 | Branch `docs/cleanup-apr15` touched this file; merged Apr 15 via PR #414 |
+| ProcessCoordinator (`feat: unified ProcessCoordinator`, PR #404) | 2026-04-13 | No dedicated doc section; `stream-json-protocol.md` may be implicitly stale |
+| Debug lifecycle logs (`debug: add lifecycle logging`, PR #406) | 2026-04-13 | Not documented — intentional (temporary code), but creates noise for contributors reading the source |
+
+### README Drift
+
+The project README (`README.md`) is end-user focused and does **not** expose `npm run dev` or other dev commands — those live in `CONTRIBUTING.md`. No drift found between the two.
+
+**CONTRIBUTING.md verification:**
+- `npm install --prefix server` — `server/package.json` exists; command is valid ✓
+- `npm run dev` — present in root `package.json` as `"vite"` ✓
+- Environment variable table — matches `server/config.ts` exports ✓
+- No stale paths or removed commands detected
+
+**Minor finding:** CONTRIBUTING.md references `server/config.ts` for env vars but does not mention `CODEKIN_AGENT_NAME` in its variable table, even though it is a documented export and configurable at runtime. Low severity.
+
+---
+
+## Draft Changelog
+
+### v0.6.4 (since v0.6.3 tag, 2026-04-12 to 2026-04-16)
+
+#### Features
+- **Unified ProcessCoordinator** for session lifecycle management — single entry point for `startClaude`, `stopClaude`, and restart logic across the session state machine (#404)
+- **Auto-setup GitHub webhook** for PR Review workflows — wizard now configures the webhook automatically during workflow creation (#391)
+
+#### Fixes
+- Prevent spurious model reconfigure when a model is first assigned to a new session (#407)
+- Harden docs browser root scope and persist canonical paths to prevent path traversal edge cases (#409)
+- Widen Edit Workflow modal to prevent day-label clipping on narrow viewports (#408)
+- Unify workflow report commit/push across Markdown and Stepflow systems (#398)
+- Add API rate-limiter map cap and attachment file-size limit (#397)
+- Harden path traversal, trust-proxy, and image-src allowlist (#394)
+- Improve Edit Workflow modal layout: two-column design, frequency highlights, day grid, model default (#393, #401, #403, #405)
+- Address GPT review feedback on report commit robustness (#400)
+
+#### Chores
+- Enforce strict `@typescript-eslint/no-unsafe-*` rules across the full codebase; promote all five `no-unsafe-*` rules from `warn` to `error` (#410)
+- Release v0.6.3 (#388 tag)
+
+#### Documentation
+- Weekly repo health report and accumulated audit reports (2026-04-15) (#413)
+- Session initiation audit report (#399)
+- Session restart root-cause audit (#402)
+- Test coverage report 2026-04-13 (#396)
+- Repo health report 2026-04-13 (#395)
+- Daily code-review report 2026-04-12 (#392)
+- PR code-review audit 2026-04-12 (#390)
+- Audit report for PR #373 GitHub webhook health checks (#374)
+- Docs cleanup: features, webhook specs, PR review spec, workflows doc (Apr 15) (PR #414)
+
+---
+
+## Stale Branches
+
+All detected remote branches have activity within the last 6 days. None are older than 30 days. The only branch warranting immediate action is `codekin/reports`, which has diverged severely from `main` and appears to serve as an accumulation buffer for automated report commits.
+
+| Branch | Last Commit | Author | Merged into main? | Recommendation |
+|---|---|---|---|---|
+| `origin/codekin/reports` | 2026-04-15 | alari | No (69 ahead, 473 behind) | Investigate purpose; if it's an automated accumulation branch, document it. If superseded by the PR-based report flow, delete it. |
+| `origin/test/coverage-gaps-apr10` | 2026-04-10 | Claude (Webhook) | No (no open PR found) | Verify work was incorporated; delete if abandoned |
+| `origin/feat/connection-status-popup` | 2026-04-11 | alari | No (no open PR found) | Verify work was merged via squash under different name; delete if done |
+| `origin/feat/pr-373-audit-report` | 2026-04-12 | alari | No (open PR #374) | Merge or close PR #374 |
+| `origin/feat/daily-code-review-2026-04-12` | 2026-04-12 | alari | No (open PR #392) | Merge or close PR #392 |
+| `origin/chore/pr-audit-2026-04-12` | 2026-04-12 | alari | No (open PR #390) | Merge or close PR #390 |
+| `origin/feat/repo-health-2026-04-13` | 2026-04-13 | alari | No (open PR #395) | Merge or close PR #395 |
+| `origin/feat/test-coverage-2026-04-13` | 2026-04-13 | alari | No (open PR #396) | Merge or close PR #396 |
+| `origin/docs/session-restart-audit` | 2026-04-15 | alari | No (open PR #402) | Merge or close PR #402 |
+| `origin/refactor/app-decompose-hooks` | 2026-04-15 | alari | Yes (merged PR #416) | Delete remote branch |
+| `origin/refactor/split-orchestrator-routes` | 2026-04-15 | alari | Yes (merged PR #415) | Delete remote branch |
+| `origin/docs/cleanup-apr15` | 2026-04-15 | alari | Yes (merged PR #414) | Delete remote branch |
+
+---
+
+## PR Hygiene
+
+All 7 open PRs are docs/audit-report submissions. None have received any review activity. None exceed the 7-day "stuck" threshold yet, but 6 of them are 3–4 days old with no movement.
+
+| PR # | Title | Author | Days Open | Review Status | Conflicts | Stuck? |
+|---|---|---|---|---|---|---|
+| #413 | docs: weekly repo health report + accumulated audit reports (2026-04-15) | alari76 | 1 | No review | Unknown | No |
+| #402 | docs: session restart root cause audit | alari76 | 3 | No review | Unknown | No |
+| #396 | docs: test coverage report 2026-04-13 | alari76 | 3 | No review | Unknown | No |
+| #395 | docs: repo health report 2026-04-13 | alari76 | 3 | No review | Unknown | No |
+| #392 | docs: add daily code review report for 2026-04-12 | alari76 | 4 | No review | Unknown | No |
+| #390 | docs: PR code review audit (2026-04-12, last 7 merged) | alari76 | 4 | No review | Unknown | No |
+| #374 | docs: Add audit report for PR #373 | alari76 | 4 | No review | Unknown | No |
+
+**Pattern note:** The repo has a recurring workflow that auto-generates report PRs. These are accumulating without a clear merge cadence. Consider either auto-merging docs-only PRs via a CI rule, or batching them into a single weekly docs PR to reduce open-PR noise.
+
+---
+
+## Merge Conflict Forecast
+
+Branches with commits in the last 14 days that have not yet merged into `main`:
+
+| Branch | Commits Ahead | Commits Behind | Files Modified on Branch | Overlapping with Main Changes | Risk |
+|---|---|---|---|---|---|
+| `origin/docs/session-restart-audit` | 1 | 4 | `.codekin/reports/` (docs only) | No source overlaps | Low |
+| `origin/feat/repo-health-2026-04-15` | 1 | 4 | `.codekin/reports/` (docs only) | No source overlaps | Low |
+| `origin/codekin/reports` | 69 | 473 | `.codekin/reports/` (accumulation) | Potential report file name collisions | Medium — file-level conflicts possible if same report dates were generated on main and on branch |
+
+Branches already merged (remote refs not yet cleaned up): `refactor/app-decompose-hooks`, `refactor/split-orchestrator-routes`, `docs/cleanup-apr15`.
+
+**No high-risk source code conflicts detected.** All active unmerged branches touch only docs/reports directories or are already merged.
+
+---
+
+## Recommendations
+
+1. **Remove debug lifecycle logs from `main`** *(High impact, Low effort)*
+   Commit #406 added `console.log` calls tagged `[startClaude]`, `[sendInput]`, `[onSystemInit]`, and `[setModel]` to `server/session-lifecycle.ts` and `server/session-manager.ts`. These were diagnostic aids for the first-message-lost bug. PR #407 fixed the bug but did not remove the logs. They now pollute server stdout in production. Strip them in a clean-up commit.
+
+2. **Remove three unused exports from `server/orchestrator-learning.ts`** *(Medium impact, Low effort)*
+   `findDuplicate`, `getSkillLevel`, and `saveSkillProfile` are exported but have no callers in any production module. Either add callers or remove the exports to reduce the public surface and avoid confusion. `saveSkillProfile` is particularly suspicious given `loadSkillProfile` has callers — a missing call site may indicate a logic gap.
+
+3. **Align TypeScript versions across workspaces** *(Medium impact, Low effort)*
+   Root `package.json` pins `typescript@^6.0.2`; `server/package.json` pins `~5.9.3`. Upgrade the server to `^6.0.x` (or a matching `~6.0.x` pin) so both workspaces compile with the same compiler. This prevents subtle type differences and simplifies upgrade coordination.
+
+4. **Promote ESLint `warn` rules to `error` incrementally** *(Medium impact, Medium effort)*
+   Eight rules are explicitly marked as "should be promoted to errors". The recent `no-unsafe-*` promotion (PR #410) demonstrates the pattern works. Tackle `@typescript-eslint/no-non-null-assertion` and `@typescript-eslint/no-misused-promises` next — they catch real runtime bugs and the codebase likely has few remaining violations after recent cleanups.
+
+5. **Merge or close the 7 open docs PRs** *(Medium impact, Low effort)*
+   Six docs/report PRs are 3–4 days old with zero reviews. These are automated outputs. Establish a policy: either merge them on creation (or via auto-merge if CI passes) or close them in favour of a weekly batch. The current accumulation creates open-PR noise and makes it harder to spot real work-in-progress PRs.
+
+6. **Investigate and clean up `origin/codekin/reports` branch** *(Medium impact, Low effort)*
+   This branch is 473 commits behind `main` and 69 ahead — it has likely drifted beyond usefulness as a merge target. If it serves as an automated report accumulation buffer (separate from the PR-based flow), document this intent. If it is superseded, delete it.
+
+7. **Delete stale remote branches for merged work** *(Low impact, Low effort)*
+   `origin/refactor/app-decompose-hooks`, `origin/refactor/split-orchestrator-routes`, and `origin/docs/cleanup-apr15` all have merged PRs but their remote refs were not deleted. Run `git push origin --delete <branch>` for each. Also confirm `feat/connection-status-popup` and `test/coverage-gaps-apr10` are accounted for (no open PRs found; verify the work landed under a different branch name).
+
+8. **Remove 5 unused frontend exports** *(Low impact, Low effort)*
+   `HealthCheckDetail` (ccApi), `RunStatus` and `StepStatus` (workflowApi), `EVENT_DRIVEN_KINDS` and `biweeklyDay` (workflowHelpers) are exported but have no importers. With `noUnusedLocals: true` in tsconfig, these survive only because they are explicitly `export`ed. Remove the `export` keyword (or the symbols entirely if they are truly dead).
+
+9. **Add a Prettier configuration** *(Low impact, Low effort)*
+   The project has no formatting config. Adding a minimal `.prettierrc` (e.g., `{ "singleQuote": true, "semi": false }`) and a `format` script would prevent formatting drift in PRs and align with the existing single-quote, no-semicolon style visible throughout the codebase.
+
+10. **Add `CODEKIN_AGENT_NAME` to CONTRIBUTING.md environment variable table** *(Low impact, Low effort)*
+    The `CODEKIN_AGENT_NAME` env var is exported from `config.ts` and documented in code comments but is absent from CONTRIBUTING.md's env var table. A one-line addition would make it discoverable for contributors.

--- a/.codekin/reports/security/2026-04-16_security-audit.md
+++ b/.codekin/reports/security/2026-04-16_security-audit.md
@@ -1,0 +1,170 @@
+# Security Audit: codekin — 2026-04-16
+
+**Overall Risk Rating: Low — 0 Critical, 0 High, 2 Medium, 4 Low**
+
+---
+
+## Summary
+
+The codebase continues to demonstrate strong security fundamentals. All five findings from the April 2 audit (M1, L1, L2, M2, L5) have been remediated. Two medium and four low findings remain open or are newly identified. No hardcoded secrets or committed credentials were detected.
+
+| Severity | Count | Status |
+|----------|-------|--------|
+| Critical | 0 | — |
+| High | 0 | — |
+| Medium | 2 | 1 new, 1 carried forward |
+| Low | 4 | 2 new, 2 carried forward |
+
+### Remediations confirmed since April 2 audit
+
+| Finding | Description | Fix |
+|---------|-------------|-----|
+| M1 | No auth token exits instead of warn | `process.exit(1)` added at `ws-server.ts:75` |
+| M2 | Stepflow enabled without secret silently drops events | `process.exit(1)` added at `ws-server.ts:183` |
+| L1 | `workingDir` not validated at session creation | `realpathSync`/`allowedRoots` check added at `session-routes.ts:148–158` |
+| L2 | Auth token accepted via request body | `req.body.token` path removed |
+| L5 | MIME type `||` bypass in file upload | Fixed to `&&` at `upload-routes.ts:179` |
+
+---
+
+## Critical Findings
+
+None.
+
+---
+
+## High Findings
+
+None.
+
+---
+
+## Medium Findings
+
+### M1 — Shell Injection via Unescaped Git Metadata in Post-Commit Hook JSON
+
+**File**: `server/commit-event-hook.sh:60`
+
+**Description**: The shell hook constructs a JSON payload by direct variable interpolation. While `COMMIT_MESSAGE` is properly escaped through `jq -Rs` (when `jq` is available), the variables `REPO_PATH`, `BRANCH`, `AUTHOR`, and `COMMIT_HASH` are embedded raw into the JSON string:
+
+```sh
+-d "{\"repoPath\":\"${REPO_PATH}\",\"branch\":\"${BRANCH}\",\"commitHash\":\"${COMMIT_HASH}\",\"commitMessage\":${ESCAPED_MESSAGE},\"author\":\"${AUTHOR}\"}"
+```
+
+A git repository path or author name containing `"`, `\`, newlines, or other special characters will produce malformed JSON. More critically, a crafted author name such as `foo", "injected": "value` corrupts the payload structure. The `AUTHOR` field is particularly exploitable — git commit author names are user-controlled and not validated server-side before the hook fires.
+
+**Impact**: Malformed or attacker-controlled JSON sent to the server's commit-event endpoint. An attacker who can author a commit to an instrumented repo (e.g., an org member) can inject arbitrary JSON fields into the webhook payload, potentially overriding `repoPath` or `branch` fields and triggering unintended server-side workflow logic.
+
+**Remediation**: Use `jq` (with the same availability check already present) or `printf '%s'` piped through per-field escaping for all four variables. Example:
+
+```sh
+REPO_PATH_ESC=$(printf '%s' "$REPO_PATH" | jq -Rs .)
+AUTHOR_ESC=$(printf '%s' "$AUTHOR" | jq -Rs .)
+BRANCH_ESC=$(printf '%s' "$BRANCH" | jq -Rs .)
+# COMMIT_HASH is already hex-only (safe), but quote it for consistency
+```
+
+---
+
+### M2 — Orchestrator `spawn` Child Validates Repo Path with `resolve()` Instead of `realpathSync()`  *(carried forward from M-class attention, now upgraded to Medium)*
+
+**File**: `server/orchestrator-routes.ts:250`
+
+**Description**: The `POST /api/orchestrator/children` endpoint validates the caller-supplied `repo` path using `path.resolve()`:
+
+```ts
+const resolvedRepo = resolve(repo)
+if (!resolvedRepo.startsWith(REPOS_ROOT + '/') && resolvedRepo !== REPOS_ROOT) {
+  return res.status(400).json({ error: 'Invalid repo path: must be under configured repos root' })
+}
+```
+
+`resolve()` normalises `..` segments but does **not** dereference symlinks. If `REPOS_ROOT` contains a symlink pointing outside it (e.g., `~/repos/linked-repo → /etc/sensitive`), the check passes and a Claude child session is spawned with `/etc/sensitive` as its working directory. This is the same class of bug fixed in the docs-routes hardening (`4bfad4e`).
+
+**Impact**: Authenticated orchestrator users can spawn Claude sessions with arbitrary filesystem paths as the working directory, bypassing the intended `REPOS_ROOT` boundary.
+
+**Remediation**: Replace `resolve(repo)` with `realpathSync(resolve(repo))` (wrapped in try/catch), identical to the pattern used in `session-routes.ts:153` and `docs-routes.ts`.
+
+---
+
+## Low Findings
+
+### L1 — Hook Config Stores Master Auth Token  *(carried forward)*
+
+**File**: `server/commit-event-hooks.ts:49–55`
+
+**Description**: `ensureHookConfig()` writes the full master `authToken` to `~/.codekin/hook-config.json` with `0600` permissions. The file is read by the post-commit shell script to authenticate commit-event webhook calls. A process running as the same user (e.g., a compromised tool in the dev environment) that reads this file obtains the master token, which grants access to all API endpoints.
+
+**Impact**: Compromise of the hook config file escalates to full server access rather than scoped commit-event access only.
+
+**Remediation**: Derive a scope-limited token using `deriveSessionToken(masterToken, 'commit-hook')` (already in `crypto-utils.ts`) and store that instead. The server's commit-event endpoint should then verify using the same derivation. This limits the blast radius of a stolen hook config.
+
+---
+
+### L2 — CSP `style-src 'unsafe-inline'`  *(carried forward)*
+
+**File**: `server/ws-server.ts:309`
+
+**Description**: The `Content-Security-Policy` header includes `style-src 'self' 'unsafe-inline'` to support TailwindCSS 4 inline styles. This weakens the XSS mitigation provided by CSP, as injected inline `<style>` tags would not be blocked.
+
+**Impact**: If an XSS vector were discovered (none currently identified), `unsafe-inline` in `style-src` reduces the defence-in-depth protection. CSS injection via `<style>` can be used for data exfiltration (CSS attribute selectors reading DOM values).
+
+**Remediation**: Investigate Tailwind's nonce-based or hash-based style approach. If not feasible, document the known exception and confirm Tailwind 4's CSS variables approach does not require `unsafe-inline` at all style call sites.
+
+---
+
+### L3 — Auth-Verify Endpoint Is a Timing/Brute-Force Oracle
+
+**File**: `server/auth-routes.ts:67–70`
+
+**Description**: `POST /auth-verify` returns `{ valid: true/false }` based on whether the supplied Bearer token matches. The endpoint is rate-limited to 10 req/min per IP, which limits online brute force. However, the binary true/false response with no jitter or lockout means a distributed attacker (multiple IPs) can test tokens at 10/min per IP without account lockout.
+
+The token comparison itself uses `timingSafeEqual` (via SHA-256 hashing in `verifyToken`), so there is no timing oracle. The concern is the existence of a public verification oracle for any auth token.
+
+**Impact**: Low — the token space is large enough (typically a UUID or random string) that enumeration is not practical even with a distributed attack. However, the endpoint provides confirmation of successful token discovery, which aids targeted attacks.
+
+**Remediation**: Add a minimum response delay (e.g., 100ms) regardless of outcome to eliminate any residual timing signal. Consider whether the endpoint is needed at all by unauthenticated clients, or whether it should require an existing valid token.
+
+---
+
+### L4 — FTS5 `MATCH` Query Accepts Unsanitised User Input (SQLite DoS)
+
+**File**: `server/orchestrator-memory.ts:218–226`
+
+**Description**: The `search()` method passes the caller-controlled `query` string directly into SQLite's FTS5 `MATCH` operator via a prepared statement:
+
+```ts
+WHERE memory_fts MATCH ?
+```
+
+While prepared statements prevent SQL injection, FTS5's `MATCH` syntax is not SQL — it has its own grammar. Malformed FTS5 expressions (e.g., `AND AND`, `"unterminated`) cause SQLite to throw a `SQLITE_ERROR`, which propagates as an unhandled exception if the caller doesn't catch it. The calling route in `orchestrator-routes.ts:294` does not wrap the call in a try/catch.
+
+**Impact**: An authenticated orchestrator user can cause the memory search endpoint to return a 500 error or crash the route handler by submitting a malformed FTS5 query string. No data exfiltration risk.
+
+**Remediation**: Wrap the `db.prepare(...).all(...)` call in a try/catch in `orchestrator-memory.ts:search()`. Return an empty result set on parse error, or sanitise the query string (strip FTS5 operators) before passing to `MATCH`.
+
+---
+
+## Secrets & Credentials Exposure
+
+No hardcoded secrets, API keys, or committed credentials were found in any tracked source file. All credentials are sourced from environment variables (`AUTH_TOKEN`, `AUTH_TOKEN_FILE`, `ANTHROPIC_API_KEY`, `GITHUB_WEBHOOK_SECRET`, `STEPFLOW_WEBHOOK_SECRET`) or from locally-stored config files outside the repository (`~/.codekin/hook-config.json`, `~/.codekin/webhook-config.json`). The `.gitignore` correctly excludes `.env` and `.env.*` files. The `settings.example.json` committed to the repo contains no real credentials.
+
+The `~/.codekin/hook-config.json` file (storing the master auth token) is written with `0600` permissions (owner read/write only) — see L1 for the scoping concern.
+
+---
+
+## Recommendations
+
+1. **[Medium — High Priority] Fix JSON injection in `commit-event-hook.sh`**: Escape all four git metadata variables through `jq -Rs` or an equivalent. The `jq` availability guard is already in place; extend it to cover all fields, not just `COMMIT_MESSAGE`. This is the highest-risk new finding.
+
+2. **[Medium] Replace `resolve()` with `realpathSync()` in orchestrator spawn validation** (`orchestrator-routes.ts:250`): Consistent with the fix already applied to docs-routes and session-routes. One-line change with high impact.
+
+3. **[Low — Quick Win] Scope the commit-hook auth token** (`commit-event-hooks.ts`): Use `deriveSessionToken(masterToken, 'commit-hook')` from the existing `crypto-utils.ts`. Add a corresponding verification path in the commit-event endpoint. Reduces master token exposure.
+
+4. **[Low] Wrap FTS5 `MATCH` in try/catch** (`orchestrator-memory.ts:search()`): One-line fix — catch the SQLite error and return `[]`. Prevents 500 responses from malformed search queries.
+
+5. **[Low] Add minimum response delay to `/auth-verify`**: A 50–100ms fixed delay eliminates any residual timing signal and slightly raises the cost of distributed brute-force enumeration without meaningfully affecting UX.
+
+6. **[Low — Ongoing] Investigate CSP `'unsafe-inline'` removal**: Evaluate whether TailwindCSS 4 can operate without `style-src 'unsafe-inline'`. If not achievable in the short term, document the exception explicitly in the security posture notes.
+
+7. **[Informational] Extend `TOOL_DEBUG` gating to `opencode-process.ts`**: The `NODE_ENV !== 'production'` check added for `claude-process.ts` (M3 fix) should be verified as applied consistently in the newer `opencode-process.ts` file, which also handles tool events.


### PR DESCRIPTION
## Summary

- Adds comprehensive **weekly repository health assessment** (`2026-04-15_repo-health-weekly.md`) covering dead code, TODO/FIXME tracker, config drift, licence compliance, doc freshness, changelog, stale branches, PR hygiene, and merge conflict forecast
- Commits 7 previously untracked accumulated reports: 2× code-review daily, 1× dependency health, 2× docs-audit, 2× repo-health daily

## Key findings (weekly report)

- Overall health: **Good** — strict TypeScript everywhere, zero TODO/FIXME debt, no orphan files
- 2 documentation gaps: `ProcessCoordinator` and GitHub webhook auto-setup not yet in `docs/`
- `origin/chore/eslint-strict-unsafe` is a duplicate of merged PR #410 — recommend deletion
- PR #402 has a merge conflict; `fix/security-and-cleanup-apr14` overlaps `session-routes.ts` (high conflict risk)
- 2 transitive deps (`busboy`, `streamsearch`) missing licence metadata in lock file

## Test plan
- [ ] Verify report files render correctly in the Markdown browser
- [ ] Confirm no source files were modified (read-only assessment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)