### PR TITLE
docs: Apr 15 cleanup — PR review entry, cross-references, roadmap restructure

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -17,6 +17,7 @@ Codekin is a web-based terminal UI for managing multiple Claude Code sessions. I
 - [Repository Browser](#repository-browser)
 - [Slash-Command Skills](#slash-command-skills)
 - [Automated Workflows](#automated-workflows)
+- [PR Review Automation](#pr-review-automation)
 - [Agent Joe Orchestrator](#agent-joe-orchestrator)
 - [Git Worktrees](#git-worktrees)
 - [Modules](#modules)
@@ -187,6 +188,24 @@ Codekin can run scheduled Claude Code sessions against repositories to produce s
 - **Auto-committed reports** — Output is saved to a configurable directory within the repo (e.g. `review logs/`, `security-reports/`) and committed with a configurable message.
 
 See [docs/WORKFLOWS.md](./WORKFLOWS.md) for the full workflow definition format, frontmatter field reference, and instructions for writing per-repo overrides.
+
+---
+
+## PR Review Automation
+
+**Shipped**: 2026-04-10
+
+Codekin automatically reviews pull requests by responding to GitHub webhook events. When a PR is opened, updated, or marked ready for review, a Claude session is spawned to analyze the diff and post findings directly to the PR.
+
+- **Event-driven** — Triggered by `pull_request` webhook events (opened, synchronize, reopened, ready_for_review). No polling or manual invocation required.
+- **Inline and summary comments** — Claude posts a summary comment (updated in place on subsequent pushes) and individual inline code comments for specific findings.
+- **Per-PR context cache** — Prior review context is cached per PR so subsequent reviews (after new commits) are faster and more informed. Cache is archived on merge, deleted on close.
+- **Session superseding** — If a new push arrives while a review session is running, the old session is cancelled and a new one starts with the latest diff.
+- **3-tier prompt resolution** — The review prompt resolves from: repo-level `.codekin/pr-review-prompt.md` → global `~/.codekin/pr-review-prompt.md` → built-in default.
+- **Concurrency control** — Maximum concurrent PR review sessions is configurable (default 3, can be raised in `~/.codekin/webhook-config.json`).
+- **Cleanup on close/merge** — When a PR is closed, active sessions are killed and the context cache is archived (merged) or deleted (abandoned).
+
+See [docs/PR-REVIEW-WEBHOOK.md](./PR-REVIEW-WEBHOOK.md) for architecture details, configuration, and operational notes.
 
 ---
 

--- a/docs/GITHUB-WEBHOOKS-SPEC.md
+++ b/docs/GITHUB-WEBHOOKS-SPEC.md
@@ -4,6 +4,8 @@
 **Date**: 2026-02-23
 **Author**: Codekin Team
 
+> **See also**: [docs/PR-REVIEW-WEBHOOK.md](./PR-REVIEW-WEBHOOK.md) — the PR review feature built on top of this webhook infrastructure, handling `pull_request` events to automate code review.
+
 ---
 
 ## Table of Contents
@@ -24,6 +26,7 @@
 - [Observability](#observability)
 - [Implementation Phases](#implementation-phases)
 - [Open Questions](#open-questions)
+- [Roadmap](#roadmap)
 
 ---
 
@@ -130,15 +133,15 @@ If the health check fails, webhook processing is disabled with a clear log warni
 
 **Phase 1 implements `workflow_run` only.** This fires once per workflow and includes the full context (repo, branch, head SHA, PR associations). `check_run` and `check_suite` are listed for future reference.
 
-### Phase 2 — Expanded Events (Future)
+### Expanded Events (Roadmap / Partially Implemented)
 
-| GitHub Event | Use Case |
-|---|---|
-| `pull_request` | Auto-review PRs, suggest changes |
-| `issues` | Triage new issues, attempt auto-fix for bug reports |
-| `push` | Run analysis on new commits |
-| `issue_comment` | Respond to comments mentioning `@claude` |
-| `pull_request_review` | Address review feedback automatically |
+| GitHub Event | Use Case | Status |
+|---|---|---|
+| `pull_request` | Auto-review PRs, post findings as comments | **Implemented** — see [docs/PR-REVIEW-WEBHOOK.md](./PR-REVIEW-WEBHOOK.md) |
+| `issues` | Triage new issues, attempt auto-fix for bug reports | Roadmap (Phase 4) |
+| `push` | Run analysis on new commits | Roadmap (Phase 4) |
+| `issue_comment` | Respond to comments mentioning `@claude` | Roadmap (Phase 4) |
+| `pull_request_review` | Address review feedback automatically | Roadmap (Phase 4) |
 
 ### Event Filtering
 
@@ -748,45 +751,6 @@ Last 100 webhook events stored in memory, accessible via:
 
 **Deliverable**: Webhooks trigger Claude sessions that diagnose and fix CI failures. Webhook sessions are visually distinct in the UI.
 
-### Phase 2 — Configuration & Modes [Planned — Not Yet Implemented]
-
-**Scope**: Make behavior configurable, add operating modes.
-
-- [ ] Implement webhook config file (`~/.codekin/webhook-config.json`)
-- [ ] Add event filtering (by workflow, branch, repo)
-- [ ] Implement operating modes (autonomous, supervised, notify-only)
-- [ ] Per-workflow mode overrides
-- [ ] Session reuse for same branch
-- [ ] `GET/PUT /api/webhooks/config` endpoints
-- [ ] Resource limits (max concurrent sessions, queue)
-
-**Deliverable**: Configurable, production-ready webhook processing.
-
-### Phase 3 — UI Integration [Planned — Not Yet Implemented]
-
-**Scope**: Surface webhook activity in the frontend.
-
-- [ ] Add `webhook_event` WebSocket message type
-- [ ] Webhook events panel in sidebar
-- [ ] Visual distinction for webhook-created sessions
-- [ ] Toast notifications for new webhook events
-- [ ] Auto-switch to webhook session option
-- [ ] Webhook configuration UI (settings panel)
-
-**Deliverable**: Full visibility into webhook activity from the browser.
-
-### Phase 4 — Expanded Events [Planned — Not Yet Implemented]
-
-**Scope**: Handle more GitHub event types.
-
-- [ ] `pull_request` events — auto-review, suggest changes
-- [ ] `issues` events — triage, attempt auto-fix for bugs
-- [ ] `issue_comment` / `pull_request_review` — respond to mentions
-- [ ] `push` events — run analysis on new commits
-- [ ] Outbound: update check run status on GitHub when Claude completes
-
-**Deliverable**: Codekin as a full GitHub-integrated AI assistant.
-
 ---
 
 ## Known Limitations (Phase 1)
@@ -811,3 +775,49 @@ Last 100 webhook events stored in memory, accessible via:
 5. **Cost control** — Each webhook-triggered session consumes API tokens. Should there be a daily budget or token cap for webhook-triggered sessions?
 
 6. **PR comments** — Instead of (or in addition to) pushing fixes, should Claude post its diagnosis as a PR comment? This would integrate with existing code review workflows.
+
+---
+
+## Roadmap
+
+The following phases are planned but not yet implemented. Phase 1 is the only functionality live today.
+
+### Phase 2 — Configuration & Modes
+
+**Scope**: Make behavior configurable, add operating modes.
+
+- [ ] Implement webhook config file (`~/.codekin/webhook-config.json`)
+- [ ] Add event filtering (by workflow, branch, repo)
+- [ ] Implement operating modes (autonomous, supervised, notify-only)
+- [ ] Per-workflow mode overrides
+- [ ] Session reuse for same branch
+- [ ] `GET/PUT /api/webhooks/config` endpoints
+- [ ] Resource limits (max concurrent sessions, queue)
+
+**Deliverable**: Configurable, production-ready webhook processing.
+
+### Phase 3 — UI Integration
+
+**Scope**: Surface webhook activity in the frontend.
+
+- [ ] Add `webhook_event` WebSocket message type
+- [ ] Webhook events panel in sidebar
+- [ ] Visual distinction for webhook-created sessions
+- [ ] Toast notifications for new webhook events
+- [ ] Auto-switch to webhook session option
+- [ ] Webhook configuration UI (settings panel)
+
+**Deliverable**: Full visibility into webhook activity from the browser.
+
+### Phase 4 — Expanded Events
+
+**Scope**: Handle more GitHub event types.
+
+- [ ] `issues` events — triage, attempt auto-fix for bugs
+- [ ] `issue_comment` / `pull_request_review` — respond to mentions
+- [ ] `push` events — run analysis on new commits
+- [ ] Outbound: update check run status on GitHub when Claude completes
+
+> **Note**: `pull_request` event handling (PR review automation) was implemented separately and is documented in [docs/PR-REVIEW-WEBHOOK.md](./PR-REVIEW-WEBHOOK.md).
+
+**Deliverable**: Codekin as a full GitHub-integrated AI assistant.

--- a/docs/PR-REVIEW-WEBHOOK.md
+++ b/docs/PR-REVIEW-WEBHOOK.md
@@ -2,6 +2,8 @@
 
 Automated pull request code review via GitHub webhooks. When a PR is opened, updated, reopened, or marked ready for review, Codekin spawns a Claude session that reviews the changes and posts findings directly to GitHub. When a PR is closed or merged, Codekin cleans up active sessions and manages the review cache.
 
+> **See also**: [docs/GITHUB-WEBHOOKS-SPEC.md](./GITHUB-WEBHOOKS-SPEC.md) — shared webhook infrastructure (signature validation, HMAC, session management, deduplication, rate limiting) that this feature builds on.
+
 ## Overview
 
 GitHub sends `pull_request` webhook events to Codekin. The handler filters by action, deduplicates, manages concurrency, creates an isolated workspace, and spawns a Claude session with the PR context and a review prompt.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -76,8 +76,9 @@ Codekin ships with nine built-in workflow definitions in `server/workflows/`:
 | `docs-audit.weekly.md` | `docs-audit.weekly` | Weekly | `.codekin/reports/docs-audit/` |
 | `commit-review.md` | `commit-review` | Event-driven | `.codekin/reports/commit-review/` |
 | `repo-health.weekly.md` | `repo-health.weekly` | Weekly | `.codekin/reports/repo-health/` |
+| `pr-review.md` | `pr-review` | Event-driven | _(no file output — posts to GitHub PR)_ |
 
-> **Note**: `commit-review` is event-driven (triggered by commit events) rather than scheduled, so it does not follow the `<topic>.<frequency>` naming convention.
+> **Note**: `commit-review` and `pr-review` are event-driven (webhook-triggered) rather than scheduled, so they do not follow the `<topic>.<frequency>` naming convention. `pr-review` is triggered by GitHub `pull_request` events and posts findings directly to the PR as review comments rather than saving a report file.
 
 All built-in workflows are loaded automatically at server start.
 


### PR DESCRIPTION
## Summary

- **FEATURES.md**: Added a new "PR Review Automation" section (shipped 2026-04-10) documenting the webhook-based PR review feature with a link to `docs/PR-REVIEW-WEBHOOK.md`.
- **WORKFLOWS.md**: Added `pr-review.md` to the built-in workflows table with an "Event-driven" schedule column entry and an updated note clarifying both `commit-review` and `pr-review` are webhook-triggered rather than scheduled.
- **GITHUB-WEBHOOKS-SPEC.md**:
  - Added a "See also" callout near the top pointing to `PR-REVIEW-WEBHOOK.md`.
  - Updated the Expanded Events table to mark `pull_request` as **Implemented** with a link to `PR-REVIEW-WEBHOOK.md`.
  - Moved Phase 2, 3, and 4 content out of "Implementation Phases" and into a clearly labelled `## Roadmap` section at the end of the file, so operators can easily distinguish what is live today from what is planned.
- **PR-REVIEW-WEBHOOK.md**: Added a "See also" callout at the top pointing back to `GITHUB-WEBHOOKS-SPEC.md` for shared webhook infrastructure context.

## Test plan

- [ ] Verify all internal Markdown links resolve correctly
- [ ] Confirm FEATURES.md TOC anchor for "PR Review Automation" renders
- [ ] Confirm GITHUB-WEBHOOKS-SPEC.md Roadmap section appears after Open Questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)