### PR TITLE
fix: prevent JSON injection in commit-event-hook.sh

### DIFF
--- a/server/commit-event-hook.sh
+++ b/server/commit-event-hook.sh
@@ -44,12 +44,21 @@ case "$COMMIT_MESSAGE" in
     ;;
 esac
 
-# JSON-escape the commit message properly (handles newlines, tabs, special chars)
+# Build JSON payload safely using jq to prevent injection via crafted values
 if command -v jq >/dev/null 2>&1; then
-  ESCAPED_MESSAGE=$(printf '%s' "$COMMIT_MESSAGE" | jq -Rs .)
+  PAYLOAD=$(jq -n \
+    --arg repoPath "$REPO_PATH" \
+    --arg branch "$BRANCH" \
+    --arg commitHash "$COMMIT_HASH" \
+    --arg commitMessage "$COMMIT_MESSAGE" \
+    --arg author "$AUTHOR" \
+    '{repoPath: $repoPath, branch: $branch, commitHash: $commitHash, commitMessage: $commitMessage, author: $author}')
 else
-  # Fallback: escape backslashes, double quotes, and control characters
-  ESCAPED_MESSAGE=$(printf '%s' "$COMMIT_MESSAGE" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e "s/$(printf '\t')/\\t/g" | { echo -n '"'; cat; echo -n '"'; })
+  # Fallback: escape each variable individually for safe JSON embedding
+  json_escape() {
+    printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e "s/$(printf '\t')/\\t/g" -e "s/$(printf '\r')//g"
+  }
+  PAYLOAD="{\"repoPath\":\"$(json_escape "$REPO_PATH")\",\"branch\":\"$(json_escape "$BRANCH")\",\"commitHash\":\"$(json_escape "$COMMIT_HASH")\",\"commitMessage\":\"$(json_escape "$COMMIT_MESSAGE")\",\"author\":\"$(json_escape "$AUTHOR")\"}"
 fi
 
 # Fire-and-forget POST to the server (5s timeout, backgrounded)
@@ -57,7 +66,7 @@ curl -s -o /dev/null -m 5 \
   -X POST "${SERVER_URL}/api/workflows/commit-event" \
   -H "Content-Type: application/json" \
   -H "Authorization: Bearer ${AUTH_TOKEN}" \
-  -d "{\"repoPath\":\"${REPO_PATH}\",\"branch\":\"${BRANCH}\",\"commitHash\":\"${COMMIT_HASH}\",\"commitMessage\":${ESCAPED_MESSAGE},\"author\":\"${AUTHOR}\"}" \
+  -d "$PAYLOAD" \
   &
 
 exit 0


### PR DESCRIPTION
## Summary

- **Security fix**: `REPO_PATH`, `AUTHOR`, `BRANCH`, and `COMMIT_HASH` were embedded raw into a JSON string in `server/commit-event-hook.sh`, allowing a crafted git author name or repo path to inject arbitrary JSON fields into the commit-event payload
- Replaced piecemeal string interpolation with `jq -n --arg` to safely construct the entire JSON payload
- The `sed`-based fallback (when `jq` is unavailable) now escapes all five variables individually, not just the commit message

## Test plan

- [ ] Verify hook fires correctly on a normal commit (`git commit` in a repo with codekin hook installed)
- [ ] Test with a git author name containing double quotes and backslashes (e.g. `git -c user.name='foo"bar' commit ...`)
- [ ] Test with a repo path containing spaces or special characters
- [ ] Test fallback path by temporarily hiding `jq` from `$PATH`

🤖 Generated with [Claude Code](https://claude.com/claude-code)