### PR TITLE
fix: add hard key caps to auth and webhook rate-limiter maps

### DIFF
--- a/server/auth-routes.ts
+++ b/server/auth-routes.ts
@@ -8,6 +8,9 @@ import { Router } from 'express'
 import type { Request, RequestHandler } from 'express'
 import type { SessionManager } from './session-manager.js'
 
+/** Maximum number of tracked IPs in the auth rate-limiter map to prevent unbounded memory growth. */
+const AUTH_RATE_MAP_MAX_SIZE = 10_000
+
 /** Simple per-IP rate limiter for auth endpoints. */
 function createIpRateLimiter(maxPerMinute: number): RequestHandler {
   const ipTimestamps = new Map<string, number[]>()
@@ -30,6 +33,11 @@ function createIpRateLimiter(maxPerMinute: number): RequestHandler {
 
     if (timestamps.length >= maxPerMinute) {
       ipTimestamps.set(ip, timestamps)
+      return res.status(429).json({ error: 'Too Many Requests', retryAfter: 60 })
+    }
+
+    // Reject new IPs if the map has grown too large (DoS protection)
+    if (timestamps.length === 0 && ipTimestamps.size >= AUTH_RATE_MAP_MAX_SIZE) {
       return res.status(429).json({ error: 'Too Many Requests', retryAfter: 60 })
     }
 

--- a/server/webhook-rate-limiter.ts
+++ b/server/webhook-rate-limiter.ts
@@ -33,6 +33,8 @@ export function createWebhookRateLimiter(
   keyExtractor: (body: unknown) => string | undefined = (body) =>
     (body as { repository?: { full_name?: string } } | undefined)?.repository?.full_name,
 ): RequestHandler {
+  /** Maximum number of tracked keys to prevent unbounded memory growth. */
+  const WEBHOOK_RATE_MAP_MAX_SIZE = 10_000
   const keyTimestamps = new Map<string, number[]>()
 
   // Periodic cleanup: every 5 minutes, remove keys with no recent timestamps
@@ -80,6 +82,12 @@ export function createWebhookRateLimiter(
     if (recent.length >= maxPerMinute) {
       keyTimestamps.set(key, recent)
       res.status(429).json({ error: 'Too Many Requests', repo: key, retryAfter: 60 })
+      return
+    }
+
+    // Reject new keys if the map has grown too large (DoS protection)
+    if (recent.length === 0 && keyTimestamps.size >= WEBHOOK_RATE_MAP_MAX_SIZE) {
+      res.status(429).json({ error: 'Too Many Requests', retryAfter: 60 })
       return
     }
 


### PR DESCRIPTION
## Summary

- Add a 10,000-key hard cap to the auth IP rate-limiter map in `server/auth-routes.ts`
- Add a 10,000-key hard cap to the webhook rate-limiter map in `server/webhook-rate-limiter.ts`
- Both maps previously only had time-based pruning (every 5 min) but no maximum size limit, leaving them vulnerable to unbounded memory growth under DoS conditions
- Follows the same pattern already established in `ws-server.ts` (`API_RATE_MAP_MAX_SIZE`, `WS_RATE_MAP_MAX_SIZE`)

## Test plan

- [ ] Verify build passes with no type errors
- [ ] Confirm auth rate limiter still returns 429 when per-IP limit is exceeded
- [ ] Confirm webhook rate limiter still returns 429 when per-key limit is exceeded
- [ ] Under high cardinality (many unique IPs/keys), new entries are rejected with 429 once the 10k cap is reached

🤖 Generated with [Claude Code](https://claude.com/claude-code)