### PR TITLE
fix: use realpathSync to prevent symlink bypass in spawn route

### DIFF
--- a/server/orchestrator-session-router.ts
+++ b/server/orchestrator-session-router.ts
@@ -6,7 +6,7 @@
 import { Router } from 'express'
 import type { Request } from 'express'
 import { resolve } from 'path'
-import { existsSync, statSync } from 'fs'
+import { existsSync, statSync, realpathSync } from 'fs'
 import type { SessionManager } from './session-manager.js'
 import { ensureOrchestratorRunning, getOrchestratorSessionId, getOrCreateOrchestratorId } from './orchestrator-manager.js'
 import { getAgentDisplayName, REPOS_ROOT } from './config.js'
@@ -153,13 +153,15 @@ export function createSessionRouter(
       }
     }
 
-    // Validate repo path: must resolve under REPOS_ROOT and be an existing directory
-    const resolvedRepo = resolve(repo)
+    // Validate repo path: must exist and be a directory
+    const absRepo = resolve(repo)
+    if (!existsSync(absRepo) || !statSync(absRepo).isDirectory()) {
+      return res.status(400).json({ error: 'Invalid repo path: directory does not exist' })
+    }
+    // Use realpathSync to resolve symlinks before boundary check (prevents symlink bypass)
+    const resolvedRepo = realpathSync(absRepo)
     if (!resolvedRepo.startsWith(REPOS_ROOT + '/') && resolvedRepo !== REPOS_ROOT) {
       return res.status(400).json({ error: 'Invalid repo path: must be under configured repos root' })
-    }
-    if (!existsSync(resolvedRepo) || !statSync(resolvedRepo).isDirectory()) {
-      return res.status(400).json({ error: 'Invalid repo path: directory does not exist' })
     }
 
     try {


### PR DESCRIPTION
## Summary

- **Security fix**: The orchestrator spawn route (`POST /spawn`) validated repo paths using `path.resolve()`, which does not follow symlinks. An attacker could create a symlink under `REPOS_ROOT` pointing outside the allowed directory and bypass the boundary check.
- Replaced `path.resolve()` with `fs.realpathSync()` to resolve the canonical (real) path before validating against `REPOS_ROOT`.
- Reordered validation: existence check runs before `realpathSync()` to avoid throwing on non-existent paths.
- Mirrors the same fix applied to `docs-routes.ts` in commit 4bfad4e (#409).

## Test plan

- [ ] Verify spawn route rejects a symlink under REPOS_ROOT that points outside the allowed directory
- [ ] Verify spawn route still accepts valid repo paths under REPOS_ROOT
- [ ] Verify spawn route returns 400 for non-existent paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)