### PR TITLE
chore: remove leftover blank line from debug lifecycle log cleanup

### DIFF
--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -65,7 +65,6 @@ export class SessionLifecycle {
     const session = this.deps.getSession(sessionId)
     if (!session) return false
 
-
     // Clear stopped flag and any pending restart timer on explicit start
     session._stoppedByUser = false
     if (session._restartTimer) { clearTimeout(session._restartTimer); session._restartTimer = undefined }


### PR DESCRIPTION
## Summary

- PR #406 added debug `console.log` calls tagged `[startClaude]`, `[sendInput]`, `[onSystemInit]`, `[setModel]`, and `[handleClaudeResult]` to diagnose the first-message-lost bug
- PR #407 fixed the bug and removed the debug logs, but left a stale blank line in `session-lifecycle.ts:startClaude()`
- This PR removes that leftover blank line

## Test plan

- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)