### PR TITLE
feat: add Claude Opus 4.7 to available models

### DIFF
--- a/server/types.ts
+++ b/server/types.ts
@@ -25,6 +25,7 @@ export const VALID_PERMISSION_MODES = new Set<PermissionMode>(['default', 'accep
 /** Allow-list for server-side validation of client-supplied model IDs.
  *  Only Claude models — OpenCode sessions bypass this (models are dynamic). */
 export const VALID_MODELS = new Set([
+  'claude-opus-4-7',
   'claude-opus-4-6',
   'claude-sonnet-4-6',
   'claude-haiku-4-5-20251001',

--- a/src/lib/workflowHelpers.ts
+++ b/src/lib/workflowHelpers.ts
@@ -45,7 +45,7 @@ export const MODEL_OPTIONS = [
 ]
 
 /** Model IDs that map to the default (Opus). Stored explicitly by some configs but equivalent to empty. */
-const DEFAULT_MODEL_IDS = new Set(['claude-opus-4-6', 'claude-opus-4-5-20250918'])
+const DEFAULT_MODEL_IDS = new Set(['claude-opus-4-7', 'claude-opus-4-6', 'claude-opus-4-5-20250918'])
 
 /** Normalize a model value: known Opus model IDs → empty string (server default). */
 export function normalizeModel(model: string | undefined): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,7 @@ export interface ModelOption { id: string; label: string }
 
 /** Static models for Claude Code CLI. */
 export const CLAUDE_MODELS: ModelOption[] = [
+  { id: 'claude-opus-4-7', label: 'Opus 4.7' },
   { id: 'claude-opus-4-6', label: 'Opus 4.6' },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
   { id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },


### PR DESCRIPTION
## Summary
- Adds `claude-opus-4-7` to the model selector dropdown, server-side validation allowlist, and workflow default model IDs

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 1639 tests pass (`npm test`)
- [x] Zero lint errors (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)