### PR TITLE
fix: validate repoPath and cron on workflow/orchestrator routes

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -148,4 +148,59 @@ describe('config', () => {
       mockError.mockRestore()
     })
   })
+
+  describe('resolveRepoPathInRoot', () => {
+    it('returns resolved path for a child directory inside REPOS_ROOT', async () => {
+      process.env.REPOS_ROOT = '/srv/repos'
+      mockExistsSync.mockImplementation((p: unknown) => p === '/srv/repos')
+      mockRealpathSync.mockImplementation((p: string) => p === '/srv/repos/myrepo' ? '/srv/repos/myrepo' : p)
+
+      const config = await loadConfig()
+      expect(config.resolveRepoPathInRoot('/srv/repos/myrepo')).toBe('/srv/repos/myrepo')
+    })
+
+    it('returns the root itself when passed REPOS_ROOT', async () => {
+      process.env.REPOS_ROOT = '/srv/repos'
+      mockExistsSync.mockImplementation((p: unknown) => p === '/srv/repos')
+      mockRealpathSync.mockImplementation((p: string) => p)
+
+      const config = await loadConfig()
+      expect(config.resolveRepoPathInRoot('/srv/repos')).toBe('/srv/repos')
+    })
+
+    it('rejects a path-traversal attempt that resolves outside REPOS_ROOT', async () => {
+      process.env.REPOS_ROOT = '/srv/repos'
+      mockExistsSync.mockImplementation((p: unknown) => p === '/srv/repos')
+      // Simulate realpath escaping via "../etc" or via a symlink that points outside
+      mockRealpathSync.mockImplementation((p: string) => {
+        if (p === '/srv/repos') return '/srv/repos'
+        return '/etc/passwd'
+      })
+
+      const config = await loadConfig()
+      expect(config.resolveRepoPathInRoot('/srv/repos/../etc/passwd')).toBeNull()
+      expect(config.resolveRepoPathInRoot('/srv/repos/symlink-to-etc')).toBeNull()
+    })
+
+    it('rejects a sibling-prefix confusion (/srv/repos vs /srv/repos-evil)', async () => {
+      process.env.REPOS_ROOT = '/srv/repos'
+      mockExistsSync.mockImplementation((p: unknown) => p === '/srv/repos')
+      mockRealpathSync.mockImplementation((p: string) => p)
+
+      const config = await loadConfig()
+      expect(config.resolveRepoPathInRoot('/srv/repos-evil/x')).toBeNull()
+    })
+
+    it('returns null when realpathSync throws (path does not exist)', async () => {
+      process.env.REPOS_ROOT = '/srv/repos'
+      mockExistsSync.mockImplementation((p: unknown) => p === '/srv/repos')
+      mockRealpathSync.mockImplementation((p: string) => {
+        if (p === '/srv/repos') return '/srv/repos'
+        throw new Error('ENOENT')
+      })
+
+      const config = await loadConfig()
+      expect(config.resolveRepoPathInRoot('/srv/repos/nonexistent')).toBeNull()
+    })
+  })
 })

--- a/server/config.ts
+++ b/server/config.ts
@@ -7,7 +7,7 @@
  */
 
 import { homedir } from 'os'
-import { join } from 'path'
+import { join, resolve as pathResolve } from 'path'
 import { readFileSync, existsSync, realpathSync } from 'fs'
 import { execFileSync } from 'child_process'
 
@@ -62,6 +62,23 @@ const rawReposRoot = process.env.REPOS_ROOT || join(homedir(), 'repos')
 export const REPOS_ROOT = existsSync(rawReposRoot)
   ? realpathSync(rawReposRoot)
   : rawReposRoot
+
+/**
+ * Resolve a user-supplied repo path and verify it resides within REPOS_ROOT.
+ * Uses realpathSync to dereference symlinks, preventing symlink-bypass traversal.
+ * Returns the resolved absolute path, or null if the path does not exist,
+ * is inaccessible, or escapes REPOS_ROOT.
+ */
+export function resolveRepoPathInRoot(repoPath: string): string | null {
+  let resolved: string
+  try {
+    resolved = realpathSync(pathResolve(repoPath))
+  } catch {
+    return null
+  }
+  if (resolved !== REPOS_ROOT && !resolved.startsWith(REPOS_ROOT + '/')) return null
+  return resolved
+}
 
 /** Codekin data directory (sessions, approvals, workflows, etc.). */
 export const DATA_DIR = process.env.DATA_DIR || join(homedir(), '.codekin')

--- a/server/orchestrator-session-router.ts
+++ b/server/orchestrator-session-router.ts
@@ -9,7 +9,7 @@ import { resolve } from 'path'
 import { existsSync, statSync, realpathSync } from 'fs'
 import type { SessionManager } from './session-manager.js'
 import { ensureOrchestratorRunning, getOrchestratorSessionId, getOrCreateOrchestratorId } from './orchestrator-manager.js'
-import { getAgentDisplayName, REPOS_ROOT } from './config.js'
+import { getAgentDisplayName, REPOS_ROOT, resolveRepoPathInRoot } from './config.js'
 import { scanRepoReports, readReport, getReportsSince } from './orchestrator-reports.js'
 import type { OrchestratorMemory } from './orchestrator-memory.js'
 import type { OrchestratorChildManager } from './orchestrator-children.js'
@@ -96,7 +96,11 @@ export function createSessionRouter(
     const since = req.query.since as string | undefined
 
     if (repoPath) {
-      const reports = scanRepoReports(repoPath)
+      const resolvedRepoPath = resolveRepoPathInRoot(repoPath)
+      if (!resolvedRepoPath) {
+        return res.status(400).json({ error: 'Invalid repo path: must be an existing directory under the configured repos root' })
+      }
+      const reports = scanRepoReports(resolvedRepoPath)
       res.json({ reports })
     } else if (since) {
       const repoItems = memory.list({ memoryType: 'repo_context' })

--- a/server/workflow-routes.test.ts
+++ b/server/workflow-routes.test.ts
@@ -1,6 +1,6 @@
-/** Tests for parseGitHubSlug — verifies GitHub slug extraction from various remote URL formats. */
+/** Tests for parseGitHubSlug and isValidCron — pure helpers exported from workflow-routes. */
 import { describe, it, expect } from 'vitest'
-import { parseGitHubSlug } from './workflow-routes.js'
+import { parseGitHubSlug, isValidCron } from './workflow-routes.js'
 
 describe('parseGitHubSlug', () => {
   it('parses HTTPS URL with .git suffix', () => {
@@ -33,5 +33,47 @@ describe('parseGitHubSlug', () => {
 
   it('handles repos with hyphens, underscores, and dots', () => {
     expect(parseGitHubSlug('git@github.com:my-org/my_repo.name.git')).toBe('my-org/my_repo.name')
+  })
+})
+
+describe('isValidCron', () => {
+  it('accepts a plain 5-field expression', () => {
+    expect(isValidCron('0 9 * * 1')).toBe(true)
+  })
+
+  it('accepts wildcard in every field', () => {
+    expect(isValidCron('* * * * *')).toBe(true)
+  })
+
+  it('accepts step and range syntax', () => {
+    expect(isValidCron('*/15 9-17 * * 1-5')).toBe(true)
+  })
+
+  it('rejects fewer than 5 fields', () => {
+    expect(isValidCron('0 9 * *')).toBe(false)
+  })
+
+  it('rejects more than 5 fields', () => {
+    expect(isValidCron('0 9 * * 1 2')).toBe(false)
+  })
+
+  it('rejects out-of-range minute (60)', () => {
+    expect(isValidCron('60 9 * * 1')).toBe(false)
+  })
+
+  it('rejects out-of-range day-of-month (32)', () => {
+    expect(isValidCron('0 9 32 * 1')).toBe(false)
+  })
+
+  it('rejects non-numeric tokens', () => {
+    expect(isValidCron('not a cron expr')).toBe(false)
+  })
+
+  it('rejects empty strings', () => {
+    expect(isValidCron('')).toBe(false)
+  })
+
+  it('rejects inverted ranges', () => {
+    expect(isValidCron('5-2 * * * *')).toBe(false)
   })
 })

--- a/server/workflow-routes.ts
+++ b/server/workflow-routes.ts
@@ -21,6 +21,7 @@ import { listAvailableKinds, ensureRepoWorkflowsRegistered } from './workflow-lo
 import { syncCommitHooks } from './commit-event-hooks.js'
 import type { CommitEventHandler } from './commit-event-handler.js'
 import type { SessionManager } from './session-manager.js'
+import { resolveRepoPathInRoot } from './config.js'
 import { VALID_PROVIDERS } from './types.js'
 import {
   previewWebhookSetup,
@@ -142,7 +143,7 @@ type VerifyFn = (token: string | undefined) => boolean
 type ExtractFn = (req: Request) => string | undefined
 
 /** Validate a 5-field cron expression. Returns true if the format is valid. */
-function isValidCron(expr: string): boolean {
+export function isValidCron(expr: string): boolean {
   const parts = expr.trim().split(/\s+/)
   if (parts.length !== 5) return false
   const ranges = [
@@ -377,6 +378,10 @@ export function createWorkflowRouter(
     const existing = engine.getSchedule(req.params.id)
     if (!existing) return res.status(404).json({ error: 'Schedule not found' })
 
+    if (req.body.cronExpression !== undefined && !isValidCron(req.body.cronExpression)) {
+      return res.status(400).json({ error: 'Invalid cron expression' })
+    }
+
     const schedule = engine.upsertSchedule({
       id: existing.id,
       kind: existing.kind,
@@ -424,6 +429,9 @@ export function createWorkflowRouter(
     }
     if (provider && !VALID_PROVIDERS.has(provider)) {
       return res.status(400).json({ error: `Invalid provider: ${provider}` })
+    }
+    if (!resolveRepoPathInRoot(repoPath)) {
+      return res.status(400).json({ error: 'Invalid repoPath: must be an existing directory under the configured repos root' })
     }
 
     // Register any standalone repo workflows before saving config
@@ -475,6 +483,9 @@ export function createWorkflowRouter(
   })
 
   router.patch('/config/repos/:id', (req: Request<{ id: string }, unknown, Partial<ReviewRepoConfig>>, res) => {
+    if (req.body.repoPath !== undefined && !resolveRepoPathInRoot(req.body.repoPath)) {
+      return res.status(400).json({ error: 'Invalid repoPath: must be an existing directory under the configured repos root' })
+    }
     try {
       const config = updateReviewRepo(req.params.id, req.body)
       try {


### PR DESCRIPTION
## Summary

Closes three input-validation gaps surfaced by the 2026-04-18 code review:

- **`POST /api/workflows/config/repos`** and **`PATCH /api/workflows/config/repos/:id`** — user-supplied `repoPath` is now run through realpath + REPOS_ROOT containment, matching the pattern used in `session-routes.ts` and `orchestrator-session-router.ts`'s spawn route.
- **`PATCH /api/workflows/schedules/:id`** — `cronExpression` is validated with `isValidCron()` and returns 400 on invalid input (parity with `POST /schedules`).
- **`GET /api/orchestrator/reports?repo=…`** — same realpath + REPOS_ROOT containment before scanning `.codekin/reports`.

A new `resolveRepoPathInRoot()` helper lives in `server/config.ts` so the check is defined once and reused. `isValidCron` is now exported from `workflow-routes.ts` so tests exercise the exact function used by both POST and PATCH.

## Test plan

- [x] `npm test` — 1654 tests pass (60 files), including 5 new cases for `resolveRepoPathInRoot` (child path, root itself, path-traversal via `..`, symlink escape, sibling-prefix confusion, non-existent path) and 10 new cases for `isValidCron` (valid & rejected shapes, including invalid inverted ranges).
- [x] `npm run build` — tsc + vite build clean.
- [x] `npm run lint` — 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)