### PR TITLE
chore(deps): bump dompurify 3.4.0, better-sqlite3 12.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.6.3",
       "license": "MIT",
       "dependencies": {
-        "better-sqlite3": "^12.6.2",
+        "better-sqlite3": "^12.9.0",
         "express": "^5.1.0",
         "multer": "^2.0.0",
         "ws": "^8.18.0"
@@ -31,7 +31,7 @@
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.2",
         "cmdk": "^1.1.1",
-        "dompurify": "^3.3.2",
+        "dompurify": "^3.4.0",
         "eslint": "^10.1.0",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
@@ -2703,9 +2703,9 @@
       }
     },
     "node_modules/better-sqlite3": {
-      "version": "12.8.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
-      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
+      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -3261,9 +3261,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
       "dev": true,
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "better-sqlite3": "^12.6.2",
+    "better-sqlite3": "^12.9.0",
     "express": "^5.1.0",
     "multer": "^2.0.0",
     "ws": "^8.18.0"
@@ -62,7 +62,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.2",
     "cmdk": "^1.1.1",
-    "dompurify": "^3.3.2",
+    "dompurify": "^3.4.0",
     "eslint": "^10.1.0",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",


### PR DESCRIPTION
## Summary
- Bumps `dompurify` 3.3.3 → 3.4.0 (security-relevant XSS sanitizer — primary reason for this PR)
- Bumps `better-sqlite3` 12.8.0 → 12.9.0
- Both flagged in the `.codekin/reports/dependencies/2026-04-21` dependency-health report

The caret ranges in `package.json` were nudged to match the new floors (`^12.6.2` → `^12.9.0`, `^3.3.2` → `^3.4.0`) by `npm install`. No source changes were required — no breaking type or API changes surfaced.

## Verification
- `npm install` — clean, 0 vulnerabilities
- `npm run lint` — 0 errors (pre-existing warnings unchanged)
- `npm test` — 60 files, 1654 tests all pass
- `tsc -b` — clean (no type regressions)
- `npm audit --audit-level=high` — 0 vulnerabilities

## Test plan
- [x] Unit tests pass
- [x] Typecheck passes
- [x] Security audit clean
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)