### PR TITLE
fix: canonicalize repos_path and namespace local repo storage by owner

### DIFF
--- a/server/session-routes.test.ts
+++ b/server/session-routes.test.ts
@@ -1,0 +1,93 @@
+/** Tests for expandTilde and canonicalizeReposPath — helpers exported from session-routes. */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs'
+import { tmpdir, homedir } from 'os'
+import { join } from 'path'
+import { expandTilde, canonicalizeReposPath } from './session-routes.js'
+
+describe('expandTilde', () => {
+  it('expands "~/foo" to <home>/foo', () => {
+    expect(expandTilde('~/foo')).toBe(join(homedir(), 'foo'))
+  })
+
+  it('expands bare "~" to home', () => {
+    expect(expandTilde('~')).toBe(homedir())
+  })
+
+  it('leaves non-tilde paths untouched', () => {
+    expect(expandTilde('/abs/path')).toBe('/abs/path')
+    expect(expandTilde('relative/path')).toBe('relative/path')
+  })
+
+  it('does not expand tilde inside a segment', () => {
+    expect(expandTilde('/foo/~bar')).toBe('/foo/~bar')
+  })
+})
+
+describe('canonicalizeReposPath', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'codekin-canon-'))
+  })
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('returns the canonical absolute path for a valid directory', () => {
+    const result = canonicalizeReposPath(dir)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.path.startsWith('/')).toBe(true)
+      expect(result.path).not.toContain('~')
+    }
+  })
+
+  it('resolves symlinks to the real path', () => {
+    const target = mkdtempSync(join(tmpdir(), 'codekin-canon-target-'))
+    const link = join(dir, 'link')
+    symlinkSync(target, link)
+    try {
+      const result = canonicalizeReposPath(link)
+      expect(result.ok).toBe(true)
+      if (result.ok) {
+        // realpathSync follows the symlink, so we should get `target`
+        // (modulo /tmp itself possibly being a symlink — compare canonicalized roots)
+        expect(result.path).not.toBe(link)
+      }
+    } finally {
+      rmSync(target, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects paths that do not exist', () => {
+    const result = canonicalizeReposPath(join(dir, 'does-not-exist'))
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/does not exist/i)
+  })
+
+  it('rejects files that are not directories', () => {
+    const file = join(dir, 'file.txt')
+    writeFileSync(file, 'hello')
+    const result = canonicalizeReposPath(file)
+    expect(result.ok).toBe(false)
+    if (!result.ok) expect(result.error).toMatch(/not a directory/i)
+  })
+
+  it('rejects a non-existent tilde path rather than persisting raw ~', () => {
+    // ~ must be expanded before existence check — a nonsense tilde path is rejected
+    const result = canonicalizeReposPath('~/__definitely_not_a_real_dir__')
+    expect(result.ok).toBe(false)
+  })
+
+  it('expands "~" and returns a path with no tilde when home exists', () => {
+    const result = canonicalizeReposPath('~')
+    // home is a real directory, so this should succeed and return an absolute
+    // canonical path (no raw ~)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.path).not.toContain('~')
+      expect(result.path.startsWith('/')).toBe(true)
+    }
+  })
+})

--- a/server/session-routes.ts
+++ b/server/session-routes.ts
@@ -86,9 +86,29 @@ interface AuthValidateBody {
 }
 
 /** Expand leading ~ to the user's home directory. */
-function expandTilde(p: string): string {
+export function expandTilde(p: string): string {
   if (p.startsWith('~/') || p === '~') return pathJoin(osHomedir(), p.slice(1))
   return p
+}
+
+/**
+ * Canonicalize a user-supplied repos path for persistence.
+ * Expands ~, then resolves the absolute canonical path via realpathSync so
+ * stored values never contain ~ or symlinks that later code would have to
+ * re-expand. Returns an error discriminated union.
+ */
+export function canonicalizeReposPath(
+  raw: string,
+): { ok: true; path: string } | { ok: false; error: string } {
+  const expanded = expandTilde(raw)
+  if (!fsExistsSync(expanded) || !fsStatSync(expanded).isDirectory()) {
+    return { ok: false, error: 'Path does not exist or is not a directory' }
+  }
+  try {
+    return { ok: true, path: fsRealpathSync(expanded) }
+  } catch {
+    return { ok: false, error: 'Path could not be resolved' }
+  }
 }
 
 type VerifyFn = (token: string | undefined) => boolean
@@ -314,14 +334,16 @@ export function createSessionRouter(
     }
     const trimmed = rawPath.trim()
     // Empty string means "use default REPOS_ROOT"
+    let toPersist = ''
     if (trimmed) {
-      const expanded = expandTilde(trimmed)
-      if (!fsExistsSync(expanded) || !fsStatSync(expanded).isDirectory()) {
-        return res.status(400).json({ error: 'Path does not exist or is not a directory' })
+      const result = canonicalizeReposPath(trimmed)
+      if (!result.ok) {
+        return res.status(400).json({ error: result.error })
       }
+      toPersist = result.path
     }
-    sessions.archive.setSetting('repos_path', trimmed)
-    res.json({ path: trimmed })
+    sessions.archive.setSetting('repos_path', toPersist)
+    res.json({ path: toPersist })
   })
 
   // --- Agent name setting ---

--- a/server/upload-routes.test.ts
+++ b/server/upload-routes.test.ts
@@ -1,0 +1,23 @@
+/** Tests for localRepoPath — helper exported from upload-routes. */
+import { describe, it, expect } from 'vitest'
+import { localRepoPath } from './upload-routes.js'
+
+describe('localRepoPath', () => {
+  it('namespaces the repo under its owner', () => {
+    expect(localRepoPath('/srv/repos', 'ownerA', 'foo')).toBe('/srv/repos/ownerA/foo')
+  })
+
+  it('prevents collision between ownerA/foo and ownerB/foo', () => {
+    const a = localRepoPath('/srv/repos', 'ownerA', 'foo')
+    const b = localRepoPath('/srv/repos', 'ownerB', 'foo')
+    expect(a).not.toBe(b)
+  })
+
+  it('works with different reposRoots', () => {
+    expect(localRepoPath('/home/user/repos', 'org', 'proj')).toBe('/home/user/repos/org/proj')
+  })
+
+  it('handles owner and repo names with hyphens, underscores, and dots', () => {
+    expect(localRepoPath('/r', 'my-org', 'my_repo.name')).toBe('/r/my-org/my_repo.name')
+  })
+})

--- a/server/upload-routes.ts
+++ b/server/upload-routes.ts
@@ -108,6 +108,14 @@ function scanModules(modulesDir: string) {
 const ghEnv = { ...process.env }
 delete ghEnv.GITHUB_TOKEN
 
+/**
+ * Local on-disk path for a repo, namespaced by owner to prevent collisions
+ * between ownerA/foo and ownerB/foo.
+ */
+export function localRepoPath(reposRoot: string, owner: string, name: string): string {
+  return join(reposRoot, owner, name)
+}
+
 async function fetchGhRepos(owner: string, reposRoot: string) {
   const { stdout } = await execFileAsync('gh', [
     'repo', 'list', owner,
@@ -118,7 +126,7 @@ async function fetchGhRepos(owner: string, reposRoot: string) {
   const repos = parsed as Array<{ name: string; url: string; description?: string }>
   repos.sort((a, b) => a.name.localeCompare(b.name))
   return repos.map((r) => {
-    const repoPath = `${reposRoot}/${r.name}`
+    const repoPath = localRepoPath(reposRoot, owner, r.name)
     const cloned = existsSync(repoPath)
     return {
       id: r.name,
@@ -297,7 +305,8 @@ export function createUploadRouter(
     }
 
     const reposRoot = realpathSync(resolveReposRoot())
-    const dest = join(reposRoot, name)
+    const ownerDir = join(reposRoot, owner)
+    const dest = localRepoPath(reposRoot, owner, name)
     // Boundary check: ensure resolved dest stays within REPOS_ROOT
     // Use realpathSync on reposRoot to prevent symlink bypass
     const resolvedDest = resolve(dest)
@@ -309,6 +318,9 @@ export function createUploadRouter(
       res.json({ success: true, path: dest })
       return
     }
+    // Ensure the owner-namespaced parent directory exists — git clone does not
+    // create missing parents.
+    mkdirSync(ownerDir, { recursive: true })
 
     console.log(`Cloning ${owner}/${name} into ${dest}...`)
     execFileAsync('gh', ['repo', 'clone', `${owner}/${name}`, dest], { timeout: 120000 })


### PR DESCRIPTION
## Summary

Fixes two related repo-path bugs flagged in the 2026-04-20 code-review report.

### 1. `repos_path` persisted raw `~` (server/session-routes.ts:318-323)

The PUT `/api/settings/repos-path` handler validated the expanded path with `expandTilde`, but persisted the raw `trimmed` string — so a value like `~/repos` would be saved as `~/repos`, and later callers (e.g. `realpathSync(resolveReposRoot())` at server/upload-routes.ts:299) would fail because `realpathSync` does not expand `~`.

Fix: introduced `canonicalizeReposPath(raw)` which expands `~`, verifies the directory exists, and resolves the absolute canonical path via `realpathSync`. The handler persists the canonicalized value, so stored values are always absolute and symlink-free.

### 2. Repo identity collision (server/upload-routes.ts:121, 299-301)

Local storage path was `<reposRoot>/<repo>` in both `fetchGhRepos` and the clone handler, so `ownerA/foo` and `ownerB/foo` would map to the same on-disk location.

Fix: introduced `localRepoPath(reposRoot, owner, name)` that returns `<reposRoot>/<owner>/<repo>`, used in both call sites. Added `mkdirSync(ownerDir, { recursive: true })` before `gh repo clone` since git clone does not create missing parents.

## Tests

- `server/session-routes.test.ts` — tests for `expandTilde` and `canonicalizeReposPath` (expansion, symlink resolution, nonexistent paths, files, raw `~` rejection/expansion).
- `server/upload-routes.test.ts` — tests for `localRepoPath` namespacing (owner prefix, collision prevention).

## Test plan

- [x] `npm test` — 1668 tests pass (62 test files)
- [x] `npm run build` — tsc + vite build succeed
- [x] `npm run lint` — no new errors/warnings introduced
- [ ] Manual: set `repos_path` to `~/repos` in the UI and confirm the stored value is absolute
- [ ] Manual: clone `ownerA/foo` and `ownerB/foo` and confirm they live in separate directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)