### PR TITLE
fix: nested reports path, narrow CSP connect-src, and API docs drift

### DIFF
--- a/docs/API-REFERENCE.md
+++ b/docs/API-REFERENCE.md
@@ -381,14 +381,14 @@ List all workflow schedules.
 Create a new schedule.
 
 **Request body:** `{ "id": "...", "kind": "code-review", "cronExpression": "0 4 * * *", "input": {}, "enabled": true }`
-**Response:** `{ "schedule": Schedule }`
+**Response:** `{ "schedule": Schedule }`, or `400` with `{ "error": "..." }` when required fields are missing or `cronExpression` is not a valid 5-field cron.
 
 ### `PATCH /api/workflows/schedules/:id`
 
 Update a schedule.
 
 **Request body:** `{ "cronExpression": "...", "input": {}, "enabled": false }` (all fields optional)
-**Response:** `{ "schedule": Schedule }` or `404`
+**Response:** `{ "schedule": Schedule }`, `400` with `{ "error": "Invalid cron expression" }` when a provided `cronExpression` fails validation, or `404`.
 
 ### `DELETE /api/workflows/schedules/:id`
 
@@ -412,14 +412,17 @@ Get workflow engine configuration.
 
 Add a repo workflow configuration.
 
+`repoPath` is resolved via `realpath` and must sit under the configured `REPOS_ROOT` — otherwise the request is rejected with `400`.
+
 **Request body:** `{ "id": "...", "name": "...", "repoPath": "...", "cronExpression": "...", "enabled": true, "customPrompt": "...", "kind": "...", "model": "..." }`
-**Response:** `{ "config": WorkflowConfig }`
+**Response:** `{ "config": WorkflowConfig, "webhookSetup"?: WebhookSetupResult }`, or `400` with `{ "error": "..." }` when required fields are missing, `provider` is invalid, or `repoPath` is not an existing directory under the configured repos root.
 
 ### `PATCH /api/workflows/config/repos/:id`
 
 Update a repo workflow configuration.
 
-**Response:** `{ "config": WorkflowConfig }` or `404`
+**Request body:** Partial `ReviewRepoConfig`. When `repoPath` is supplied, it must resolve to a directory under `REPOS_ROOT`.
+**Response:** `{ "config": WorkflowConfig }`, `400` with `{ "error": "Invalid repoPath: ..." }` for an out-of-root `repoPath`, or `404`.
 
 ### `DELETE /api/workflows/config/repos/:id`
 
@@ -451,17 +454,19 @@ Ensure the orchestrator session is running. Starts it if not already active.
 
 #### `GET /api/orchestrator/reports`
 
-List available audit reports across managed repos.
+List available audit reports. Exactly one of `repo` or `since` must be provided.
 
-**Query params:** `repo` (optional), `category` (optional), `since` (optional — ISO timestamp)
-**Response:** `{ "reports": Report[] }`
+When `repo` is supplied, it is resolved via `realpath` and must sit under the configured `REPOS_ROOT`; otherwise the request is rejected with `400`.
+
+**Query params:** `repo` (path under `REPOS_ROOT`) **or** `since` (YYYY-MM-DD date; lists reports across managed repos newer than that date)
+**Response:** `{ "reports": ReportMeta[] }`, or `400` with `{ "error": "..." }` when neither query param is provided or when `repo` is not under the configured repos root.
 
 #### `GET /api/orchestrator/reports/read`
 
-Read the contents of a specific report file.
+Read the contents of a specific report file. The resolved path must sit under `REPOS_ROOT` and contain `/.codekin/reports/`, or under the Codekin data directory's `reports/` subfolder — otherwise the request returns `404`.
 
-**Query params:** `path` (required) — report file path
-**Response:** `{ "content": "...", "path": "..." }`
+**Query params:** `path` (required) — absolute report file path
+**Response:** `{ "report": ReportContent }` where `ReportContent` includes `filePath`, `category`, `date`, `repoPath`, `size`, `mtime`, and `content`. `400` when `path` is missing; `404` when the resolved path is outside the allowed roots or the file cannot be read.
 
 ### Child Sessions
 
@@ -473,10 +478,10 @@ List child sessions spawned by the orchestrator.
 
 #### `POST /api/orchestrator/children`
 
-Spawn a new child session for a task.
+Spawn a new child session for a task. `repo` is resolved via `realpath` and must sit under `REPOS_ROOT`. `branchName` must match `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`.
 
-**Request body:** `{ "repo": "...", "task": "...", "branchName": "...", "useWorktree": true, "completionPolicy": "pr" | "merge" | "commit-only" }`
-**Response:** `{ "childId": "...", "sessionId": "..." }`
+**Request body:** `{ "repo": "...", "task": "...", "branchName": "...", "useWorktree"?: boolean, "completionPolicy"?: "pr" | "merge" | "commit-only", "deployAfter"?: boolean, "model"?: "...", "allowedTools"?: string[] }`
+**Response:** `{ "child": ChildSession }`, `400` with `{ "error": "..." }` when required fields are missing, `branchName` / `allowedTools` fail validation, or `repo` is not an existing directory under the configured repos root, or `503` when the child session cannot be spawned.
 
 #### `GET /api/orchestrator/children/:id`
 
@@ -502,20 +507,20 @@ Get sessions that have pending approval prompts.
 
 Respond to a pending prompt in a session.
 
-**Request body:** `{ "requestId": "...", "value": "..." }`
-**Response:** `{ "success": true }`
+**Request body:** `{ "requestId"?: "...", "value": "..." }`
+**Response:** `{ "ok": true }`, `400` when `value` is missing, `404` when the session does not exist, or `409` when there is no pending prompt to respond to.
 
 #### `DELETE /api/orchestrator/sessions/cleanup`
 
-Clean up stale or completed child sessions.
+Delete all automated sessions (sources: `workflow`, `webhook`, `stepflow`, `agent`).
 
-**Response:** `{ "cleaned": number }`
+**Response:** `{ "deleted": number }` — count of sessions deleted.
 
 #### `DELETE /api/orchestrator/sessions/:id`
 
 Delete a specific orchestrator-managed session.
 
-**Response:** `{ "success": true }` or `404`
+**Response:** `{ "deleted": true }` or `404`
 
 ### Memory
 

--- a/server/orchestrator-reports.test.ts
+++ b/server/orchestrator-reports.test.ts
@@ -1,0 +1,97 @@
+/** Tests for readReport — verifies depth-agnostic path-validation for nested repo
+ * layouts (org/repo/.codekin/reports/...) while still rejecting paths that escape
+ * REPOS_ROOT or live outside the data-dir reports root. */
+import { describe, it, expect, afterAll, vi } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from 'fs'
+import { tmpdir } from 'os'
+import { join, resolve } from 'path'
+
+const root = mkdtempSync(join(tmpdir(), 'codekin-reports-test-'))
+const reposRoot = join(root, 'repos')
+const dataDir = join(root, 'data')
+const outside = join(root, 'outside')
+mkdirSync(reposRoot, { recursive: true })
+mkdirSync(dataDir, { recursive: true })
+mkdirSync(outside, { recursive: true })
+
+// Flat: <REPOS_ROOT>/flatrepo/.codekin/reports/security/<date>_x.md
+const flatDir = join(reposRoot, 'flatrepo', '.codekin', 'reports', 'security')
+mkdirSync(flatDir, { recursive: true })
+const flatReport = join(flatDir, '2026-04-21_audit.md')
+writeFileSync(flatReport, '# Flat\n')
+
+// Nested: <REPOS_ROOT>/org/subteam/nested-repo/.codekin/reports/code-review/<date>_y.md
+const nestedDir = join(reposRoot, 'org', 'subteam', 'nested-repo', '.codekin', 'reports', 'code-review')
+mkdirSync(nestedDir, { recursive: true })
+const nestedReport = join(nestedDir, '2026-04-21_review.md')
+writeFileSync(nestedReport, '# Nested\n')
+
+// Data-dir report: <DATA_DIR>/reports/dashboard/<date>_z.md
+const dataReportsDir = join(dataDir, 'reports', 'dashboard')
+mkdirSync(dataReportsDir, { recursive: true })
+const dataReport = join(dataReportsDir, '2026-04-21_summary.md')
+writeFileSync(dataReport, '# Data\n')
+
+// Malicious report outside REPOS_ROOT
+const outsideReport = join(outside, 'evil.md')
+writeFileSync(outsideReport, '# Evil\n')
+
+// Symlink inside REPOS_ROOT pointing outside REPOS_ROOT
+const symlinkReport = join(reposRoot, 'flatrepo', '.codekin', 'reports', 'security', 'link.md')
+symlinkSync(outsideReport, symlinkReport)
+
+// File under REPOS_ROOT but not under a `.codekin/reports` directory
+const strayDir = join(reposRoot, 'flatrepo', 'docs')
+mkdirSync(strayDir, { recursive: true })
+const strayReport = join(strayDir, 'stray.md')
+writeFileSync(strayReport, '# Stray\n')
+
+vi.mock('./config.js', () => ({
+  REPOS_ROOT: resolve(reposRoot),
+  DATA_DIR: resolve(dataDir),
+}))
+
+// Import after mocks
+const { readReport } = await import('./orchestrator-reports.js')
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe('readReport', () => {
+  it('accepts a flat one-level repo layout', () => {
+    const result = readReport(flatReport)
+    expect(result).not.toBeNull()
+    expect(result?.content).toContain('Flat')
+    expect(result?.category).toBe('security')
+  })
+
+  it('accepts a nested deep repo layout (org/subteam/repo/.codekin/reports/...)', () => {
+    const result = readReport(nestedReport)
+    expect(result).not.toBeNull()
+    expect(result?.content).toContain('Nested')
+    expect(result?.category).toBe('code-review')
+  })
+
+  it('accepts data-dir reports', () => {
+    const result = readReport(dataReport)
+    expect(result).not.toBeNull()
+    expect(result?.content).toContain('Data')
+  })
+
+  it('rejects a symlink that escapes REPOS_ROOT', () => {
+    expect(readReport(symlinkReport)).toBeNull()
+  })
+
+  it('rejects a path that does not contain /.codekin/reports/', () => {
+    expect(readReport(strayReport)).toBeNull()
+  })
+
+  it('rejects a path outside REPOS_ROOT and DATA_DIR', () => {
+    expect(readReport(outsideReport)).toBeNull()
+  })
+
+  it('returns null when the path does not exist', () => {
+    expect(readReport(join(reposRoot, 'flatrepo', '.codekin', 'reports', 'security', 'missing.md'))).toBeNull()
+  })
+})

--- a/server/orchestrator-reports.ts
+++ b/server/orchestrator-reports.ts
@@ -110,10 +110,12 @@ export function readReport(filePath: string): ReportContent | null {
   } catch {
     return null
   }
-  // Verify the path is within a known reports directory (anchored startsWith, not includes)
+  // Verify the path is within a known reports directory. Depth-agnostic so nested
+  // layouts like REPOS_ROOT/org/repo/.codekin/reports/... are accepted; the
+  // realpath-based REPOS_ROOT containment check prevents traversal escape.
   const isDataReport = resolved.startsWith(DATA_DIR + '/reports/')
   const isRepoReport = resolved.startsWith(REPOS_ROOT + '/') &&
-    /^[^/]+\/\.codekin\/reports\//.test(resolved.slice(REPOS_ROOT.length + 1))
+    resolved.includes('/.codekin/reports/')
   if (!isDataReport && !isRepoReport) return null
 
   const content = readFileSync(resolved, 'utf-8')

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -306,7 +306,10 @@ app.use((_req, res, next) => {
   res.header('X-Frame-Options', 'DENY')
   res.header('Referrer-Policy', 'strict-origin-when-cross-origin')
   res.header('Permissions-Policy', 'camera=(), microphone=(), geolocation=()')
-  res.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self' wss: ws:; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com")
+  // connect-src is restricted to same-origin: the frontend always connects to
+  // `${location.host}/cc/` (see src/lib/ccApi.ts wsUrl()), and CSP 'self'
+  // covers both http(s): and ws(s): schemes at the page origin.
+  res.header('Content-Security-Policy', "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; connect-src 'self'; img-src 'self' data: https:; font-src 'self' https://fonts.gstatic.com")
   if (process.env.NODE_ENV === 'production') {
     res.header('Strict-Transport-Security', 'max-age=31536000; includeSubDomains')
   }


### PR DESCRIPTION
## Summary

Three small fixes flagged in the 2026-04-21 code-review report.

- **`server/orchestrator-reports.ts`** — `readReport()` only accepted flat `REPOS_ROOT/<repo>/.codekin/reports/...` layouts because the validation regex anchored on exactly one path segment between `REPOS_ROOT` and `.codekin/reports/`. Replaced with a depth-agnostic canonical-path check (realpath stays under `REPOS_ROOT` + includes `/.codekin/reports/`), so nested `REPOS_ROOT/org/.../repo/.codekin/reports/...` layouts now resolve. The existing `realpath` containment check still blocks symlink escapes.
- **`server/ws-server.ts`** — CSP `connect-src 'self' wss: ws:` allowed arbitrary WS destinations. The frontend always connects same-origin via `${location.host}/cc/` (see `src/lib/ccApi.ts#wsUrl()`), so tightened `connect-src` to `'self'` only. CSP `'self'` covers both `http(s):` and `ws(s):` at the page origin.
- **`docs/API-REFERENCE.md`** — documented the HTTP 400 validation responses added by #423 for workflow config (`repoPath`), schedule `PATCH` (cron), and orchestrator reports (`repoPath`). Also fixed drift between the documented query params / response shapes and the actual behaviour in `server/orchestrator-session-router.ts` — reports (dropped the non-existent `category` query param; corrected response shapes), children spawn (`child` not `childId`/`sessionId`), session respond (`ok` not `success`), cleanup (`deleted` not `cleaned`), and single-session delete (`deleted` not `success`).

## Test plan

- [x] New `server/orchestrator-reports.test.ts` exercises flat, nested-deep, data-dir, symlink-escape, non-reports-path, outside-`REPOS_ROOT`, and missing-file cases
- [x] `npm test` — 1661 passing
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)