### PR TITLE
chore: remove unused exports and document Opus 4.7 in API reference

### DIFF
--- a/server/orchestrator-learning.ts
+++ b/server/orchestrator-learning.ts
@@ -582,15 +582,6 @@ export function updateSkillLevel(
 }
 
 /**
- * Get the user's assessed skill level for a domain.
- * Returns null if we have no data for this domain.
- */
-export function getSkillLevel(domain: string): SkillLevel | null {
-  const profile = loadSkillProfile()
-  return profile.find(s => s.domain === domain) ?? null
-}
-
-/**
  * Get a guidance style recommendation based on the user's overall skill profile.
  */
 export function getGuidanceStyle(): {

--- a/server/orchestrator-reports.ts
+++ b/server/orchestrator-reports.ts
@@ -145,14 +145,6 @@ export function readReport(filePath: string): ReportContent | null {
 }
 
 /**
- * Get the latest report for a given repo and category.
- */
-export function getLatestReport(repoPath: string, category: string): ReportMeta | null {
-  const reports = scanRepoReports(repoPath)
-  return reports.find(r => r.category === category) ?? null
-}
-
-/**
  * Get reports that are newer than a given date.
  */
 export function getReportsSince(repoPaths: string[], sinceDate: string): ReportMeta[] {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,12 +37,6 @@ export interface Repo {
   tags: string[]
 }
 
-/** Response shape from the upload server's /repos endpoint. */
-export interface RepoManifest {
-  repos: Repo[]
-  generatedAt: string
-}
-
 /**
  * Permission modes supported by the Claude CLI `--permission-mode` flag.
  * Controls how tool permissions are handled during a session.


### PR DESCRIPTION
## Summary

Two cleanups from the 2026-04-26 repo-health report.

### 1. Removed three unused exports

Each was confirmed via grep to have zero references outside its defining file (incl. tests):

- `src/types.ts` — `export interface RepoManifest` (no importers anywhere)
- `server/orchestrator-learning.ts` — `export function getSkillLevel` (callers use `loadSkillProfile()` directly)
- `server/orchestrator-reports.ts` — `export function getLatestReport` (callers use `scanRepoReports()` + filter)

Net diff: 3 files, 23 lines removed.

### 2. Opus 4.7 in API reference — already done

The audit flagged that `docs/API-REFERENCE.md` was missing `claude-opus-4-7`, but it was actually added in PR #429 (commit `567349e`, 2026-04-25, the day before the audit ran). It is currently present at `docs/API-REFERENCE.md:25` in the Models table:

```
| `claude-opus-4-7` | Opus 4.7 |
```

The audit was working from a stale snapshot. No doc change was needed; leaving the file untouched.

## Test plan

- [x] `npm test` — 1791 tests pass
- [x] `npm run lint` — 0 errors (448 pre-existing warnings, unchanged)
- [x] `npm run build` — typecheck + production build succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)