### PR TITLE
fix: silence passive-repo alert for repos with no enabled workflows

### DIFF
--- a/server/orchestrator-monitor.test.ts
+++ b/server/orchestrator-monitor.test.ts
@@ -1,0 +1,48 @@
+/** Tests for the passive-repo notifier predicate — see #issue: alerts were
+ * firing for repos with zero enabled workflows, recommending de-scheduling
+ * workflows that didn't exist. */
+import { describe, it, expect } from 'vitest'
+import { hasEnabledWorkflowForRepo } from './orchestrator-monitor.js'
+import type { ReviewRepoConfig } from './workflow-config.js'
+
+const make = (overrides: Partial<ReviewRepoConfig>): ReviewRepoConfig => ({
+  id: overrides.id ?? 'r',
+  name: overrides.name ?? 'repo',
+  repoPath: overrides.repoPath ?? '/srv/repos/foo',
+  cronExpression: overrides.cronExpression ?? '0 6 * * *',
+  enabled: overrides.enabled ?? false,
+  ...overrides,
+})
+
+describe('hasEnabledWorkflowForRepo', () => {
+  const repoPath = '/srv/repos/calendar-scheduling-advanced'
+
+  it('returns false when there are no entries in reviewRepos', () => {
+    expect(hasEnabledWorkflowForRepo(repoPath, [])).toBe(false)
+  })
+
+  it('returns false when 3 entries match the repo but all are disabled', () => {
+    const entries = [
+      make({ id: '1', repoPath, enabled: false }),
+      make({ id: '2', repoPath, enabled: false, kind: 'commit-review' }),
+      make({ id: '3', repoPath, enabled: false, kind: 'security' }),
+    ]
+    expect(hasEnabledWorkflowForRepo(repoPath, entries)).toBe(false)
+  })
+
+  it('returns true when 1 entry is enabled and 2 are disabled', () => {
+    const entries = [
+      make({ id: '1', repoPath, enabled: false }),
+      make({ id: '2', repoPath, enabled: true, kind: 'commit-review' }),
+      make({ id: '3', repoPath, enabled: false, kind: 'security' }),
+    ]
+    expect(hasEnabledWorkflowForRepo(repoPath, entries)).toBe(true)
+  })
+
+  it('ignores enabled entries belonging to a different repo', () => {
+    const entries = [
+      make({ id: '1', repoPath: '/srv/repos/other', enabled: true }),
+    ]
+    expect(hasEnabledWorkflowForRepo(repoPath, entries)).toBe(false)
+  })
+})

--- a/server/orchestrator-monitor.ts
+++ b/server/orchestrator-monitor.ts
@@ -15,6 +15,7 @@ import { OrchestratorMemory } from './orchestrator-memory.js'
 import { runAgingCycle, getPendingOutcomeAssessments } from './orchestrator-learning.js'
 import { getOrchestratorSessionId } from './orchestrator-manager.js'
 import { REPOS_ROOT, getAgentDisplayName } from './config.js'
+import { loadWorkflowConfig, type ReviewRepoConfig } from './workflow-config.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -186,9 +187,12 @@ export class OrchestratorMonitor {
   /** Check for repos that haven't had recent commits. */
   private checkPassiveRepos(repoPaths: string[]): void {
     const now = Date.now()
+    const reviewRepos = loadWorkflowConfig().reviewRepos
 
     for (const repoPath of repoPaths) {
       try {
+        if (!hasEnabledWorkflowForRepo(repoPath, reviewRepos)) continue
+
         const gitDir = join(repoPath, '.git')
         if (!existsSync(gitDir)) continue
 
@@ -280,4 +284,19 @@ export class OrchestratorMonitor {
       return []
     }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Suppress passive-repo alerts unless at least one workflow is enabled for the
+ * repo — there's nothing to "de-schedule" otherwise, so the nag is noise.
+ */
+export function hasEnabledWorkflowForRepo(
+  repoPath: string,
+  reviewRepos: ReviewRepoConfig[],
+): boolean {
+  return reviewRepos.some(r => r.repoPath === repoPath && r.enabled)
 }


### PR DESCRIPTION
## Summary

The orchestrator's `checkPassiveRepos` notifier in `server/orchestrator-monitor.ts` was firing for any repo with no recent commits, regardless of whether anything was actually scheduled against it. The alert text recommends "de-scheduling workflows to save resources," which is meaningless when there are no workflows enabled — purely noise.

This change adds a small predicate `hasEnabledWorkflowForRepo` that loads `~/.codekin/workflow-config.json` and skips the alert unless the repo has at least one `reviewRepos` entry with `enabled: true`. No threshold change, no wording change, no other notifier touched.

## Motivation — 13 false alerts observed today

All 13 hit repos with zero enabled entries in `workflow-config.json` (every matching `reviewRepos[].enabled` was `false`, or no entries at all). Sample of the alert text we were getting:

> [Agent Joe Notification — INFO] calendar-scheduling-advanced looks passive — No activity in 63 days. Consider de-scheduling workflows to save resources.

That alert fired 13 times today across the following repos (all with no enabled workflows):

1. calendar-scheduling-advanced
2. calendar-scheduling-advanced (re-fire on next poll)
3. legacy-prototype-a
4. legacy-prototype-b
5. spike-llm-routing
6. spike-llm-routing (re-fire)
7. archive-internal-docs
8. archive-internal-docs (re-fire)
9. dead-vendor-fork
10. one-off-migration-tool
11. one-off-migration-tool (re-fire)
12. weekend-hack-board
13. notebook-experiments

After this change, none of those would have produced an alert because none of them have an enabled workflow that costs anything to "de-schedule."

## Changes

- `server/orchestrator-monitor.ts` — Load `reviewRepos` once per poll; gate the existing predicate on `hasEnabledWorkflowForRepo`. Wording, severity, threshold (30 days), and all other notifier types are unchanged.
- `server/orchestrator-monitor.test.ts` — New unit tests for the predicate covering: empty config, 3 disabled entries (skip), 1 enabled + 2 disabled (fire), enabled entry for a different repo (skip).

## Test plan

- [x] `npx vitest run server/orchestrator-monitor.test.ts` — 4/4 pass
- [x] `npm test` — full suite 1799/1799 pass
- [x] `npm run lint` — 0 errors (no new warnings introduced)
- [x] `npm run build` — typecheck + vite build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)