### PR TITLE
fix: 2026-04-27 code-review warnings (W1-W5)

### DIFF
--- a/server/commit-event-hooks.test.ts
+++ b/server/commit-event-hooks.test.ts
@@ -366,6 +366,23 @@ describe('syncCommitHooks', () => {
     expect(existsSync(hookPath)).toBe(false)
   })
 
+  it('uninstalls hook when a repo is fully removed from the config (W2)', () => {
+    // First pass: commit-review enabled → hook installed
+    state.workflowConfig.reviewRepos = [{
+      id: 'a', name: 'RepoA', repoPath: repoA,
+      cronExpression: 'event', enabled: true, kind: 'commit-review',
+    }]
+    syncCommitHooks()
+    const hookPath = join(repoA, '.git', 'hooks', 'post-commit')
+    expect(existsSync(hookPath)).toBe(true)
+
+    // Second pass: repo fully removed from config (not just kind change).
+    // syncCommitHooks must still uninstall the stale hook left behind.
+    state.workflowConfig.reviewRepos = []
+    syncCommitHooks()
+    expect(existsSync(hookPath)).toBe(false)
+  })
+
   it('handles multiple repos — installing the enabled commit-review one only', () => {
     state.workflowConfig.reviewRepos = [
       { id: 'a', name: 'A', repoPath: repoA, cronExpression: 'event', enabled: true, kind: 'commit-review' },

--- a/server/commit-event-hooks.ts
+++ b/server/commit-event-hooks.ts
@@ -23,6 +23,7 @@ const BEGIN_MARKER = '# BEGIN CODEKIN COMMIT HOOK'
 const END_MARKER = '# END CODEKIN COMMIT HOOK'
 
 const HOOK_CONFIG_PATH = join(homedir(), '.codekin', 'hook-config.json')
+const INSTALLED_HOOKS_PATH = join(homedir(), '.codekin', 'installed-commit-hooks.json')
 
 // Resolve the hook script path relative to this file.
 // In compiled mode (dist/), the shell script is at ../server/commit-event-hook.sh
@@ -166,8 +167,42 @@ export function uninstallCommitHook(repoPath: string): boolean {
 // ---------------------------------------------------------------------------
 
 /**
+ * Read the persisted set of repo paths that we previously installed hooks for.
+ * Returns an empty array on any read/parse error so sync can proceed.
+ */
+function loadInstalledHookPaths(): string[] {
+  try {
+    if (!existsSync(INSTALLED_HOOKS_PATH)) return []
+    const raw = readFileSync(INSTALLED_HOOKS_PATH, 'utf-8')
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter((p): p is string => typeof p === 'string')
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Persist the current set of repo paths with installed hooks so a future
+ * sync can detect repos that have been fully removed from the config.
+ */
+function saveInstalledHookPaths(paths: string[]): void {
+  try {
+    const dir = dirname(INSTALLED_HOOKS_PATH)
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+    writeFileSync(INSTALLED_HOOKS_PATH, JSON.stringify([...paths].sort(), null, 2), 'utf-8')
+  } catch (err) {
+    console.warn(`[commit-hooks] Failed to persist installed hook list:`, err)
+  }
+}
+
+/**
  * Sync commit hooks with the current workflow config.
  * Installs hooks for enabled commit-review repos, uninstalls for disabled/removed ones.
+ *
+ * To handle repos that have been fully removed from the config (not just changed
+ * kind), the previously-managed set is persisted to ~/.codekin/installed-commit-hooks.json
+ * and used to detect stale hooks that need to be cleaned up.
  */
 export function syncCommitHooks(): void {
   const config = loadWorkflowConfig()
@@ -187,16 +222,26 @@ export function syncCommitHooks(): void {
     }
   }
 
-  // Uninstall hooks for repos that are no longer configured for commit-review
+  // Build set of all paths we should clean up: any repo currently in config
+  // that isn't a target, plus any repo we previously installed for that's no
+  // longer a target (covers the fully-removed case).
+  const toUninstall = new Set<string>()
   for (const repo of config.reviewRepos) {
-    if (!commitReviewRepos.has(repo.repoPath)) {
-      try {
-        uninstallCommitHook(repo.repoPath)
-      } catch {
-        // Silently ignore — hook may not exist
-      }
+    if (!commitReviewRepos.has(repo.repoPath)) toUninstall.add(repo.repoPath)
+  }
+  for (const path of loadInstalledHookPaths()) {
+    if (!commitReviewRepos.has(path)) toUninstall.add(path)
+  }
+
+  for (const repoPath of toUninstall) {
+    try {
+      uninstallCommitHook(repoPath)
+    } catch {
+      // Silently ignore — hook may not exist
     }
   }
+
+  saveInstalledHookPaths([...commitReviewRepos])
 }
 
 // ---------------------------------------------------------------------------

--- a/server/upload-routes.test.ts
+++ b/server/upload-routes.test.ts
@@ -1,6 +1,33 @@
-/** Tests for localRepoPath — helper exported from upload-routes. */
-import { describe, it, expect } from 'vitest'
-import { localRepoPath } from './upload-routes.js'
+/**
+ * Tests for upload-routes — covers the localRepoPath helper plus the clone
+ * route's handling of an unresolvable repos root (W4).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import express from 'express'
+import type { AddressInfo } from 'net'
+import type { Server } from 'http'
+
+// ---------------------------------------------------------------------------
+// Hoisted mock state — lets tests toggle realpathSync's behavior.
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  realpathThrows: false,
+}))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    realpathSync: ((p: string) => {
+      if (mocks.realpathThrows) throw new Error('ENOENT: no such file or directory')
+      return actual.realpathSync(p)
+    }) as typeof actual.realpathSync,
+  }
+})
+
+// Imported after vi.mock so the router picks up the mocked fs.
+import { localRepoPath, createUploadRouter } from './upload-routes.js'
 
 describe('localRepoPath', () => {
   it('namespaces the repo under its owner', () => {
@@ -19,5 +46,60 @@ describe('localRepoPath', () => {
 
   it('handles owner and repo names with hyphens, underscores, and dots', () => {
     expect(localRepoPath('/r', 'my-org', 'my_repo.name')).toBe('/r/my-org/my_repo.name')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/clone — error handling for unresolvable repos root (W4)
+// ---------------------------------------------------------------------------
+
+const AUTH_TOKEN = 'test-token'
+
+function verifyToken(token: string | undefined): boolean {
+  return token === AUTH_TOKEN
+}
+
+function extractToken(req: { headers: Record<string, string | string[] | undefined> }): string | undefined {
+  const h = req.headers['authorization']
+  if (typeof h === 'string' && h.startsWith('Bearer ')) return h.slice(7)
+  return undefined
+}
+
+describe('POST /api/clone', () => {
+  let server: Server
+  let baseUrl: string
+
+  beforeEach(async () => {
+    mocks.realpathThrows = false
+    const app = express()
+    app.use(express.json())
+    app.use(createUploadRouter(
+      verifyToken,
+      extractToken as unknown as (req: express.Request) => string | undefined,
+      () => '/tmp/codekin-test-repos',
+    ))
+    server = app.listen(0)
+    await new Promise<void>(res => server.once('listening', () => res()))
+    const port = (server.address() as AddressInfo).port
+    baseUrl = `http://127.0.0.1:${port}`
+  })
+
+  afterEach(async () => {
+    await new Promise<void>(res => server.close(() => res()))
+  })
+
+  it('returns 500 with structured error when realpathSync throws (W4)', async () => {
+    mocks.realpathThrows = true
+    const res = await fetch(`${baseUrl}/api/clone`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${AUTH_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ owner: 'someone', name: 'somerepo' }),
+    })
+    expect(res.status).toBe(500)
+    const body = await res.json() as { error: string }
+    expect(body.error).toBe('invalid_repos_root')
   })
 })

--- a/server/upload-routes.ts
+++ b/server/upload-routes.ts
@@ -321,7 +321,14 @@ export function createUploadRouter(
       return
     }
 
-    const reposRoot = realpathSync(resolveReposRoot())
+    let reposRoot: string
+    try {
+      reposRoot = realpathSync(resolveReposRoot())
+    } catch (err) {
+      console.error('Failed to resolve repos root:', err)
+      res.status(500).json({ error: 'invalid_repos_root' })
+      return
+    }
     const ownerDir = join(reposRoot, owner)
     const dest = localRepoPath(reposRoot, owner, name)
     // Boundary check: ensure resolved dest stays within REPOS_ROOT

--- a/server/workflow-routes.test.ts
+++ b/server/workflow-routes.test.ts
@@ -199,6 +199,12 @@ describe('isValidCron', () => {
   it('rejects inverted ranges', () => {
     expect(isValidCron('5-2 * * * *')).toBe(false)
   })
+
+  it('rejects step value of 0 (e.g. */0)', () => {
+    expect(isValidCron('*/0 * * * *')).toBe(false)
+    expect(isValidCron('* */0 * * *')).toBe(false)
+    expect(isValidCron('0-30/0 * * * *')).toBe(false)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/server/workflow-routes.ts
+++ b/server/workflow-routes.ts
@@ -157,6 +157,10 @@ export function isValidCron(expr: string): boolean {
     const [min, max] = ranges[i]
     return part.split(',').every(segment => {
       const stepMatch = segment.match(/^(.+)\/(\d+)$/)
+      if (stepMatch) {
+        const step = parseInt(stepMatch[2], 10)
+        if (isNaN(step) || step < 1) return false
+      }
       const range = stepMatch ? stepMatch[1] : segment
       if (range === '*') return true
       if (range.includes('-')) {

--- a/server/ws-origin-check.test.ts
+++ b/server/ws-origin-check.test.ts
@@ -1,0 +1,43 @@
+/** Tests for isWsOriginAllowed — origin-header gate for WebSocket handshakes. */
+import { describe, it, expect } from 'vitest'
+import { isWsOriginAllowed } from './ws-origin-check.js'
+
+describe('isWsOriginAllowed', () => {
+  const CORS = 'https://app.example.com'
+
+  describe('production', () => {
+    it('allows a matching Origin', () => {
+      expect(isWsOriginAllowed(CORS, CORS, true)).toBe(true)
+    })
+
+    it('rejects a mismatched Origin', () => {
+      expect(isWsOriginAllowed('https://evil.example.com', CORS, true)).toBe(false)
+    })
+
+    it('rejects a missing Origin (W3 — non-browser clients cannot bypass the check)', () => {
+      expect(isWsOriginAllowed(undefined, CORS, true)).toBe(false)
+    })
+
+    it('rejects an empty-string Origin', () => {
+      expect(isWsOriginAllowed('', CORS, true)).toBe(false)
+    })
+  })
+
+  describe('development', () => {
+    it('allows a matching Origin', () => {
+      expect(isWsOriginAllowed(CORS, CORS, false)).toBe(true)
+    })
+
+    it('rejects a mismatched non-empty Origin', () => {
+      expect(isWsOriginAllowed('https://evil.example.com', CORS, false)).toBe(false)
+    })
+
+    it('allows a missing Origin (CLI tools)', () => {
+      expect(isWsOriginAllowed(undefined, CORS, false)).toBe(true)
+    })
+
+    it('allows an empty-string Origin', () => {
+      expect(isWsOriginAllowed('', CORS, false)).toBe(true)
+    })
+  })
+})

--- a/server/ws-origin-check.ts
+++ b/server/ws-origin-check.ts
@@ -1,0 +1,22 @@
+/**
+ * Origin-header validation for incoming WebSocket connections.
+ *
+ * Browsers always send an Origin header on WebSocket handshakes, so a
+ * missing Origin in production indicates a non-browser client (curl,
+ * proxies, or attackers attempting to bypass the cross-site WebSocket
+ * hijacking check). In production we reject those.
+ *
+ * Dev mode stays relaxed so CLI tools and local scripts continue to work.
+ */
+export function isWsOriginAllowed(
+  origin: string | undefined,
+  corsOrigin: string,
+  isProduction: boolean,
+): boolean {
+  if (isProduction) {
+    return typeof origin === 'string' && origin === corsOrigin
+  }
+  // Dev: accept missing Origin (CLI tools); reject only mismatched non-empty Origin.
+  if (!origin) return true
+  return origin === corsOrigin
+}

--- a/server/ws-rate-limit.test.ts
+++ b/server/ws-rate-limit.test.ts
@@ -59,6 +59,25 @@ describe('createMessageRateLimiter', () => {
     expect(next.firstOverflow).toBe(false)
   })
 
+  it('rolls the window for a request EXACTLY at the boundary (W5 — was off-by-one with >)', () => {
+    let t = 0
+    const limiter = createMessageRateLimiter(5, 1000, () => t)
+
+    // Fill the window
+    for (let i = 0; i < 5; i++) {
+      expect(limiter.observe().allowed).toBe(true)
+    }
+    // Next call at t=0 should overflow
+    expect(limiter.observe().allowed).toBe(false)
+
+    // A request exactly at windowStart + windowMs (t=1000) should be the start
+    // of a new window and therefore allowed.
+    t = 1000
+    const onBoundary = limiter.observe()
+    expect(onBoundary.allowed).toBe(true)
+    expect(onBoundary.firstOverflow).toBe(false)
+  })
+
   it('counts every frame, including frames that would fail JSON parsing — the call site only invokes observe() once per message regardless of payload validity', () => {
     const t = 0
     const limiter = createMessageRateLimiter(5, 1000, () => t)

--- a/server/ws-rate-limit.ts
+++ b/server/ws-rate-limit.ts
@@ -29,7 +29,7 @@ export function createMessageRateLimiter(
   return {
     observe(): RateLimitDecision {
       const t = now()
-      if (t - windowStart > windowMs) {
+      if (t - windowStart >= windowMs) {
         count = 0
         windowStart = t
       }

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -34,6 +34,7 @@ import { createWorkflowRouter, syncSchedules } from './workflow-routes.js'
 import { CommitEventHandler } from './commit-event-handler.js'
 import { jsonParse } from './json-parse.js'
 import { createMessageRateLimiter } from './ws-rate-limit.js'
+import { isWsOriginAllowed } from './ws-origin-check.js'
 import { checkForUpdates, getUpdateNotification } from './version-check.js'
 import { stopOpenCodeServer } from './opencode-process.js'
 import { ensureHookConfig, syncCommitHooks } from './commit-event-hooks.js'
@@ -443,9 +444,11 @@ function checkWsRateLimit(ip: string): boolean {
 
 wss.on('connection', (ws: WebSocket, req) => {
   // Validate Origin header to prevent cross-site WebSocket hijacking.
-  // In production CORS_ORIGIN is always set; in dev we also accept no origin (CLI tools).
+  // Production: require Origin === CORS_ORIGIN (browsers always send it; a
+  // missing Origin in prod indicates a non-browser client trying to bypass
+  // the check). Dev: accept missing Origin so CLI tools still work.
   const origin = req.headers.origin
-  if (origin && origin !== CORS_ORIGIN) {
+  if (!isWsOriginAllowed(origin, CORS_ORIGIN, process.env.NODE_ENV === 'production')) {
     ws.close(4003, 'Origin not allowed')
     return
   }


### PR DESCRIPTION
## Summary

Addresses the five warnings flagged in `.codekin/reports/code-review/2026-04-27_code-review-daily.md`. One commit per finding, regression test added per finding.

- **W1** `fix(workflow-routes): reject cron step value of 0` — `isValidCron()` parsed step syntax but accepted `*/0`. Now rejects step values < 1.
- **W2** `fix(commit-hooks): clean up hooks for fully-removed repos` — `syncCommitHooks()` only iterated the current config when uninstalling, so hooks for fully-removed repos were left behind. Persists the previously-managed set to `~/.codekin/installed-commit-hooks.json` and uninstalls stale entries on the next sync.
- **W3** `fix(ws-server): require Origin header in production WS handshake` — the previous check rejected only mismatched non-empty Origins; in production we now require `Origin === CORS_ORIGIN`. Dev mode stays relaxed for CLI tools. Logic extracted to `isWsOriginAllowed()` for testability.
- **W4** `fix(upload-routes): guard realpathSync in clone route` — `realpathSync(resolveReposRoot())` was unguarded in `POST /api/clone`. Now wrapped in try/catch; returns `500 { error: 'invalid_repos_root' }`.
- **W5** `fix(ws-rate-limit): roll window at boundary, not after` — `>` instead of `>=` when rolling the rate-limit window meant a request arriving exactly at `windowStart + windowMs` was still counted in the previous window.

## Test plan

- [x] `npm test` — 1817 / 1817 pass (5 new regression tests)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — succeeds