### PR TITLE
fix(workflow): output-path consistency (single dir + fresh branch per run)

### DIFF
--- a/server/commit-event-handler.ts
+++ b/server/commit-event-handler.ts
@@ -6,7 +6,8 @@
  * for cycle prevention and deduplication.
  *
  * Filter chain (defense in depth):
- *   1. Branch filter — reject if `codekin/reports`
+ *   1. Branch filter — reject if a workflow reports branch (legacy
+ *      `codekin/reports` or per-run `audit/<kind>-<YYYY-MM-DD>`)
  *   2. Message filter — reject if message starts with any workflow commitMessage prefix
  *   3. Config lookup — reject if no enabled `commit-review` workflow for this repo
  *   4. Commit hash dedup — in-memory Map with 1h TTL, reject duplicates
@@ -15,7 +16,7 @@
 
 import { getWorkflowEngine } from './workflow-engine.js'
 import { loadWorkflowConfig } from './workflow-config.js'
-import { getWorkflowCommitPrefixes } from './workflow-loader.js'
+import { getWorkflowCommitPrefixes, isWorkflowReportsBranch } from './workflow-loader.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -61,7 +62,7 @@ export class CommitEventHandler {
    */
   async handle(event: CommitEvent): Promise<CommitEventResult> {
     // Layer 1: Branch filter
-    if (event.branch === 'codekin/reports') {
+    if (isWorkflowReportsBranch(event.branch)) {
       return { accepted: false, reason: 'Rejected: reports branch' }
     }
 

--- a/server/commit-event-hook.sh
+++ b/server/commit-event-hook.sh
@@ -4,7 +4,8 @@
 # between BEGIN/END CODEKIN markers manually.
 #
 # Client-side fast filters avoid unnecessary HTTP calls:
-#   1. Skip if branch = codekin/reports
+#   1. Skip if branch is a workflow reports branch
+#      (legacy 'codekin/reports' or per-run 'audit/<kind>-<YYYY-MM-DD>')
 #   2. Skip if message starts with a workflow commit prefix
 #
 # Fire-and-forget: never blocks `git commit`.
@@ -32,10 +33,17 @@ COMMIT_MESSAGE=$(git log -1 --format="%s" 2>/dev/null)
 AUTHOR=$(git log -1 --format="%an" 2>/dev/null)
 REPO_PATH=$(git rev-parse --show-toplevel 2>/dev/null)
 
-# Client-side filter 1: skip reports branch
-if [ "$BRANCH" = "codekin/reports" ]; then
-  exit 0
-fi
+# Client-side filter 1: skip workflow reports branches
+# - 'codekin/reports' (legacy long-lived branch)
+# - 'audit/<kind>-<YYYY-MM-DD>' (per-run branch produced by workflow-loader)
+case "$BRANCH" in
+  codekin/reports)
+    exit 0
+    ;;
+  audit/*-[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
+    exit 0
+    ;;
+esac
 
 # Client-side filter 2: skip workflow-generated commits
 case "$COMMIT_MESSAGE" in

--- a/server/workflow-loader.test.ts
+++ b/server/workflow-loader.test.ts
@@ -501,7 +501,7 @@ Prompt text.
 
         expect(sessions.sendInput).toHaveBeenCalledWith(
           'session-1',
-          'You are performing an automated test review of the codebase.'
+          expect.stringContaining('You are performing an automated test review of the codebase.')
         )
         expect(result.reportText).toBe('Review output text')
         expect(result.repoName).toBe('my-repo')
@@ -550,7 +550,7 @@ This is the repo-specific override prompt.
 
         expect(sessions.sendInput).toHaveBeenCalledWith(
           'session-1',
-          'This is the repo-specific override prompt.'
+          expect.stringContaining('This is the repo-specific override prompt.')
         )
         expect(result.reportText).toBe('Override result')
         expect(logSpy).toHaveBeenCalledWith(
@@ -870,15 +870,15 @@ This is the repo-specific override prompt.
         warnSpy.mockRestore()
       })
 
-      it('creates the reports branch when it does not exist', async () => {
+      it('creates a fresh per-run audit/<kind>-<date> branch when it does not exist', async () => {
         const gitCalls: string[][] = []
         mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
           gitCalls.push(args)
           // rev-parse --abbrev-ref HEAD → main
           if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return Buffer.from('main\n')
-          // rev-parse --verify codekin/reports → fail (branch doesn't exist)
+          // rev-parse --verify <branch> → fail (branch doesn't exist)
           if (args[0] === 'rev-parse' && args[1] === '--verify') throw new Error('not found')
-          // branch codekin/reports → success
+          // branch <name> → success
           if (args[0] === 'branch') return Buffer.from('')
           return Buffer.from('')
         })
@@ -895,9 +895,12 @@ This is the repo-specific override prompt.
           { runId: 'r1', run: {}, abortSignal: new AbortController().signal }
         )
 
-        // Should have called 'git branch codekin/reports'
-        const branchCall = gitCalls.find(args => args[0] === 'branch' && args[1] === 'codekin/reports')
+        // Should have created a fresh audit/<kind>-<YYYY-MM-DD> branch — never
+        // the legacy long-lived 'codekin/reports' branch.
+        const branchCall = gitCalls.find(args => args[0] === 'branch' && /^audit\/test-review\.daily-\d{4}-\d{2}-\d{2}$/.test(args[1] ?? ''))
         expect(branchCall).toBeDefined()
+        const legacyCall = gitCalls.find(args => args[0] === 'branch' && args[1] === 'codekin/reports')
+        expect(legacyCall).toBeUndefined()
       })
 
       it('uses git worktree instead of stash/checkout', async () => {
@@ -1028,6 +1031,191 @@ This is the repo-specific override prompt.
 
         const writtenContent = mockWriteFileSync.mock.calls[0][1] as string
         expect(writtenContent).toContain('**Branch**: unknown')
+      })
+
+      // ----------------------------------------------------------------
+      // Output-path consistency (regression — 2026-04-27 coverage bug)
+      // ----------------------------------------------------------------
+
+      it('writes the report only under the configured outputDir', async () => {
+        // Today (2026-04-27) the coverage workflow produced two files: a
+        // substantive report under `.codekin/reports/test-coverage/` written by
+        // Claude itself, and a stub under `.codekin/reports/coverage/` written
+        // by the workflow's save_report step. The workflow's own write must
+        // target exactly one location: the configured outputDir.
+        mockExecFileSync.mockReturnValue(Buffer.from('main\n'))
+
+        const handler = registeredDef.steps[3].handler
+        await handler(
+          {
+            repoPath: '/tmp/repo',
+            repoName: 'my-repo',
+            reportText: '## Summary\nReport body.\n',
+            sessionId: 's1',
+            branch: 'main',
+          },
+          { runId: 'run-output-path', run: {}, abortSignal: new AbortController().signal }
+        )
+
+        // Every writeFileSync call must target a path containing the configured
+        // outputDir + filename, never any other category (e.g. `test-coverage`).
+        const writePaths = mockWriteFileSync.mock.calls.map(c => String(c[0]))
+        expect(writePaths.length).toBeGreaterThan(0)
+        for (const p of writePaths) {
+          expect(p).toContain('.codekin/reports/test/')
+          expect(p).toMatch(/_test-review\.md$/)
+          expect(p).not.toContain('test-coverage')
+        }
+      })
+
+      it('runs save_report exactly once and writes a single distinct report path', async () => {
+        mockExecFileSync.mockReturnValue(Buffer.from('main\n'))
+
+        const handler = registeredDef.steps[3].handler
+        const result = await handler(
+          {
+            repoPath: '/tmp/repo',
+            repoName: 'my-repo',
+            reportText: '## R\nbody',
+            sessionId: 's1',
+            branch: 'main',
+          },
+          { runId: 'run-single', run: {}, abortSignal: new AbortController().signal }
+        )
+
+        // The handler returns a single filePath/filename pair, and that
+        // filename matches the configured suffix.
+        expect(result.filePath).toMatch(/\.codekin\/reports\/test\/[^/]+_test-review\.md$/)
+        expect(result.filename).toMatch(/^\d{4}-\d{2}-\d{2}_test-review\.md$/)
+
+        // After dedup, the workflow only ever writes the single configured
+        // relative path (working tree + worktree both target the same
+        // outputDir/filename, just in different cwd's).
+        const writePaths = mockWriteFileSync.mock.calls.map(c => String(c[0]))
+        const relativePaths = new Set(
+          writePaths.map(p => {
+            const idx = p.indexOf('.codekin/reports/')
+            return idx === -1 ? p : p.slice(idx)
+          })
+        )
+        expect(relativePaths.size).toBe(1)
+      })
+
+      // ----------------------------------------------------------------
+      // Per-run branch (regression — stale docs/audit-reports-* branch)
+      // ----------------------------------------------------------------
+
+      it('uses a fresh per-run audit/<kind>-<YYYY-MM-DD> branch, never the legacy codekin/reports', async () => {
+        const gitCalls: string[][] = []
+        mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+          gitCalls.push(args)
+          if (args[0] === 'rev-parse' && args[1] === '--verify') return Buffer.from('')
+          return Buffer.from('')
+        })
+
+        const handler = registeredDef.steps[3].handler
+        await handler(
+          {
+            repoPath: '/tmp/repo',
+            repoName: 'my-repo',
+            reportText: 'Content',
+            sessionId: 's1',
+            branch: 'main',
+          },
+          { runId: 'run-fresh-branch', run: {}, abortSignal: new AbortController().signal }
+        )
+
+        const reportsBranchPattern = /^audit\/test-review\.daily-\d{4}-\d{2}-\d{2}$/
+
+        const verifyCall = gitCalls.find(args =>
+          args[0] === 'rev-parse' && args[1] === '--verify' && reportsBranchPattern.test(String(args[2] ?? ''))
+        )
+        expect(verifyCall).toBeDefined()
+
+        const worktreeAddCall = gitCalls.find(args =>
+          args[0] === 'worktree' && args[1] === 'add' && reportsBranchPattern.test(String(args[3] ?? ''))
+        )
+        expect(worktreeAddCall).toBeDefined()
+
+        const pushCall = gitCalls.find(args =>
+          args[0] === 'push' && args[1] === 'origin' && reportsBranchPattern.test(String(args[2] ?? ''))
+        )
+        expect(pushCall).toBeDefined()
+
+        // The legacy branch must not appear in any git call.
+        const legacyCall = gitCalls.find(args => args.includes('codekin/reports'))
+        expect(legacyCall).toBeUndefined()
+      })
+
+      it('uses today\'s date in the branch name', async () => {
+        const gitCalls: string[][] = []
+        mockExecFileSync.mockImplementation((_cmd: string, args: string[]) => {
+          gitCalls.push(args)
+          if (args[0] === 'rev-parse' && args[1] === '--verify') return Buffer.from('')
+          return Buffer.from('')
+        })
+
+        const handler = registeredDef.steps[3].handler
+        await handler(
+          {
+            repoPath: '/tmp/repo',
+            repoName: 'my-repo',
+            reportText: 'Content',
+            sessionId: 's1',
+            branch: 'main',
+          },
+          { runId: 'run-today', run: {}, abortSignal: new AbortController().signal }
+        )
+
+        const today = new Date().toISOString().slice(0, 10)
+        const expected = `audit/test-review.daily-${today}`
+        const branchCall = gitCalls.find(args =>
+          args[0] === 'worktree' && args[1] === 'add' && args[3] === expected
+        )
+        expect(branchCall).toBeDefined()
+      })
+    })
+
+    // ----------------------------------------------------------------
+    // Prompt guard (regression — Bug 1)
+    // ----------------------------------------------------------------
+
+    describe('run_prompt prompt guard', () => {
+      it('prepends a guard so Claude does not duplicate the report via the Write tool', async () => {
+        vi.useFakeTimers()
+
+        mockExistsSync.mockImplementation((p: string) => {
+          if (String(p).includes('.codekin/workflows')) return false
+          return true
+        })
+
+        sessions.get.mockReturnValue({
+          outputHistory: [
+            { type: 'output', data: 'guarded output' },
+            { type: 'result' },
+          ],
+        })
+
+        const handler = registeredDef.steps[2].handler
+        const promise = handler(
+          { sessionId: 'session-1', repoName: 'my-repo', repoPath: '/tmp/repo', branch: 'main' },
+          { runId: 'r1', run: { kind: 'test-review.daily' }, abortSignal: new AbortController().signal }
+        )
+
+        await vi.advanceTimersByTimeAsync(2000)
+        await promise
+
+        const sentPrompt = String(sessions.sendInput.mock.calls[0][1])
+        // Guard names the offending tools and the override of CLAUDE.md guidance.
+        expect(sentPrompt).toContain('Do NOT use the Write or Edit tools')
+        expect(sentPrompt).toContain('CLAUDE.md')
+        // The original workflow prompt is still present, after the guard.
+        expect(sentPrompt).toContain('You are performing an automated test review of the codebase.')
+        const guardIdx = sentPrompt.indexOf('Do NOT use the Write or Edit tools')
+        const promptIdx = sentPrompt.indexOf('You are performing an automated test review of the codebase.')
+        expect(guardIdx).toBeLessThan(promptIdx)
+
+        vi.useRealTimers()
       })
     })
   })
@@ -1479,7 +1667,7 @@ This just keeps going without a closing ---
       // Should have used the default prompt since override failed
       expect(sessions.sendInput).toHaveBeenCalledWith(
         'session-1',
-        'You are performing an automated test review of the codebase.'
+        expect.stringContaining('You are performing an automated test review of the codebase.')
       )
       expect(result.reportText).toBe('Fallback output')
 

--- a/server/workflow-loader.ts
+++ b/server/workflow-loader.ts
@@ -9,7 +9,8 @@
  *   1. validate_repo  — verify path exists, is a git repo, check staleness
  *   2. create_session — create a Codekin session for the run
  *   3. run_prompt     — start Claude, send the prompt, wait for result
- *   4. save_report    — write Markdown output to outputDir, commit on codekin/reports branch, push
+ *   4. save_report    — write Markdown output to outputDir, commit on a fresh
+ *                       audit/<kind>-<YYYY-MM-DD> branch, push
  *
  * MD file format — YAML frontmatter followed by the Claude prompt:
  *
@@ -192,6 +193,37 @@ async function waitForSessionResult(
 }
 
 // ---------------------------------------------------------------------------
+// Prompt guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Prepended to every workflow prompt so Claude does not duplicate the report.
+ * The save_report step writes Claude's response text to the configured outputDir;
+ * if Claude also uses the Write tool (per CLAUDE.md guidance), two files appear
+ * — one substantive file under whatever category Claude chose, and one stub
+ * (the conversational reply) under the configured outputDir.
+ */
+const WORKFLOW_PROMPT_GUARD = [
+  'IMPORTANT: You are running as part of an automated Codekin workflow.',
+  'The workflow runner will save your entire response as the report file.',
+  'Do NOT use the Write or Edit tools to create the report yourself — that produces a duplicate file.',
+  'Respond with the report Markdown directly, with no preamble.',
+  'Disregard any conflicting guidance in CLAUDE.md about writing audit reports to disk; the workflow handles saving and committing.',
+].join(' ')
+
+/** Branch name for the per-run report commit. Kept short and stable per (kind, date). */
+export function reportBranchName(kind: string, dateStr: string): string {
+  return `audit/${kind}-${dateStr}`
+}
+
+/** True when a branch name is one a workflow run produces (or used to produce). */
+export function isWorkflowReportsBranch(branch: string): boolean {
+  // Accept the legacy long-lived branch and the new per-run audit/<kind>-<date> form.
+  if (branch === 'codekin/reports') return true
+  return /^audit\/[^/]+-\d{4}-\d{2}-\d{2}$/.test(branch)
+}
+
+// ---------------------------------------------------------------------------
 // Workflow registration
 // ---------------------------------------------------------------------------
 
@@ -288,9 +320,13 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
             const repoOverride = loadRepoOverride(repoPath, ctx.run.kind)
             const basePrompt = repoOverride ? repoOverride.prompt : def.prompt
 
-            const prompt = customPrompt
+            const userPrompt = customPrompt
               ? `${basePrompt}\n\nAdditional focus areas:\n${customPrompt}`
               : basePrompt
+
+            // Prepend the guard to suppress Claude's CLAUDE.md-driven file-write
+            // behavior, which otherwise creates a duplicate report file.
+            const prompt = `${WORKFLOW_PROMPT_GUARD}\n\n${userPrompt}`
 
             if (repoOverride) {
               console.log(`[workflow:${def.kind}] Using per-repo prompt override from ${repoPath}`)
@@ -357,26 +393,29 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
 
           console.log(`[workflow:${def.kind}] Saved report to ${filePath}`)
 
-          // Commit on a dedicated branch so reports don't pollute the working branch.
-          // Use a temporary git worktree to avoid stash/checkout races when
-          // multiple workflow runs target the same repo concurrently.
-          const REPORTS_BRANCH = 'codekin/reports'
+          // Commit on a fresh per-run branch (audit/<kind>-<YYYY-MM-DD>) so each
+          // audit gets its own PR and we never append to a stale, long-lived
+          // reports branch. Use a temporary git worktree to avoid stash/checkout
+          // races when multiple workflow runs target the same repo concurrently.
+          const reportsBranch = reportBranchName(def.kind, dateStr)
           try {
             const relativePath = `${def.outputDir}/${filename}`
 
-            // Ensure the reports branch exists (create if needed)
+            // Ensure the reports branch exists (create if needed). For same-day
+            // reruns of the same kind we reuse the existing daily branch and
+            // append a new commit.
             try {
-              execFileSync('git', ['rev-parse', '--verify', REPORTS_BRANCH], { cwd: repoPath, timeout: 5_000, stdio: 'pipe' })
+              execFileSync('git', ['rev-parse', '--verify', reportsBranch], { cwd: repoPath, timeout: 5_000, stdio: 'pipe' })
             } catch {
               // Branch doesn't exist yet — create it from the current branch
-              execFileSync('git', ['branch', REPORTS_BRANCH], { cwd: repoPath, timeout: 5_000 })
-              console.log(`[workflow:${def.kind}] Created branch ${REPORTS_BRANCH}`)
+              execFileSync('git', ['branch', reportsBranch], { cwd: repoPath, timeout: 5_000 })
+              console.log(`[workflow:${def.kind}] Created branch ${reportsBranch}`)
             }
 
             // Create a temporary worktree on the reports branch
             const wtDir = join(repoPath, '..', `.codekin-wt-report-${ctx.runId}`)
             try {
-              execFileSync('git', ['worktree', 'add', wtDir, REPORTS_BRANCH], { cwd: repoPath, timeout: 10_000 })
+              execFileSync('git', ['worktree', 'add', wtDir, reportsBranch], { cwd: repoPath, timeout: 10_000 })
 
               // Write the report file in the worktree
               const reportsDirInWt = join(wtDir, def.outputDir)
@@ -390,14 +429,14 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
                 'git', ['commit', '-m', `${def.commitMessage} ${dateStr}`],
                 { cwd: wtDir, timeout: 15_000 }
               )
-              console.log(`[workflow:${def.kind}] Committed ${relativePath} on ${REPORTS_BRANCH}`)
+              console.log(`[workflow:${def.kind}] Committed ${relativePath} on ${reportsBranch}`)
 
               // Push to remote
               try {
-                execFileSync('git', ['push', 'origin', REPORTS_BRANCH], { cwd: wtDir, timeout: 30_000, stdio: 'pipe' })
-                console.log(`[workflow:${def.kind}] Pushed ${REPORTS_BRANCH} to origin`)
+                execFileSync('git', ['push', 'origin', reportsBranch], { cwd: wtDir, timeout: 30_000, stdio: 'pipe' })
+                console.log(`[workflow:${def.kind}] Pushed ${reportsBranch} to origin`)
               } catch (pushErr) {
-                console.warn(`[workflow:${def.kind}] Could not push ${REPORTS_BRANCH}: ${pushErr}`)
+                console.warn(`[workflow:${def.kind}] Could not push ${reportsBranch}: ${pushErr}`)
               }
             } finally {
               // Always clean up the temporary worktree


### PR DESCRIPTION
Fixes two output-path bugs: coverage workflow dual-writing to coverage/ + test-coverage/, and audit runs appending to docs/audit-reports-2026-04-18 instead of fresh per-run branches.