### PR TITLE
fix(ci): unblock lint + repair commit-event-handler test mock

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -95,6 +95,10 @@ export default defineConfig([
     },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
+      // require() is needed inside vi.hoisted() callbacks, which run before ES imports resolve.
+      '@typescript-eslint/no-require-imports': 'off',
+      // Honor the `_`-prefix convention for intentionally unused args in mock callbacks.
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     },
   },
 ])

--- a/server/commit-event-handler.test.ts
+++ b/server/commit-event-handler.test.ts
@@ -42,6 +42,8 @@ vi.mock('./workflow-config.js', () => ({
 
 vi.mock('./workflow-loader.js', () => ({
   getWorkflowCommitPrefixes: () => mockState.prefixes,
+  isWorkflowReportsBranch: (branch: string) =>
+    branch === 'codekin/reports' || /^audit\/[^/]+-\d{4}-\d{2}-\d{2}$/.test(branch),
 }))
 
 import { CommitEventHandler, type CommitEvent } from './commit-event-handler.js'


### PR DESCRIPTION
## Summary

Fixes [CI run #1101](https://github.com/Multiplier-Labs/codekin/actions/runs/24985270692) (test-and-lint matrix 20 & 22), which began failing on `main` after PRs #440 and #441 merged in succession.

Two distinct problems, both surfaced by the merge order:

- **Lint (10 errors)** — test files used `_kind`/`_input`/`_opts`/`_req` for intentionally unused mock-callback args and `require()` inside `vi.hoisted()` callbacks (where ES imports aren't yet resolved). The test eslint config only carved out `no-explicit-any`, leaving `no-unused-vars` and `no-require-imports` at error severity.
- **Test (14 failures in `commit-event-handler.test.ts`)** — PR #440 mocked `./workflow-loader.js` with only `getWorkflowCommitPrefixes`. PR #441 then added a new `isWorkflowReportsBranch` export that the handler now calls before any other logic, so every test in that file crashed at the first branch-filter check.

## Changes

- `eslint.config.js` — for the `**/*.test.{ts,tsx}` block, add `argsIgnorePattern: '^_'` / `varsIgnorePattern: '^_'` to `no-unused-vars` and disable `no-require-imports`. Mirrors the existing `no-explicit-any: off` carve-out for tests.
- `server/commit-event-handler.test.ts` — add `isWorkflowReportsBranch` to the `./workflow-loader.js` mock with the same regex contract as the real implementation in `server/workflow-loader.ts:220`.

## Verification

- `npm run lint` → `0 errors, 464 warnings` (was `10 errors, 463 warnings`)
- `npm test` → `1973 passed` (was `14 failed`)
- `npm run build` → green

## Test plan

- [x] `npm run lint` exits 0
- [x] `npm test` — full suite passes
- [x] `npm run build` — typecheck + production build succeed
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)