### PR TITLE
fix(tests): resolve CI lint errors + stale workflow-loader mock

### DIFF
--- a/server/commit-event-handler.test.ts
+++ b/server/commit-event-handler.test.ts
@@ -14,7 +14,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 // ---------------------------------------------------------------------------
 
 const mockState = vi.hoisted(() => ({
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   startRun: vi.fn(async (_kind: string, _input: Record<string, unknown>) => ({ id: 'run-123' })),
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   listRuns: vi.fn((_opts?: unknown) => [] as Array<{ input: { repoPath: string } }>),
   config: { reviewRepos: [] as Array<{
     id: string
@@ -42,6 +44,8 @@ vi.mock('./workflow-config.js', () => ({
 
 vi.mock('./workflow-loader.js', () => ({
   getWorkflowCommitPrefixes: () => mockState.prefixes,
+  isWorkflowReportsBranch: (branch: string) =>
+    branch === 'codekin/reports' || /^audit\/[^/]+-\d{4}-\d{2}-\d{2}$/.test(branch),
 }))
 
 import { CommitEventHandler, type CommitEvent } from './commit-event-handler.js'

--- a/server/orchestrator-learning-router.test.ts
+++ b/server/orchestrator-learning-router.test.ts
@@ -32,6 +32,7 @@ vi.mock('./orchestrator-learning.js', () => learningMocks)
 import { createLearningRouter } from './orchestrator-learning-router.js'
 import type { OrchestratorMemory } from './orchestrator-memory.js'
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const verifyAuth = vi.fn((_req: Request) => true)
 
 async function startApp(router: express.Router): Promise<{ baseUrl: string; close: () => Promise<void> }> {

--- a/server/session-persistence.test.ts
+++ b/server/session-persistence.test.ts
@@ -1,12 +1,15 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmdirSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
 import { join } from 'path'
 
 const { TEST_DATA_DIR } = vi.hoisted(() => {
+  /* eslint-disable @typescript-eslint/no-require-imports */
   const fs = require('fs') as typeof import('fs')
   const os = require('os') as typeof import('os')
   const path = require('path') as typeof import('path')
+  /* eslint-enable @typescript-eslint/no-require-imports */
   return { TEST_DATA_DIR: fs.mkdtempSync(path.join(os.tmpdir(), 'codekin-persist-test-')) }
 })
 
@@ -109,13 +112,12 @@ describe('SessionPersistence.persistToDisk', () => {
     // Point DATA_DIR-derived SESSIONS_FILE at an unwritable path by replacing
     // the real sessions file with a directory at the .tmp location, which
     // causes writeFileSync to fail.
-    const fs = require('fs') as typeof import('fs')
-    fs.mkdirSync(SESSIONS_FILE + '.tmp', { recursive: true })
+    mkdirSync(SESSIONS_FILE + '.tmp', { recursive: true })
 
     expect(() => new SessionPersistence(sessions).persistToDisk()).not.toThrow()
     expect(errSpy).toHaveBeenCalledWith('Failed to persist sessions:', expect.any(Error))
 
-    fs.rmdirSync(SESSIONS_FILE + '.tmp')
+    rmdirSync(SESSIONS_FILE + '.tmp')
     errSpy.mockRestore()
   })
 })
@@ -194,9 +196,7 @@ describe('SessionPersistence.restoreFromDisk', () => {
   })
 
   it('falls back to groupDir when worktreePath no longer exists', () => {
-    const fs = require('fs') as typeof import('fs')
-    const os = require('os') as typeof import('os')
-    const repoDir = fs.mkdtempSync(join(os.tmpdir(), 'codekin-fallback-'))
+    const repoDir = mkdtempSync(join(tmpdir(), 'codekin-fallback-'))
     seed([{
       id: 's1',
       name: 'WT',


### PR DESCRIPTION
## Summary

- Fix the 10 lint errors that broke CI on `main` after PR #440 (run #1100, jobs `test-and-lint (20)` and `test-and-lint (22)`).
- Fix a stale mock in `commit-event-handler.test.ts` that PR #441 silently broke (it added an `isWorkflowReportsBranch` import to the production file but didn't update the mock — masked locally because lint failed first).

## Root cause

`main` is currently red. The `test-and-lint` job's lint step exits 1 with 10 errors, all in three test files added by PR #440:

| File | Lines | Rule |
|---|---|---|
| `server/commit-event-handler.test.ts` | 17, 18 | `@typescript-eslint/no-unused-vars` (`_kind`, `_input`, `_opts`) |
| `server/orchestrator-learning-router.test.ts` | 35 | `@typescript-eslint/no-unused-vars` (`_req`) |
| `server/session-persistence.test.ts` | 7-9, 112, 197-198 | `@typescript-eslint/no-require-imports` |

The repo's `tseslint.configs.recommended` (applied to test files) flags both rules, and `_`-prefixing isn't auto-ignored. Existing tests like `server/opencode-process.test.ts` already use `// eslint-disable-next-line` for the same pattern.

## Fixes

1. Apply `eslint-disable-next-line` to the `_`-prefixed unused params (matches repo convention).
2. In `session-persistence.test.ts`:
   - Inside `vi.hoisted(...)`, keep `require()` (ES imports aren't yet evaluated) but disable the rule.
   - In test bodies, replace `require('fs' | 'os')` with proper top-level imports from `fs` / `os` (cleaner than disabling the rule).
3. Add the missing `isWorkflowReportsBranch` export to the `./workflow-loader.js` mock so the `CommitEventHandler` Layer-1 branch filter test doesn't blow up once lint passes.

## Test plan

- [x] `npm run lint` → 0 errors (was 10), 463 warnings unchanged
- [x] `npm test` → 1973/1973 passing
- [x] `npm run build` → clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)