### PR TITLE
fix(test): add isWorkflowReportsBranch to commit-event-handler mock

### DIFF
--- a/server/commit-event-handler.test.ts
+++ b/server/commit-event-handler.test.ts
@@ -42,6 +42,8 @@ vi.mock('./workflow-config.js', () => ({
 
 vi.mock('./workflow-loader.js', () => ({
   getWorkflowCommitPrefixes: () => mockState.prefixes,
+  isWorkflowReportsBranch: (branch: string) =>
+    branch === 'codekin/reports' || /^audit\/[^/]+-\d{4}-\d{2}-\d{2}$/.test(branch),
 }))
 
 import { CommitEventHandler, type CommitEvent } from './commit-event-handler.js'


### PR DESCRIPTION
## Summary
- The `commit-event-handler.test.ts` mock for `./workflow-loader.js` only exported `getWorkflowCommitPrefixes`. After PR #445 merged into main, every CommitEventHandler test failed at branch-filter check (commit-event-handler.ts:65) because `isWorkflowReportsBranch` was missing from the mock.
- Add `isWorkflowReportsBranch` to the mock, mirroring the loader's real regex (legacy `codekin/reports` + per-run `audit/<kind>-<YYYY-MM-DD>`) so the existing branch-filter test still validates real behavior.
- Fixes CI run #1110 on `main` (test-and-lint matrix Node 20 + 22).

## Test plan
- [x] `npx vitest run server/commit-event-handler.test.ts` — 14/14 pass
- [x] `npx vitest run` — 1973/1973 pass
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)