### PR TITLE
fix(test): add isWorkflowReportsBranch to commit-event-handler mock

### DIFF
--- a/server/commit-event-handler.test.ts
+++ b/server/commit-event-handler.test.ts
@@ -42,6 +42,8 @@ vi.mock('./workflow-config.js', () => ({
 
 vi.mock('./workflow-loader.js', () => ({
   getWorkflowCommitPrefixes: () => mockState.prefixes,
+  isWorkflowReportsBranch: (branch: string) =>
+    branch === 'codekin/reports' || /^audit\/[^/]+-\d{4}-\d{2}-\d{2}$/.test(branch),
 }))
 
 import { CommitEventHandler, type CommitEvent } from './commit-event-handler.js'


### PR DESCRIPTION
## Summary
- PR #441 added a call to `isWorkflowReportsBranch(event.branch)` in `CommitEventHandler.handle` (server/commit-event-handler.ts:65) but did not update `server/commit-event-handler.test.ts`, whose `vi.mock('./workflow-loader.js', ...)` only exposed `getWorkflowCommitPrefixes`.
- Every test that exercises `handle()` then failed with: `Error: [vitest] No "isWorkflowReportsBranch" export is defined on the "./workflow-loader.js" mock.`
- This broke CI on `main` (run #1107) and on the `deps/stepflow-0.3.4` PR (#445, run #1109).
- Fix: add `isWorkflowReportsBranch` to the mock, mirroring the real implementation (legacy `codekin/reports` plus per-run `audit/<kind>-<YYYY-MM-DD>`).

## Test plan
- [x] `npm test -- server/commit-event-handler.test.ts` — 14/14 pass locally
- [x] `npm test` — 1973/1973 pass locally
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)