### PR TITLE
fix(test): unblock commit-event-handler.test.ts on main

### DIFF
--- a/server/commit-event-handler.test.ts
+++ b/server/commit-event-handler.test.ts
@@ -42,6 +42,8 @@ vi.mock('./workflow-config.js', () => ({
 
 vi.mock('./workflow-loader.js', () => ({
   getWorkflowCommitPrefixes: () => mockState.prefixes,
+  isWorkflowReportsBranch: (branch: string) =>
+    branch === 'codekin/reports' || /^audit\/[^/]+-\d{4}-\d{2}-\d{2}$/.test(branch),
 }))
 
 import { CommitEventHandler, type CommitEvent } from './commit-event-handler.js'


### PR DESCRIPTION
## Summary
Fixes 14 failing tests in `server/commit-event-handler.test.ts` that have been red on `main` since #440 landed.

## Root cause
`CommitEventHandler.handle()` calls both `getWorkflowCommitPrefixes` and `isWorkflowReportsBranch` from `./workflow-loader.js`, but the test file's `vi.mock('./workflow-loader.js', ...)` only stubbed `getWorkflowCommitPrefixes`. The mocked module returned `undefined` for the missing export, so every call to `handler.handle()` threw at the branch-filter layer — all 14 tests failed.

## Fix
Add `isWorkflowReportsBranch` to the mock with the same matcher as the real implementation in `server/workflow-loader.ts:220` (`codekin/reports` + the `audit/<kind>-YYYY-MM-DD` pattern), so the branch-filter layer exercises real semantics.

## Verification
- [x] `npm test` — 1973 tests / 79 files pass (was 1959/14 failed before the fix)
- [x] `npm run build` — passes
- [x] `npm run lint` — 0 errors

## Note on lint
The lint side of the earlier red CI was already fixed by the third commit on #445 (`fix(lint): allow _-prefixed unused vars and require() in test files`). This PR is just the missing test-mock entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)