### PR TITLE
fix(security): cron DoS, path traversal, dedup scoping, PATCH validation

### DIFF
--- a/server/commit-event-handler.test.ts
+++ b/server/commit-event-handler.test.ts
@@ -196,6 +196,31 @@ describe('CommitEventHandler', () => {
     expect(mockState.startRun).toHaveBeenCalledOnce()
   })
 
+  it('does NOT cross-suppress identical hashes across different repos', async () => {
+    // Two unrelated repos can produce the same commit hash (e.g. cherry-pick,
+    // identical empty commit). Each deserves its own commit-review run. The
+    // dedup key must be scoped per-repo.
+    mockState.config.reviewRepos = [
+      { id: 'r1', name: 'foo', repoPath: '/repos/owner/foo', enabled: true, kind: 'commit-review' },
+      { id: 'r2', name: 'bar', repoPath: '/repos/owner/bar', enabled: true, kind: 'commit-review' },
+    ]
+    const sharedHash = 'd'.repeat(40)
+
+    const r1 = await handler.handle(makeEvent({ repoPath: '/repos/owner/foo', commitHash: sharedHash }))
+    expect(r1.accepted).toBe(true)
+
+    const r2 = await handler.handle(makeEvent({ repoPath: '/repos/owner/bar', commitHash: sharedHash }))
+    expect(r2.accepted).toBe(true)
+
+    // And a *third* call against the first repo with the same hash is still
+    // suppressed (per-repo dedup is intact).
+    const r1Dup = await handler.handle(makeEvent({ repoPath: '/repos/owner/foo', commitHash: sharedHash }))
+    expect(r1Dup.accepted).toBe(false)
+    expect(r1Dup.reason).toMatch(/duplicate commit hash/i)
+
+    expect(mockState.startRun).toHaveBeenCalledTimes(2)
+  })
+
   it('accepts the same commit hash again after the dedup TTL elapses', async () => {
     enableRepoConfig()
     const event = makeEvent({ commitHash: 'c'.repeat(40) })

--- a/server/commit-event-handler.ts
+++ b/server/commit-event-handler.ts
@@ -47,13 +47,24 @@ const DEDUP_TTL_MS = 60 * 60 * 1000
 const DEDUP_CLEANUP_INTERVAL_MS = 10 * 60 * 1000
 
 export class CommitEventHandler {
-  /** commitHash → timestamp of when it was recorded. */
+  /**
+   * `${repoPath}::${commitHash}` → timestamp recorded.
+   *
+   * Keying by repoPath as well as the hash prevents a duplicate-suppression
+   * cross-talk between repos: two unrelated repos can legitimately produce
+   * the same short hash (or the same full hash, in degenerate cases) and
+   * each deserves its own commit-review run.
+   */
   private seenCommits = new Map<string, number>()
   private cleanupTimer: ReturnType<typeof setInterval>
 
   constructor() {
     // Periodically prune expired dedup entries
     this.cleanupTimer = setInterval(() => this.pruneExpired(), DEDUP_CLEANUP_INTERVAL_MS)
+  }
+
+  private dedupKey(repoPath: string, commitHash: string): string {
+    return `${repoPath}::${commitHash}`
   }
 
   /**
@@ -83,11 +94,13 @@ export class CommitEventHandler {
       return { accepted: false, reason: 'Rejected: no enabled commit-review config for this repo' }
     }
 
-    // Layer 4: Commit hash dedup
-    if (this.seenCommits.has(event.commitHash)) {
+    // Layer 4: Commit hash dedup (scoped per repoPath so identical hashes
+    // across different repos do not suppress each other).
+    const dedupKey = this.dedupKey(event.repoPath, event.commitHash)
+    if (this.seenCommits.has(dedupKey)) {
       return { accepted: false, reason: 'Rejected: duplicate commit hash' }
     }
-    this.seenCommits.set(event.commitHash, Date.now())
+    this.seenCommits.set(dedupKey, Date.now())
 
     // Layer 5: Concurrency cap — max 1 running commit-review per repo
     const engine = getWorkflowEngine()
@@ -122,8 +135,8 @@ export class CommitEventHandler {
   /** Remove dedup entries older than the TTL. */
   private pruneExpired() {
     const cutoff = Date.now() - DEDUP_TTL_MS
-    for (const [hash, ts] of this.seenCommits) {
-      if (ts < cutoff) this.seenCommits.delete(hash)
+    for (const [key, ts] of this.seenCommits) {
+      if (ts < cutoff) this.seenCommits.delete(key)
     }
   }
 

--- a/server/workflow-engine.test.ts
+++ b/server/workflow-engine.test.ts
@@ -30,7 +30,7 @@ vi.mock('fs', async (importOriginal) => {
   }
 })
 
-import { WorkflowEngine, WorkflowSkipped, SessionGoneError, initWorkflowEngine, getWorkflowEngine, shutdownWorkflowEngine } from './workflow-engine.js'
+import { WorkflowEngine, WorkflowSkipped, SessionGoneError, initWorkflowEngine, getWorkflowEngine, shutdownWorkflowEngine, cronMatchesDate } from './workflow-engine.js'
 import type { StepHandler } from './workflow-engine.js'
 
 describe('WorkflowEngine', () => {
@@ -807,5 +807,30 @@ describe('WorkflowSkipped', () => {
     expect(err.name).toBe('WorkflowSkipped')
     expect(err.message).toBe('no changes')
     expect(err).toBeInstanceOf(Error)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// cronMatchesDate — defensive parseCronField guard against step <= 0
+// ---------------------------------------------------------------------------
+describe('cronMatchesDate', () => {
+  it('returns true for a matching minute on a plain expression', () => {
+    // 2024-01-15 09:30:00 UTC — 09:30 on a Monday
+    const d = new Date('2024-01-15T09:30:00Z')
+    // Build the expression in local time so the test is timezone-stable
+    expect(cronMatchesDate(`${d.getMinutes()} ${d.getHours()} * * *`, d)).toBe(true)
+  })
+
+  it('returns false for a malformed step value of 0 (defense in depth)', () => {
+    // parseCronField now throws on step <= 0; cronMatchesDate must catch and
+    // return false rather than propagate or hang the scheduler.
+    expect(cronMatchesDate('*/0 * * * *', new Date())).toBe(false)
+    expect(cronMatchesDate('* */0 * * *', new Date())).toBe(false)
+    expect(cronMatchesDate('0-30/0 * * * *', new Date())).toBe(false)
+  })
+
+  it('returns false for the wrong number of fields', () => {
+    expect(cronMatchesDate('* * * *', new Date())).toBe(false)
+    expect(cronMatchesDate('* * * * * *', new Date())).toBe(false)
   })
 })

--- a/server/workflow-engine.ts
+++ b/server/workflow-engine.ts
@@ -211,6 +211,12 @@ function parseCronField(field: string, min: number, max: number): number[] {
   for (const part of field.split(',')) {
     const stepMatch = part.match(/^(.+)\/(\d+)$/)
     const step = stepMatch ? parseInt(stepMatch[2], 10) : 1
+    // Defensive guard — `step <= 0` would make the loops below never advance
+    // (or run backwards), pinning the scheduler. Any caller that reaches this
+    // branch with a zero/negative step has bypassed isValidCron, so refuse loudly.
+    if (!Number.isFinite(step) || step <= 0) {
+      throw new Error(`Invalid cron step value: ${stepMatch?.[2]} (must be > 0)`)
+    }
     const range = stepMatch ? stepMatch[1] : part
 
     if (range === '*') {
@@ -225,24 +231,30 @@ function parseCronField(field: string, min: number, max: number): number[] {
   return values
 }
 
-function cronMatchesDate(expression: string, date: Date): boolean {
+export function cronMatchesDate(expression: string, date: Date): boolean {
   const parts = expression.trim().split(/\s+/)
   if (parts.length !== 5) return false
 
-  const [minF, hourF, domF, monF, dowF] = parts
-  const minute = parseCronField(minF, 0, 59)
-  const hour = parseCronField(hourF, 0, 23)
-  const dom = parseCronField(domF, 1, 31)
-  const month = parseCronField(monF, 1, 12)
-  const dow = parseCronField(dowF, 0, 6)
+  try {
+    const [minF, hourF, domF, monF, dowF] = parts
+    const minute = parseCronField(minF, 0, 59)
+    const hour = parseCronField(hourF, 0, 23)
+    const dom = parseCronField(domF, 1, 31)
+    const month = parseCronField(monF, 1, 12)
+    const dow = parseCronField(dowF, 0, 6)
 
-  return (
-    minute.includes(date.getMinutes()) &&
-    hour.includes(date.getHours()) &&
-    dom.includes(date.getDate()) &&
-    month.includes(date.getMonth() + 1) &&
-    dow.includes(date.getDay())
-  )
+    return (
+      minute.includes(date.getMinutes()) &&
+      hour.includes(date.getHours()) &&
+      dom.includes(date.getDate()) &&
+      month.includes(date.getMonth() + 1) &&
+      dow.includes(date.getDay())
+    )
+  } catch {
+    // Malformed expression (e.g. step 0). Treat as never-matching so a bad
+    // legacy schedule cannot pin the scheduler in a tight loop.
+    return false
+  }
 }
 
 /** Compute the next matching minute for a cron expression after `after`. */

--- a/server/workflow-loader.test.ts
+++ b/server/workflow-loader.test.ts
@@ -238,6 +238,137 @@ Prompt text.
 
       expect(engine.registerWorkflow).toHaveBeenCalledTimes(1)
     })
+
+    // ----------------------------------------------------------------
+    // Path traversal — outputDir / filenameSuffix coming from untrusted
+    // repo workflow MD frontmatter must not be allowed to escape repoPath
+    // ----------------------------------------------------------------
+
+    it('rejects an MD def with an absolute outputDir', () => {
+      const badMd = `---
+kind: bad.daily
+name: Bad
+sessionPrefix: bad
+outputDir: /etc
+filenameSuffix: _bad.md
+commitMessage: chore: bad
+---
+Prompt.
+`
+      mockReaddirSync.mockReturnValue(['bad.md'])
+      mockReadFileSync.mockReturnValue(badMd)
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const engine = fakeEngine()
+      loadMdWorkflows(engine, fakeSessionManager())
+
+      expect(engine.registerWorkflow).not.toHaveBeenCalled()
+      expect(errSpy).toHaveBeenCalled()
+      errSpy.mockRestore()
+    })
+
+    it('rejects an MD def with ".." in outputDir', () => {
+      const badMd = `---
+kind: bad.daily
+name: Bad
+sessionPrefix: bad
+outputDir: ../../etc
+filenameSuffix: _bad.md
+commitMessage: chore: bad
+---
+Prompt.
+`
+      mockReaddirSync.mockReturnValue(['bad.md'])
+      mockReadFileSync.mockReturnValue(badMd)
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const engine = fakeEngine()
+      loadMdWorkflows(engine, fakeSessionManager())
+
+      expect(engine.registerWorkflow).not.toHaveBeenCalled()
+      expect(errSpy).toHaveBeenCalled()
+      errSpy.mockRestore()
+    })
+
+    it('rejects an MD def with ".." nested deeper in outputDir', () => {
+      const badMd = `---
+kind: bad.daily
+name: Bad
+sessionPrefix: bad
+outputDir: .codekin/../../../etc
+filenameSuffix: _bad.md
+commitMessage: chore: bad
+---
+Prompt.
+`
+      mockReaddirSync.mockReturnValue(['bad.md'])
+      mockReadFileSync.mockReturnValue(badMd)
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const engine = fakeEngine()
+      loadMdWorkflows(engine, fakeSessionManager())
+
+      expect(engine.registerWorkflow).not.toHaveBeenCalled()
+      expect(errSpy).toHaveBeenCalled()
+      errSpy.mockRestore()
+    })
+
+    it('rejects an MD def with traversal in filenameSuffix', () => {
+      const badMd = `---
+kind: bad.daily
+name: Bad
+sessionPrefix: bad
+outputDir: .codekin/reports
+filenameSuffix: ../../etc/passwd
+commitMessage: chore: bad
+---
+Prompt.
+`
+      mockReaddirSync.mockReturnValue(['bad.md'])
+      mockReadFileSync.mockReturnValue(badMd)
+      const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+      const engine = fakeEngine()
+      loadMdWorkflows(engine, fakeSessionManager())
+
+      expect(engine.registerWorkflow).not.toHaveBeenCalled()
+      expect(errSpy).toHaveBeenCalled()
+      errSpy.mockRestore()
+    })
+
+    it('rejects a repo workflow with absolute outputDir at registration', () => {
+      const repoPath = '/tmp/traversal-repo'
+      const repoDir = join(repoPath, '.codekin', 'workflows')
+      const badMd = `---
+kind: traversal.daily
+name: Traversal
+sessionPrefix: traversal
+outputDir: /etc
+filenameSuffix: _x.md
+commitMessage: chore: x
+---
+Prompt.
+`
+      mockExistsSync.mockImplementation((p: string) => String(p) === repoDir)
+      mockReaddirSync.mockImplementation((p: string) =>
+        String(p) === repoDir ? ['traversal.daily.md'] : [],
+      )
+      mockReadFileSync.mockReturnValue(badMd)
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const mockEngine = {
+        registerWorkflow: vi.fn(),
+        hasWorkflow: vi.fn(() => false),
+      } as any
+
+      ensureRepoWorkflowsRegistered(mockEngine, {} as any, repoPath)
+
+      expect(mockEngine.registerWorkflow).not.toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalled()
+
+      warnSpy.mockRestore()
+    })
   })
 
   describe('registered workflow steps', () => {
@@ -821,6 +952,33 @@ This is the repo-specific override prompt.
         expect(result.sessionId).toBe('session-1')
         expect(mockWriteFileSync).toHaveBeenCalled()
         expect(mockExecFileSync).toHaveBeenCalled()
+      })
+
+      it('refuses to write outside repoPath when realpath resolves to elsewhere (symlink attack)', async () => {
+        // Simulate a symlinked outputDir whose realpath lands outside the
+        // repo. The save_report runtime check must reject the write rather
+        // than letting it through.
+        mockRealpathSync.mockImplementation((p: string) => {
+          if (String(p) === '/tmp/repo') return '/tmp/repo'
+          if (String(p).includes('.codekin/reports/test')) return '/etc/evil'
+          return p
+        })
+        mockExecFileSync.mockReturnValue(Buffer.from('main\n'))
+
+        const handler = registeredDef.steps[3].handler
+        await expect(handler(
+          {
+            repoPath: '/tmp/repo',
+            repoName: 'my-repo',
+            reportText: 'pwn',
+            sessionId: 's1',
+            branch: 'main',
+          },
+          { runId: 'r-traverse', run: {}, abortSignal: new AbortController().signal }
+        )).rejects.toThrow(/Refusing to write/)
+
+        // Reset for subsequent tests
+        mockRealpathSync.mockImplementation((p: string) => p)
       })
 
       it('creates output directory if it does not exist', async () => {

--- a/server/workflow-loader.ts
+++ b/server/workflow-loader.ts
@@ -32,7 +32,7 @@
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, realpathSync, writeFileSync } from 'fs'
 import { execFileSync } from 'child_process'
-import { dirname, join, sep } from 'path'
+import { dirname, isAbsolute, join, resolve, sep } from 'path'
 import { REPOS_ROOT } from './config.js'
 import { fileURLToPath } from 'url'
 import type { WorkflowEngine, WorkflowRun } from './workflow-engine.js'
@@ -65,7 +65,27 @@ export interface WorkflowDef {
 // MD parser
 // ---------------------------------------------------------------------------
 
-/** Parse a workflow MD file into a WorkflowDef. Throws if required fields are missing. */
+/**
+ * Validate a relative path that came from untrusted MD frontmatter.
+ *
+ * `outputDir` and `filenameSuffix` are joined with `repoPath` and written to
+ * disk by the save_report step. A repo workflow author who set
+ * `outputDir: /etc` or `outputDir: ../../foo` could otherwise smuggle the
+ * write outside the repo. We reject absolute paths and any segment equal to
+ * `..`; the runtime check in save_report enforces the boundary defensively.
+ */
+function assertSafeRelativePath(value: string, field: string, sourcePath: string): void {
+  if (isAbsolute(value)) {
+    throw new Error(`Invalid ${field} in ${sourcePath}: absolute paths are not allowed`)
+  }
+  // Normalize backslashes so a Windows-style ..\\ is caught the same as ../
+  const segments = value.split(/[/\\]/)
+  if (segments.some(s => s === '..')) {
+    throw new Error(`Invalid ${field} in ${sourcePath}: path traversal segments ('..') are not allowed`)
+  }
+}
+
+/** Parse a workflow MD file into a WorkflowDef. Throws if required fields are missing or unsafe. */
 function parseMdWorkflow(content: string, sourcePath: string): WorkflowDef {
   const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/m)
   if (!fmMatch) throw new Error(`No frontmatter found in ${sourcePath}`)
@@ -84,6 +104,12 @@ function parseMdWorkflow(content: string, sourcePath: string): WorkflowDef {
   for (const key of required) {
     if (!meta[key]) throw new Error(`Missing frontmatter field "${key}" in ${sourcePath}`)
   }
+
+  // Reject path-traversal in any frontmatter field that is later joined with
+  // repoPath at save time. Failing here prevents an unsafe def from being
+  // registered at all.
+  assertSafeRelativePath(meta.outputDir, 'outputDir', sourcePath)
+  assertSafeRelativePath(meta.filenameSuffix, 'filenameSuffix', sourcePath)
 
   return {
     kind: meta.kind,
@@ -389,6 +415,31 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
 
           const filename = `${dateStr}${def.filenameSuffix}`
           const filePath = join(reportsDir, filename)
+
+          // Defense in depth — even though parseMdWorkflow rejects unsafe
+          // outputDir/filenameSuffix at load, re-verify the resolved write
+          // target is under the repo. realpath the parent so a symlinked
+          // outputDir cannot escape; the file itself does not exist yet.
+          const repoRealRoot = existsSync(repoPath) ? realpathSync(repoPath) : resolve(repoPath)
+          const reportsRealRoot = existsSync(reportsDir) ? realpathSync(reportsDir) : resolve(reportsDir)
+          if (
+            !reportsRealRoot.startsWith(repoRealRoot + sep) &&
+            reportsRealRoot !== repoRealRoot
+          ) {
+            throw new Error(
+              `Refusing to write report outside repo: ${reportsRealRoot} is not under ${repoRealRoot}`,
+            )
+          }
+          const resolvedFilePath = resolve(reportsRealRoot, filename)
+          if (
+            !resolvedFilePath.startsWith(reportsRealRoot + sep) &&
+            resolvedFilePath !== reportsRealRoot
+          ) {
+            throw new Error(
+              `Refusing to write report outside outputDir: ${resolvedFilePath} is not under ${reportsRealRoot}`,
+            )
+          }
+
           writeFileSync(filePath, markdown, 'utf-8')
 
           console.log(`[workflow:${def.kind}] Saved report to ${filePath}`)

--- a/server/workflow-routes.test.ts
+++ b/server/workflow-routes.test.ts
@@ -582,6 +582,57 @@ describe('workflow routes', () => {
       const body = await res.json() as { error: string }
       expect(body.error).toMatch(/Invalid repoPath/)
     })
+
+    it('returns 400 for a malformed cron expression', async () => {
+      const res = await fetch(`${harness.baseUrl}/config/repos`, {
+        method: 'POST',
+        headers: authHeader(),
+        body: JSON.stringify({
+          id: 'r1',
+          name: 'My Repo',
+          repoPath: '/fake/path',
+          cronExpression: '*/0 * * * *',
+        }),
+      })
+      expect(res.status).toBe(400)
+      const body = await res.json() as { error: string }
+      expect(body.error).toBe('Invalid cron expression')
+      expect(mocks.addReviewRepo).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 for non-cron / non-event cronExpression', async () => {
+      const res = await fetch(`${harness.baseUrl}/config/repos`, {
+        method: 'POST',
+        headers: authHeader(),
+        body: JSON.stringify({
+          id: 'r1',
+          name: 'My Repo',
+          repoPath: '/fake/path',
+          cronExpression: 'not a cron',
+        }),
+      })
+      expect(res.status).toBe(400)
+      const body = await res.json() as { error: string }
+      expect(body.error).toBe('Invalid cron expression')
+    })
+
+    it('accepts the special cronExpression value "event"', async () => {
+      const res = await fetch(`${harness.baseUrl}/config/repos`, {
+        method: 'POST',
+        headers: authHeader(),
+        body: JSON.stringify({
+          id: 'r1',
+          name: 'My Repo',
+          repoPath: '/fake/path',
+          cronExpression: 'event',
+          kind: 'commit-review',
+        }),
+      })
+      expect(res.status).toBe(200)
+      expect(mocks.addReviewRepo).toHaveBeenCalledWith(
+        expect.objectContaining({ cronExpression: 'event' }),
+      )
+    })
   })
 
   describe('PATCH /config/repos/:id', () => {
@@ -618,6 +669,56 @@ describe('workflow routes', () => {
         body: JSON.stringify({ name: 'nope' }),
       })
       expect(res.status).toBe(404)
+    })
+
+    it('returns 400 for a malformed cron expression in patch', async () => {
+      const res = await fetch(`${harness.baseUrl}/config/repos/r1`, {
+        method: 'PATCH',
+        headers: authHeader(),
+        body: JSON.stringify({ cronExpression: '*/0 * * * *' }),
+      })
+      expect(res.status).toBe(400)
+      const body = await res.json() as { error: string }
+      expect(body.error).toBe('Invalid cron expression')
+      expect(mocks.updateReviewRepo).not.toHaveBeenCalled()
+    })
+
+    it('accepts cronExpression="event" in patch', async () => {
+      mocks.workflowConfig.reviewRepos = [{
+        id: 'r1', name: 'X', repoPath: '/p', cronExpression: '0 6 * * *', enabled: true,
+      }]
+      const res = await fetch(`${harness.baseUrl}/config/repos/r1`, {
+        method: 'PATCH',
+        headers: authHeader(),
+        body: JSON.stringify({ cronExpression: 'event' }),
+      })
+      expect(res.status).toBe(200)
+      expect(mocks.updateReviewRepo).toHaveBeenCalledWith('r1', { cronExpression: 'event' })
+    })
+
+    it('returns 400 for an invalid provider in patch', async () => {
+      const res = await fetch(`${harness.baseUrl}/config/repos/r1`, {
+        method: 'PATCH',
+        headers: authHeader(),
+        body: JSON.stringify({ provider: 'bogus' }),
+      })
+      expect(res.status).toBe(400)
+      const body = await res.json() as { error: string }
+      expect(body.error).toMatch(/Invalid provider/)
+      expect(mocks.updateReviewRepo).not.toHaveBeenCalled()
+    })
+
+    it('accepts a valid provider in patch', async () => {
+      mocks.workflowConfig.reviewRepos = [{
+        id: 'r1', name: 'X', repoPath: '/p', cronExpression: '0 6 * * *', enabled: true,
+      }]
+      const res = await fetch(`${harness.baseUrl}/config/repos/r1`, {
+        method: 'PATCH',
+        headers: authHeader(),
+        body: JSON.stringify({ provider: 'opencode' }),
+      })
+      expect(res.status).toBe(200)
+      expect(mocks.updateReviewRepo).toHaveBeenCalledWith('r1', { provider: 'opencode' })
     })
   })
 

--- a/server/workflow-routes.ts
+++ b/server/workflow-routes.ts
@@ -431,6 +431,9 @@ export function createWorkflowRouter(
     if (!id || !name || !repoPath || !cronExpression) {
       return res.status(400).json({ error: 'Missing required fields: id, name, repoPath, cronExpression' })
     }
+    if (cronExpression !== 'event' && !isValidCron(cronExpression)) {
+      return res.status(400).json({ error: 'Invalid cron expression' })
+    }
     if (provider && !VALID_PROVIDERS.has(provider)) {
       return res.status(400).json({ error: `Invalid provider: ${provider}` })
     }
@@ -489,6 +492,16 @@ export function createWorkflowRouter(
   router.patch('/config/repos/:id', (req: Request<{ id: string }, unknown, Partial<ReviewRepoConfig>>, res) => {
     if (req.body.repoPath !== undefined && !resolveRepoPathInRoot(req.body.repoPath)) {
       return res.status(400).json({ error: 'Invalid repoPath: must be an existing directory under the configured repos root' })
+    }
+    if (
+      req.body.cronExpression !== undefined &&
+      req.body.cronExpression !== 'event' &&
+      !isValidCron(req.body.cronExpression)
+    ) {
+      return res.status(400).json({ error: 'Invalid cron expression' })
+    }
+    if (req.body.provider !== undefined && !VALID_PROVIDERS.has(req.body.provider)) {
+      return res.status(400).json({ error: `Invalid provider: ${req.body.provider}` })
     }
     try {
       const config = updateReviewRepo(req.params.id, req.body)


### PR DESCRIPTION
## Summary

Address four findings from the 2026-04-28 code review.

### 1. CRITICAL — Cron validation gap (DoS)
`POST /api/workflows/config/repos` and `PATCH /api/workflows/config/repos/:id` accepted any `cronExpression` without validation. Combined with `parseCronField()` permitting step `0`, a malformed schedule (e.g. `*/0 * * * *`) could pin the scheduler in a tight loop.

- Both write paths now require either the special value `event` or a valid 5-field cron (reusing `isValidCron`).
- `parseCronField()` rejects `step <= 0` defensively; `cronMatchesDate()` catches and returns `false` so a bad legacy schedule already in the DB cannot crash the scheduler — `nextCronMatch()` falls through to its 24h fallback instead.

### 2. CRITICAL — Path traversal in repo workflow MD frontmatter
`outputDir` and `filenameSuffix` from `{repoPath}/.codekin/workflows/*.md` are joined with `repoPath` and written to disk by `save_report`. A repo author who set `outputDir: /etc` or `outputDir: ../..` could smuggle the write outside the repo.

- Reject absolute paths and any `..` segment at parse time (`assertSafeRelativePath`), so unsafe defs never register at load or via `ensureRepoWorkflowsRegistered`.
- Defensively verify the realpath of the resolved write target stays under `repoPath` at runtime in `save_report`, guarding against symlink races.

### 3. WARNING — Commit dedup key cross-talk
`CommitEventHandler.seenCommits` was keyed on `commitHash` alone, so two repos producing the same hash suppressed each other. Now keyed by `${repoPath}::${commitHash}`.

### 4. WARNING — Provider validation missing on PATCH
The create route validates `provider` against `VALID_PROVIDERS`. The patch route now reuses the same check (and adds the cron validation noted above).

## Tests added

- `isValidCron('*/0 * * * *')` already covered; new tests verify the POST and PATCH routes return 400 on `*/0 * * * *` and other malformed expressions, and accept `cronExpression: "event"`.
- `cronMatchesDate` returns `false` for `*/0` step expressions (defense in depth).
- `parseMdWorkflow` rejects `outputDir: /etc`, `outputDir: ../../etc`, deeper `..` segments, and traversal in `filenameSuffix`. `ensureRepoWorkflowsRegistered` skips unsafe repo defs with a warning instead of registering them.
- `save_report` runtime check rejects writes whose realpath escapes `repoPath` (symlink scenario).
- Commit dedup test: same hash on different repos both accepted; same hash on the same repo still suppressed.
- PATCH route returns 400 for invalid provider, 200 for valid provider.

## Test plan

- [x] `npm test` — 1990/1990 passing
- [x] `npm run build` — typecheck + production build clean
- [x] `npm run lint` — 0 errors (warnings unchanged from baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)