### PR TITLE
fix(security): canonicalize clone destination to prevent symlink escape

### DIFF
--- a/server/upload-routes.test.ts
+++ b/server/upload-routes.test.ts
@@ -6,6 +6,9 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import express from 'express'
 import type { AddressInfo } from 'net'
 import type { Server } from 'http'
+import { mkdtempSync, symlinkSync, rmSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
 
 // ---------------------------------------------------------------------------
 // Hoisted mock state — lets tests toggle realpathSync's behavior.
@@ -101,5 +104,98 @@ describe('POST /api/clone', () => {
     expect(res.status).toBe(500)
     const body = await res.json() as { error: string }
     expect(body.error).toBe('invalid_repos_root')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/clone — symlink escape prevention (C1)
+// ---------------------------------------------------------------------------
+
+describe('POST /api/clone — symlink escape (C1)', () => {
+  let tmpRoot: string
+  let server: Server
+  let baseUrl: string
+
+  beforeEach(async () => {
+    mocks.realpathThrows = false
+    tmpRoot = mkdtempSync(join(tmpdir(), 'codekin-symtest-'))
+    const app = express()
+    app.use(express.json())
+    app.use(createUploadRouter(
+      verifyToken,
+      extractToken as unknown as (req: express.Request) => string | undefined,
+      () => tmpRoot,
+    ))
+    server = app.listen(0)
+    await new Promise<void>(res => server.once('listening', () => res()))
+    const port = (server.address() as AddressInfo).port
+    baseUrl = `http://127.0.0.1:${port}`
+  })
+
+  afterEach(async () => {
+    await new Promise<void>(res => server.close(() => res()))
+    rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('rejects clone when owner dir is a symlink pointing outside REPOS_ROOT (C1)', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'codekin-evil-'))
+    try {
+      symlinkSync(outside, join(tmpRoot, 'evil-owner'))
+      const res = await fetch(`${baseUrl}/api/clone`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ owner: 'evil-owner', name: 'myrepo' }),
+      })
+      expect(res.status).toBe(400)
+      const body = await res.json() as { error: string }
+      expect(body.error).toBe('Path escapes allowed root')
+    } finally {
+      rmSync(outside, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects clone when REPOS_ROOT is symlinked and owner dir escapes (C1 grandparent)', async () => {
+    // realRoot is the actual filesystem root; symRoot is a symlink to it.
+    // Inside realRoot, the owner dir is itself a symlink pointing outside.
+    const realRoot = mkdtempSync(join(tmpdir(), 'codekin-real-'))
+    const outside = mkdtempSync(join(tmpdir(), 'codekin-evil2-'))
+    const symRootPath = join(tmpdir(), `codekin-symroot-${Date.now()}`)
+    symlinkSync(realRoot, symRootPath)
+    symlinkSync(outside, join(realRoot, 'linked-owner'))
+
+    const app2 = express()
+    app2.use(express.json())
+    app2.use(createUploadRouter(
+      verifyToken,
+      extractToken as unknown as (req: express.Request) => string | undefined,
+      () => symRootPath,
+    ))
+    const server2 = app2.listen(0)
+    await new Promise<void>(res => server2.once('listening', () => res()))
+    const port2 = (server2.address() as AddressInfo).port
+
+    try {
+      const res = await fetch(`http://127.0.0.1:${port2}/api/clone`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${AUTH_TOKEN}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ owner: 'linked-owner', name: 'myrepo' }),
+      })
+      expect(res.status).toBe(400)
+    } finally {
+      await new Promise<void>(res => server2.close(() => res()))
+      rmSync(realRoot, { recursive: true, force: true })
+      rmSync(outside, { recursive: true, force: true })
+      rmSync(symRootPath, { force: true })
+    }
+  })
+
+  it('allows clone when owner dir does not exist (normal path, regression)', async () => {
+    const res = await fetch(`${baseUrl}/api/clone`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${AUTH_TOKEN}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ owner: 'valid-owner', name: 'myrepo' }),
+    })
+    // Boundary check passes; clone itself may fail (no gh credentials) — not 400
+    expect(res.status).not.toBe(400)
   })
 })

--- a/server/upload-routes.ts
+++ b/server/upload-routes.ts
@@ -8,8 +8,8 @@
 import { Router } from 'express'
 import type { Request } from 'express'
 import multer from 'multer'
-import { mkdirSync, existsSync, readFileSync, readdirSync, realpathSync } from 'fs'
-import { join, extname, resolve, sep } from 'path'
+import { mkdirSync, existsSync, lstatSync, readFileSync, readdirSync, realpathSync } from 'fs'
+import { join, extname, sep } from 'path'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { homedir } from 'os'
@@ -331,9 +331,34 @@ export function createUploadRouter(
     }
     const ownerDir = join(reposRoot, owner)
     const dest = localRepoPath(reposRoot, owner, name)
-    // Boundary check: ensure resolved dest stays within REPOS_ROOT
-    // Use realpathSync on reposRoot to prevent symlink bypass
-    const resolvedDest = resolve(dest)
+    // C1: Prevent symlink-based path escape. lstat the owner dir to reject
+    // symlinks; then canonicalize with realpathSync before the boundary check.
+    // Lexical resolve() does not follow symlinks and cannot catch this class of escape.
+    let resolvedDest: string
+    if (existsSync(ownerDir)) {
+      let ownerStat
+      try {
+        ownerStat = lstatSync(ownerDir)
+      } catch {
+        res.status(400).json({ error: 'Path escapes allowed root' })
+        return
+      }
+      if (ownerStat.isSymbolicLink()) {
+        res.status(400).json({ error: 'Path escapes allowed root' })
+        return
+      }
+      let canonicalOwner: string
+      try {
+        canonicalOwner = realpathSync(ownerDir)
+      } catch {
+        res.status(400).json({ error: 'Path escapes allowed root' })
+        return
+      }
+      resolvedDest = join(canonicalOwner, name)
+    } else {
+      // ownerDir does not exist; reposRoot is already canonical so this is safe.
+      resolvedDest = join(reposRoot, owner, name)
+    }
     if (!resolvedDest.startsWith(reposRoot + sep) && resolvedDest !== reposRoot) {
       res.status(400).json({ error: 'Path escapes allowed root' })
       return


### PR DESCRIPTION
## Summary

Fixes the **C1 symlink-escape** finding from the 2026-04-30 codekin security review.

### Threat model

The previous boundary check used lexical `resolve(dest)` to verify that the clone destination stays within `REPOS_ROOT`. `resolve()` does not follow symlinks — it performs purely lexical path normalization. An attacker who can plant a symlink at `REPOS_ROOT/<owner>/` (e.g. via a prior write primitive or misconfigured permissions) can point that symlink to an arbitrary filesystem location outside `REPOS_ROOT`. The lexical check passes because `REPOS_ROOT/owner/name` still starts with `REPOS_ROOT/`, but the actual `git clone` write lands at the symlink target outside the root.

### Fix (`server/upload-routes.ts`)

- **lstat the owner dir** before any resolution: if it exists and `isSymbolicLink()` is true, immediately return 400. This rejects the attack at the earliest point.
- **Canonicalize with `realpathSync`**: if the owner dir exists and is not a symlink, resolve it to its canonical path and reconstruct the destination from the canonical parent. The final boundary check compares the canonical destination against the (already-canonicalized) `REPOS_ROOT`.
- If the owner dir does not yet exist, `REPOS_ROOT` is already canonical (resolved earlier), so the lexical join is safe.
- Removed unused `resolve` import from `path`.

### Tests (`server/upload-routes.test.ts`)

Three new tests in the `POST /api/clone — symlink escape (C1)` describe block:

| Test | Scenario | Expected |
|------|----------|----------|
| Symlinked owner dir escape | `REPOS_ROOT/evil-owner → /tmp/outside` | 400 |
| Symlinked grandparent (C1) | `REPOS_ROOT` is a symlink; inside, `owner` is also a symlink pointing outside | 400 |
| Normal path regression | Owner dir does not exist, valid owner/name | not 400 |

## Test plan

- [x] `npm test` — all 2006 tests pass
- [x] `npm run lint` — no new errors (pre-existing warnings only)
- [x] `npm run build` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)