### PR TITLE
fix(security): sanitize commit-event prompt input, remove duplicate report write

### DIFF
--- a/server/commit-event-handler.test.ts
+++ b/server/commit-event-handler.test.ts
@@ -46,7 +46,7 @@ vi.mock('./workflow-loader.js', () => ({
     branch === 'codekin/reports' || /^audit\/[^/]+-\d{4}-\d{2}-\d{2}$/.test(branch),
 }))
 
-import { CommitEventHandler, type CommitEvent } from './commit-event-handler.js'
+import { CommitEventHandler, sanitizeCommitField, type CommitEvent } from './commit-event-handler.js'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -81,6 +81,31 @@ function enableRepoConfig(repoPath = '/repos/owner/foo') {
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
+
+describe('sanitizeCommitField', () => {
+  it('truncates strings longer than the default maxLen (500)', () => {
+    const long = 'a'.repeat(600)
+    expect(sanitizeCommitField(long)).toHaveLength(500)
+  })
+
+  it('truncates to a custom maxLen', () => {
+    const long = 'b'.repeat(300)
+    expect(sanitizeCommitField(long, 200)).toHaveLength(200)
+  })
+
+  it('strips ASCII control characters including NUL and ESC', () => {
+    expect(sanitizeCommitField('hello\x00world')).toBe('helloworld')
+    expect(sanitizeCommitField('esc\x1b[31mcolor')).toBe('esc[31mcolor')
+    expect(sanitizeCommitField('line\nfeed')).toBe('linefeed')
+    expect(sanitizeCommitField('\x7fhidden')).toBe('hidden')
+    expect(sanitizeCommitField('\x01\x02\x1f\x7f')).toBe('')
+  })
+
+  it('leaves normal commit message text unchanged', () => {
+    const msg = 'feat: add login page (issue #123)'
+    expect(sanitizeCommitField(msg)).toBe(msg)
+  })
+})
 
 describe('CommitEventHandler', () => {
   let handler: CommitEventHandler
@@ -288,6 +313,29 @@ describe('CommitEventHandler', () => {
         provider: 'claude',
       }),
     )
+  })
+
+  it('passes sanitized commitMessage, branch, and author to engine.startRun', async () => {
+    enableRepoConfig('/repos/owner/foo')
+    // Craft inputs with control characters that should be stripped and a
+    // commitMessage that exceeds 500 chars (should be truncated).
+    const longMsg = 'feat: ' + 'x'.repeat(600)
+    const event = makeEvent({
+      repoPath: '/repos/owner/foo',
+      commitHash: 'f'.repeat(40),
+      commitMessage: longMsg,
+      branch: 'main\x1b[danger',
+      author: 'alice\x00',
+    })
+
+    const result = await handler.handle(event)
+    expect(result.accepted).toBe(true)
+
+    const startRunInput = mockState.startRun.mock.calls[0][1] as Record<string, unknown>
+    expect((startRunInput.commitMessage as string).length).toBe(500)
+    expect(startRunInput.commitMessage).not.toContain('\x1b')
+    expect(startRunInput.branch).toBe('main[danger')
+    expect(startRunInput.author).toBe('alice')
   })
 
   it('returns a failure result and reason when startRun throws', async () => {

--- a/server/commit-event-handler.ts
+++ b/server/commit-event-handler.ts
@@ -19,6 +19,19 @@ import { loadWorkflowConfig } from './workflow-config.js'
 import { getWorkflowCommitPrefixes, isWorkflowReportsBranch } from './workflow-loader.js'
 
 // ---------------------------------------------------------------------------
+// Input sanitization
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitize a commit event field before it reaches a prompt.
+ * Strips ASCII control characters (0x00–0x1f, 0x7f) and truncates to maxLen.
+ */
+export function sanitizeCommitField(s: string, maxLen = 500): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/[\x00-\x1f\x7f]/g, '').slice(0, maxLen)
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -72,15 +85,20 @@ export class CommitEventHandler {
    * Returns accepted=true if a workflow run was dispatched.
    */
   async handle(event: CommitEvent): Promise<CommitEventResult> {
+    // Sanitize user-supplied fields before any filter checks or downstream use
+    const branch = sanitizeCommitField(event.branch, 200)
+    const commitMessage = sanitizeCommitField(event.commitMessage, 500)
+    const author = sanitizeCommitField(event.author, 200)
+
     // Layer 1: Branch filter
-    if (isWorkflowReportsBranch(event.branch)) {
+    if (isWorkflowReportsBranch(branch)) {
       return { accepted: false, reason: 'Rejected: reports branch' }
     }
 
     // Layer 2: Message filter — reject if message starts with any workflow commit prefix
     const prefixes = getWorkflowCommitPrefixes()
     for (const prefix of prefixes) {
-      if (event.commitMessage.startsWith(prefix)) {
+      if (commitMessage.startsWith(prefix)) {
         return { accepted: false, reason: `Rejected: workflow commit message (${prefix})` }
       }
     }
@@ -118,6 +136,9 @@ export class CommitEventHandler {
         repoPath: event.repoPath,
         repoName: repoConfig.name,
         commitHash: event.commitHash,
+        commitMessage,
+        branch,
+        author,
         customPrompt: repoConfig.customPrompt,
         model: repoConfig.model,
         provider: repoConfig.provider,

--- a/server/workflow-loader.test.ts
+++ b/server/workflow-loader.test.ts
@@ -692,6 +692,82 @@ This is the repo-specific override prompt.
         vi.useRealTimers()
       })
 
+      it('includes XML commit context delimiters when commitMessage is in input (M2)', async () => {
+        vi.useFakeTimers()
+
+        mockExistsSync.mockImplementation((p: string) => {
+          if (String(p).includes('.codekin/workflows')) return false
+          return true
+        })
+
+        sessions.get.mockReturnValue({
+          outputHistory: [
+            { type: 'output', data: 'Commit review result' },
+            { type: 'result' },
+          ],
+        })
+
+        const handler = registeredDef.steps[2].handler
+        const promise = handler(
+          {
+            sessionId: 'session-1',
+            repoName: 'my-repo',
+            repoPath: '/tmp/repo',
+            branch: 'feat/my-branch',
+            commitMessage: 'fix: resolve the bug',
+            author: 'alice',
+          },
+          { runId: 'r1', run: { kind: 'test-review.daily' }, abortSignal: new AbortController().signal }
+        )
+
+        await vi.advanceTimersByTimeAsync(2000)
+        await promise
+
+        const sentPrompt = String(sessions.sendInput.mock.calls[0][1])
+        expect(sentPrompt).toContain('<commit-message>')
+        expect(sentPrompt).toContain('fix: resolve the bug')
+        expect(sentPrompt).toContain('</commit-message>')
+        expect(sentPrompt).toContain('<branch>feat/my-branch</branch>')
+        expect(sentPrompt).toContain('<author>alice</author>')
+        // Context block must appear before the workflow prompt
+        const contextIdx = sentPrompt.indexOf('<commit-message>')
+        const promptIdx = sentPrompt.indexOf('You are performing an automated test review')
+        expect(contextIdx).toBeLessThan(promptIdx)
+
+        vi.useRealTimers()
+      })
+
+      it('does not add commit context when commitMessage is absent', async () => {
+        vi.useFakeTimers()
+
+        mockExistsSync.mockImplementation((p: string) => {
+          if (String(p).includes('.codekin/workflows')) return false
+          return true
+        })
+
+        sessions.get.mockReturnValue({
+          outputHistory: [
+            { type: 'output', data: 'Regular review output' },
+            { type: 'result' },
+          ],
+        })
+
+        const handler = registeredDef.steps[2].handler
+        const promise = handler(
+          { sessionId: 'session-1', repoName: 'my-repo', repoPath: '/tmp/repo', branch: 'main' },
+          { runId: 'r1', run: { kind: 'test-review.daily' }, abortSignal: new AbortController().signal }
+        )
+
+        await vi.advanceTimersByTimeAsync(2000)
+        await promise
+
+        const sentPrompt = String(sessions.sendInput.mock.calls[0][1])
+        expect(sentPrompt).not.toContain('<commit-message>')
+        expect(sentPrompt).not.toContain('<author>')
+
+        vi.useRealTimers()
+      })
+
       it('appends customPrompt to the base prompt', async () => {
         vi.useFakeTimers()
 
@@ -1303,6 +1379,33 @@ This is the repo-specific override prompt.
         // The legacy branch must not appear in any git call.
         const legacyCall = gitCalls.find(args => args.includes('codekin/reports'))
         expect(legacyCall).toBeUndefined()
+      })
+
+      it('does not write the report to the main working tree (C2 regression: no untracked reports file)', async () => {
+        // Before this fix, save_report wrote twice: once to the main working
+        // tree (creating an untracked .codekin/reports/** file) and once to
+        // the temporary audit worktree. Only the worktree write should remain.
+        mockExecFileSync.mockReturnValue(Buffer.from('main\n'))
+
+        const handler = registeredDef.steps[3].handler
+        await handler(
+          {
+            repoPath: '/tmp/repo',
+            repoName: 'my-repo',
+            reportText: 'Content',
+            sessionId: 's1',
+            branch: 'main',
+          },
+          { runId: 'run-c2', run: {}, abortSignal: new AbortController().signal }
+        )
+
+        const writePaths = mockWriteFileSync.mock.calls.map(c => String(c[0]))
+        // No write must land under the main working tree
+        const mainTreeWrites = writePaths.filter(p => p.startsWith('/tmp/repo/'))
+        expect(mainTreeWrites).toHaveLength(0)
+        // Exactly one write lands in the temporary audit worktree
+        const worktreeWrites = writePaths.filter(p => p.includes('.codekin-wt-report-'))
+        expect(worktreeWrites).toHaveLength(1)
       })
 
       it('uses today\'s date in the branch name', async () => {

--- a/server/workflow-loader.ts
+++ b/server/workflow-loader.ts
@@ -350,9 +350,28 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
               ? `${basePrompt}\n\nAdditional focus areas:\n${customPrompt}`
               : basePrompt
 
+            // If the run carries sanitized commit fields, prepend them as
+            // XML-delimited context so injected text cannot escape its data
+            // context. Fields are sanitized upstream in commit-event-handler.ts.
+            const commitMessage = input.commitMessage as string | undefined
+            const commitBranch = input.branch as string | undefined
+            const commitAuthor = input.author as string | undefined
+            let commitContext = ''
+            if (commitMessage !== undefined) {
+              commitContext = [
+                '<commit-message>',
+                commitMessage,
+                '</commit-message>',
+                `<branch>${commitBranch ?? 'unknown'}</branch>`,
+                `<author>${commitAuthor ?? 'unknown'}</author>`,
+                '',
+                '',
+              ].join('\n')
+            }
+
             // Prepend the guard to suppress Claude's CLAUDE.md-driven file-write
             // behavior, which otherwise creates a duplicate report file.
-            const prompt = `${WORKFLOW_PROMPT_GUARD}\n\n${userPrompt}`
+            const prompt = `${WORKFLOW_PROMPT_GUARD}\n\n${commitContext}${userPrompt}`
 
             if (repoOverride) {
               console.log(`[workflow:${def.kind}] Using per-repo prompt override from ${repoPath}`)
@@ -409,10 +428,6 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
           ].join('\n')
 
           const reportsDir = join(repoPath, def.outputDir)
-          if (!existsSync(reportsDir)) {
-            mkdirSync(reportsDir, { recursive: true })
-          }
-
           const filename = `${dateStr}${def.filenameSuffix}`
           const filePath = join(reportsDir, filename)
 
@@ -440,9 +455,7 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
             )
           }
 
-          writeFileSync(filePath, markdown, 'utf-8')
-
-          console.log(`[workflow:${def.kind}] Saved report to ${filePath}`)
+          console.log(`[workflow:${def.kind}] Writing report to ${filePath}`)
 
           // Commit on a fresh per-run branch (audit/<kind>-<YYYY-MM-DD>) so each
           // audit gets its own PR and we never append to a stale, long-lived


### PR DESCRIPTION
## Summary

Final two items from the 2026-04-30 codekin security audit / code-review backlog. Follows PR #452, #453, and #454.

### M2 — Commit-event input sanitization

`commitMessage`, `branch`, and `author` from `POST /api/workflows/commit-event` flow into a Claude prompt. Without sanitization a crafted commit message could attempt prompt injection.

- New `sanitizeCommitField(s, maxLen)` helper strips ASCII control characters (`/[\x00-\x1f\x7f]/g`) and truncates: 500 for commitMessage, 200 for branch/author.
- Sanitized values are passed through `engine.startRun` and surface in the workflow prompt wrapped in distinct XML-style delimiters (`<commit-message>...</commit-message>`, `<branch>...</branch>`, `<author>...</author>`) so injected text cannot escape its data context.
- Tests cover truncation (default 500 + custom 200), control-char stripping (NUL, ESC, LF, DEL, range), normal-text passthrough, end-to-end sanitization through `handle()`, and XML-delimiter presence in the composed prompt.

### C2 — Duplicate report write

`save_report` was writing the report twice — first to the main working tree at `repoPath/.codekin/reports/...` (creating an untracked file in the live checkout), then again in the temporary `.codekin-wt-report-*` worktree before commit/push.

- Removed the main-tree write. Only the audit worktree write remains.
- Regression test asserts no write under the main repo path and exactly one write to the temp worktree.

This explains the two stale untracked report files I noticed in `/srv/repos/codekin` after this morning's deploy — those were artifacts of the bug.

## Test plan

- [x] `npm test` — 80 files / 2019 tests pass (11 new tests)
- [x] Targeted run on the two changed files: 102/102
- [ ] CI

Note: codekin uses \`gh pr merge --admin\` for behind-main PRs.