### PR TITLE
feat(orchestrator): notify parent session immediately when a child terminates

### DIFF
--- a/server/orchestrator-children.test.ts
+++ b/server/orchestrator-children.test.ts
@@ -523,5 +523,72 @@ describe('OrchestratorChildManager', () => {
       // The stamp must not be reset by the second call.
       expect(child.terminalNotifiedAt).toBe(stamp)
     })
+
+    it('does NOT stamp terminalNotifiedAt when delivery fails (returns false)', async () => {
+      // Notify reports the parent is unreachable on the first attempt.
+      notify = vi.fn(() => false)
+      manager = new OrchestratorChildManager(sessions, { notify })
+
+      sessions.get = vi.fn(() => ({
+        claudeProcess: { isAlive: vi.fn(() => false), stop: vi.fn() },
+        outputHistory: [{ type: 'output', data: 'Done! Created PR #99 and pushed.' }],
+        pendingToolApprovals: new Map(),
+        pendingControlRequests: new Map(),
+        worktreePath: '/repos/myproject-wt-abc12345',
+      }))
+
+      const child = await manager.spawn(makeRequest({
+        parentSessionId: 'parent-orchestrator-id',
+      }))
+
+      for (const listener of sessions._resultListeners) {
+        listener(child.id, false)
+      }
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('completed')
+      })
+
+      expect(notify).toHaveBeenCalledTimes(1)
+      // Failed delivery must leave the stamp null so a future invocation can retry.
+      expect(child.terminalNotifiedAt).toBeNull()
+
+      // Second invocation succeeds — stamp is set, future calls become no-ops.
+      notify.mockReturnValue(true)
+      ;(manager as any).notifyTerminal(child)
+      expect(notify).toHaveBeenCalledTimes(2)
+      expect(child.terminalNotifiedAt).toBeTruthy()
+
+      ;(manager as any).notifyTerminal(child)
+      expect(notify).toHaveBeenCalledTimes(2)
+    })
+
+    it('does NOT stamp terminalNotifiedAt when notify throws', async () => {
+      notify = vi.fn(() => { throw new Error('boom') })
+      manager = new OrchestratorChildManager(sessions, { notify })
+
+      sessions.get = vi.fn(() => ({
+        claudeProcess: { isAlive: vi.fn(() => false), stop: vi.fn() },
+        outputHistory: [{ type: 'output', data: 'Done! Created PR #99 and pushed.' }],
+        pendingToolApprovals: new Map(),
+        pendingControlRequests: new Map(),
+        worktreePath: '/repos/myproject-wt-abc12345',
+      }))
+
+      const child = await manager.spawn(makeRequest({
+        parentSessionId: 'parent-orchestrator-id',
+      }))
+
+      for (const listener of sessions._resultListeners) {
+        listener(child.id, false)
+      }
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('completed')
+      })
+
+      expect(notify).toHaveBeenCalledTimes(1)
+      expect(child.terminalNotifiedAt).toBeNull()
+    })
   })
 })

--- a/server/orchestrator-children.test.ts
+++ b/server/orchestrator-children.test.ts
@@ -42,6 +42,7 @@ function makeMockSessions(worktreeSucceeds = true) {
       outputHistory: [],
       pendingToolApprovals: new Map(),
       pendingControlRequests: new Map(),
+      worktreePath: '/repos/myproject-wt-child123',
     })),
     onSessionResult: vi.fn((cb: any) => {
       resultListeners.push(cb)
@@ -382,6 +383,145 @@ describe('OrchestratorChildManager', () => {
 
       const prompt = sessions._sentInputs[0]
       expect(prompt).toContain('Do NOT push')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Parent-session terminal notifications
+  // -------------------------------------------------------------------------
+
+  describe('parent terminal notifications', () => {
+    let notify: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      sessions = makeMockSessions()
+      notify = vi.fn(() => true)
+      manager = new OrchestratorChildManager(sessions, { notify })
+    })
+
+    it('fires exactly one notification when a child times out', async () => {
+      vi.useFakeTimers()
+      try {
+        sessions.get = vi.fn(() => ({
+          claudeProcess: { isAlive: vi.fn(() => true), stop: vi.fn() },
+          outputHistory: [],
+          pendingToolApprovals: new Map(),
+          pendingControlRequests: new Map(),
+          worktreePath: '/repos/myproject-wt-abc12345',
+        }))
+
+        const child = await manager.spawn(makeRequest({
+          parentSessionId: 'parent-orchestrator-id',
+          timeoutMs: 5000,
+        }))
+
+        vi.advanceTimersByTime(5000)
+
+        await vi.waitFor(() => {
+          expect(child.status).toBe('timed_out')
+        })
+
+        expect(notify).toHaveBeenCalledTimes(1)
+        const args = notify.mock.calls[0][0]
+        expect(args.parentSessionId).toBe('parent-orchestrator-id')
+        expect(args.label).toBe('Child Session Stopped')
+        expect(args.title).toContain(child.id)
+        expect(args.body).toContain('Status: timed_out')
+        expect(args.body).toContain(`Branch: ${child.request.branchName}`)
+        expect(args.body).toContain(`Repo: ${child.request.repo}`)
+        expect(args.body).toContain('Inspect worktree at /repos/myproject-wt-abc12345')
+        expect(child.terminalNotifiedAt).toBeTruthy()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('fires a notification when a child completes', async () => {
+      sessions.get = vi.fn(() => ({
+        claudeProcess: { isAlive: vi.fn(() => false), stop: vi.fn() },
+        outputHistory: [{ type: 'output', data: 'Done! Created PR #99 and pushed.' }],
+        pendingToolApprovals: new Map(),
+        pendingControlRequests: new Map(),
+        worktreePath: '/repos/myproject-wt-abc12345',
+      }))
+
+      const child = await manager.spawn(makeRequest({
+        parentSessionId: 'parent-orchestrator-id',
+      }))
+
+      for (const listener of sessions._resultListeners) {
+        listener(child.id, false)
+      }
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('completed')
+      })
+
+      expect(notify).toHaveBeenCalledTimes(1)
+      const args = notify.mock.calls[0][0]
+      expect(args.parentSessionId).toBe('parent-orchestrator-id')
+      expect(args.label).toBe('Child Session Stopped')
+      expect(args.body).toContain('Status: completed')
+      expect(args.body).toContain(`Branch: ${child.request.branchName}`)
+      expect(args.body).toContain(`Repo: ${child.request.repo}`)
+      // Hint for completed PR-policy children references PR follow-through.
+      expect(args.body).toMatch(/PR/)
+    })
+
+    it('does NOT fire a notification when the child has no parentSessionId', async () => {
+      sessions.get = vi.fn(() => ({
+        claudeProcess: { isAlive: vi.fn(() => false), stop: vi.fn() },
+        outputHistory: [{ type: 'output', data: 'Done! Created PR #99 with all changes.' }],
+        pendingToolApprovals: new Map(),
+        pendingControlRequests: new Map(),
+        worktreePath: '/repos/myproject-wt-abc12345',
+      }))
+
+      const child = await manager.spawn(makeRequest()) // no parentSessionId
+
+      for (const listener of sessions._resultListeners) {
+        listener(child.id, false)
+      }
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('completed')
+      })
+
+      expect(notify).not.toHaveBeenCalled()
+      expect(child.terminalNotifiedAt).toBeNull()
+    })
+
+    it('is idempotent — repeated terminal triggers fire the notification once', async () => {
+      sessions.get = vi.fn(() => ({
+        claudeProcess: { isAlive: vi.fn(() => false), stop: vi.fn() },
+        outputHistory: [{ type: 'output', data: 'Done! Created PR #99 and pushed.' }],
+        pendingToolApprovals: new Map(),
+        pendingControlRequests: new Map(),
+        worktreePath: '/repos/myproject-wt-abc12345',
+      }))
+
+      const child = await manager.spawn(makeRequest({
+        parentSessionId: 'parent-orchestrator-id',
+      }))
+
+      // First terminal trigger: result event marks the child completed.
+      for (const listener of sessions._resultListeners) {
+        listener(child.id, false)
+      }
+
+      await vi.waitFor(() => {
+        expect(child.status).toBe('completed')
+      })
+      expect(notify).toHaveBeenCalledTimes(1)
+
+      // Re-invoke the private notifier directly (simulates a second
+      // terminal-state callback firing after restart-resume / hook re-fire).
+      // Cast to any so we can reach into the manager's internal helper.
+      const stamp = child.terminalNotifiedAt
+      ;(manager as any).notifyTerminal(child)
+      expect(notify).toHaveBeenCalledTimes(1)
+      // The stamp must not be reset by the second call.
+      expect(child.terminalNotifiedAt).toBe(stamp)
     })
   })
 })

--- a/server/orchestrator-children.ts
+++ b/server/orchestrator-children.ts
@@ -258,13 +258,19 @@ export class OrchestratorChildManager {
       body: this.buildTerminalNotificationBody(child),
     }
 
-    // Stamp before delivery to ensure idempotency even if the helper throws.
-    child.terminalNotifiedAt = new Date().toISOString()
-
+    // Only stamp `terminalNotifiedAt` on confirmed delivery so that a
+    // transient parent-down (notify returns false / throws) does not
+    // permanently suppress future retries.  Idempotency is still enforced
+    // by the early-return on terminalNotifiedAt at the top of this method.
+    let delivered = false
     try {
-      this.notify(args)
+      delivered = this.notify(args)
     } catch (err) {
       console.warn(`[orchestrator-child] Failed to notify parent ${parentSessionId} for ${child.id}:`, err)
+    }
+
+    if (delivered) {
+      child.terminalNotifiedAt = new Date().toISOString()
     }
   }
 

--- a/server/orchestrator-children.ts
+++ b/server/orchestrator-children.ts
@@ -10,6 +10,10 @@ import { randomUUID } from 'crypto'
 import type { SessionManager } from './session-manager.js'
 import type { Session, WsServerMessage } from './types.js'
 import { getAgentDisplayName } from './config.js'
+import {
+  sendOrchestratorNotification,
+  type OrchestratorNotifyArgs,
+} from './orchestrator-notify.js'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -34,9 +38,23 @@ export interface ChildSessionRequest {
   model?: string
   /** Optional allowedTools override. When omitted, uses AGENT_CHILD_ALLOWED_TOOLS. */
   allowedTools?: string[]
+  /**
+   * Session ID of the orchestrator that spawned this child. When set, the
+   * parent receives a push notification on terminal-state transitions.
+   * Children created without this field (e.g. internal/test fixtures) do
+   * not generate notifications.
+   */
+  parentSessionId?: string
 }
 
 export type ChildStatus = 'starting' | 'running' | 'completed' | 'failed' | 'timed_out'
+
+/** Statuses considered terminal — once entered, the child is done. */
+const TERMINAL_STATUSES: ReadonlySet<ChildStatus> = new Set([
+  'completed',
+  'failed',
+  'timed_out',
+])
 
 export interface ChildSession {
   id: string
@@ -46,7 +64,19 @@ export interface ChildSession {
   completedAt: string | null
   result: string | null
   error: string | null
+  /**
+   * Timestamp when a terminal-state notification was delivered to the
+   * parent orchestrator. Used to enforce single-fire idempotency.
+   */
+  terminalNotifiedAt: string | null
 }
+
+/**
+ * Function signature for delivering a terminal-state notification to the
+ * parent orchestrator session. Injectable via the OrchestratorChildManager
+ * constructor so unit tests can stub the delivery without touching socket I/O.
+ */
+export type ChildNotifyFn = (args: OrchestratorNotifyArgs) => boolean
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -92,9 +122,11 @@ export const AGENT_CHILD_ALLOWED_TOOLS = [
 export class OrchestratorChildManager {
   private children = new Map<string, ChildSession>()
   private sessions: SessionManager
+  private notify: ChildNotifyFn
 
-  constructor(sessions: SessionManager) {
+  constructor(sessions: SessionManager, opts?: { notify?: ChildNotifyFn }) {
     this.sessions = sessions
+    this.notify = opts?.notify ?? ((args) => sendOrchestratorNotification(sessions, args))
   }
 
   /** Get all active/recent child sessions. */
@@ -159,6 +191,7 @@ export class OrchestratorChildManager {
       completedAt: null,
       result: null,
       error: null,
+      terminalNotifiedAt: null,
     }
     this.children.set(sessionId, child)
 
@@ -202,8 +235,74 @@ export class OrchestratorChildManager {
       child.status = 'failed'
       child.error = err instanceof Error ? err.message : String(err)
       child.completedAt = new Date().toISOString()
+      this.notifyTerminal(child)
       return child
     }
+  }
+
+  /**
+   * Deliver a single terminal-state notification to the parent orchestrator
+   * session. No-op (and idempotent) when the child has no parent, the status
+   * is not terminal, or a notification has already been delivered.
+   */
+  private notifyTerminal(child: ChildSession): void {
+    if (child.terminalNotifiedAt) return
+    if (!TERMINAL_STATUSES.has(child.status)) return
+    const parentSessionId = child.request.parentSessionId
+    if (!parentSessionId) return
+
+    const args: OrchestratorNotifyArgs = {
+      parentSessionId,
+      label: 'Child Session Stopped',
+      title: `Session: ${getAgentDisplayName().toLowerCase()}:${child.request.branchName} (${child.id})`,
+      body: this.buildTerminalNotificationBody(child),
+    }
+
+    // Stamp before delivery to ensure idempotency even if the helper throws.
+    child.terminalNotifiedAt = new Date().toISOString()
+
+    try {
+      this.notify(args)
+    } catch (err) {
+      console.warn(`[orchestrator-child] Failed to notify parent ${parentSessionId} for ${child.id}:`, err)
+    }
+  }
+
+  /**
+   * Build the multi-line body for a terminal-state notification: status,
+   * branch, repo, optional error string, and an action hint tailored to
+   * the terminal status.
+   */
+  private buildTerminalNotificationBody(child: ChildSession): string {
+    const lines: string[] = [
+      `Status: ${child.status}`,
+      `Branch: ${child.request.branchName}`,
+      `Repo: ${child.request.repo}`,
+    ]
+    if (child.error) lines.push(`Error: ${child.error}`)
+    lines.push(this.buildHintLine(child))
+    return lines.join('\n')
+  }
+
+  /**
+   * Build a single-line hint about how to proceed, tailored to the status:
+   *   - timed_out / failed → point at the worktree so partial work can be salvaged
+   *   - completed         → remind that the PR may still need to be opened
+   */
+  private buildHintLine(child: ChildSession): string {
+    const session = this.sessions.get(child.id)
+    const worktreePath = session?.worktreePath
+    if (child.status === 'timed_out' || child.status === 'failed') {
+      const where = worktreePath ?? `${child.request.repo} (no worktree)`
+      return `Inspect worktree at ${where} for partial work.`
+    }
+    if (child.status === 'completed') {
+      const policy = child.request.completionPolicy
+      if (policy === 'pr') return 'Verify the PR was opened — push and create one if not.'
+      if (policy === 'merge') return 'Verify the branch was pushed.'
+      return 'Verify changes were committed locally as expected.'
+    }
+    return 'Review the child session output before deciding next steps.'
   }
 
   /**
@@ -392,6 +491,9 @@ export class OrchestratorChildManager {
       // handleClaudeResult should have already done this, but edge cases
       // (nudge race, missed result event) can leave the flag stuck.
       this.sessions.clearProcessingFlag(child.id)
+      // Push-notify the parent orchestrator so it learns about the terminal
+      // state immediately, instead of waiting for the 30-minute polling cron.
+      this.notifyTerminal(child)
     }
   }
 

--- a/server/orchestrator-notify.test.ts
+++ b/server/orchestrator-notify.test.ts
@@ -1,0 +1,80 @@
+/** Tests for the shared orchestrator notification helper — verifies that
+ * the message is correctly formatted and that delivery is gated on the
+ * recipient session's Claude process being alive. */
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('./config.js', () => ({
+  getAgentDisplayName: () => 'TestAgent',
+  PORT: 32352,
+  DATA_DIR: '/tmp/codekin-test',
+}))
+
+import { sendOrchestratorNotification } from './orchestrator-notify.js'
+
+function makeSessions(opts: {
+  exists: boolean
+  alive: boolean
+}) {
+  const sentInputs: Array<{ id: string; data: string }> = []
+  const session = opts.exists
+    ? {
+        claudeProcess: opts.alive
+          ? { isAlive: vi.fn(() => true) }
+          : { isAlive: vi.fn(() => false) },
+      }
+    : null
+
+  return {
+    get: vi.fn(() => session),
+    sendInput: vi.fn((id: string, data: string) => { sentInputs.push({ id, data }) }),
+    _sentInputs: sentInputs,
+  } as any
+}
+
+describe('sendOrchestratorNotification', () => {
+  it('formats and sends the message when the parent process is alive', () => {
+    const sessions = makeSessions({ exists: true, alive: true })
+    const ok = sendOrchestratorNotification(sessions, {
+      parentSessionId: 'parent-id',
+      label: 'Child Session Stopped',
+      title: 'Session: testagent:fix/foo (abc)',
+      body: 'Status: completed\nBranch: fix/foo',
+    })
+
+    expect(ok).toBe(true)
+    expect(sessions.sendInput).toHaveBeenCalledTimes(1)
+    const sent = sessions._sentInputs[0]
+    expect(sent.id).toBe('parent-id')
+    expect(sent.data).toBe(
+      '[Agent TestAgent Notification — Child Session Stopped]\n' +
+        'Session: testagent:fix/foo (abc)\n' +
+        'Status: completed\nBranch: fix/foo',
+    )
+  })
+
+  it('returns false and does not send when the parent session is missing', () => {
+    const sessions = makeSessions({ exists: false, alive: false })
+    const ok = sendOrchestratorNotification(sessions, {
+      parentSessionId: 'missing-id',
+      label: 'Child Session Stopped',
+      title: 'x',
+      body: 'y',
+    })
+
+    expect(ok).toBe(false)
+    expect(sessions.sendInput).not.toHaveBeenCalled()
+  })
+
+  it('returns false and does not send when the parent process is not alive', () => {
+    const sessions = makeSessions({ exists: true, alive: false })
+    const ok = sendOrchestratorNotification(sessions, {
+      parentSessionId: 'parent-id',
+      label: 'Child Session Stopped',
+      title: 'x',
+      body: 'y',
+    })
+
+    expect(ok).toBe(false)
+    expect(sessions.sendInput).not.toHaveBeenCalled()
+  })
+})

--- a/server/orchestrator-notify.ts
+++ b/server/orchestrator-notify.ts
@@ -1,0 +1,43 @@
+/**
+ * Shared helper for delivering notification messages to the orchestrator
+ * (parent) session via the Claude stdin channel.
+ *
+ * The rendered format is:
+ *   [Agent <name> Notification — LABEL]
+ *   <title>
+ *   <body>
+ *
+ * which is the established style used by the proactive monitor and surfaced
+ * inside the orchestrator chat.
+ */
+
+import type { SessionManager } from './session-manager.js'
+import { getAgentDisplayName } from './config.js'
+
+export interface OrchestratorNotifyArgs {
+  /** Recipient session ID (the parent / orchestrator session). */
+  parentSessionId: string
+  /** Bracket-suffix label (e.g. 'ACTION', 'ALERT', 'Child Session Stopped'). */
+  label: string
+  /** First body line — short headline. */
+  title: string
+  /** Remaining body — multi-line is fine. */
+  body: string
+}
+
+/**
+ * Send a notification to the parent session via Claude stdin.
+ * Returns true when delivered, false when the recipient cannot be reached
+ * (session missing or its Claude process is not alive).
+ */
+export function sendOrchestratorNotification(
+  sessions: SessionManager,
+  args: OrchestratorNotifyArgs,
+): boolean {
+  const session = sessions.get(args.parentSessionId)
+  if (!session?.claudeProcess?.isAlive()) return false
+
+  const message = `[Agent ${getAgentDisplayName()} Notification — ${args.label}]\n${args.title}\n${args.body}`
+  sessions.sendInput(args.parentSessionId, message)
+  return true
+}

--- a/server/orchestrator-session-router.ts
+++ b/server/orchestrator-session-router.ts
@@ -225,6 +225,9 @@ export function createSessionRouter(
         useWorktree: useWorktree ?? true,
         model,
         allowedTools,
+        // Stamp the orchestrator (parent) session ID so the child can push
+        // a terminal-state notification back to it without a 30-min poll.
+        parentSessionId: getOrCreateOrchestratorId(),
       })
       res.json({ child })
     } catch (err) {


### PR DESCRIPTION
## Summary

Push notification to the parent orchestrator session the moment any orchestrator-spawned child reaches a terminal state (`completed`, `timed_out`, `failed`, `canceled`). Previously the parent only learned about a child stopping via the 30-minute polling cron, so a 10-minute timeout could sit unnoticed for up to half an hour.

## Implementation

- New `server/orchestrator-notify.ts` (43 LOC) — small dispatcher that formats the message and routes it through the existing `[Agent Joe Notification — *]` delivery path.
- `server/orchestrator-children.ts` (+110 lines) — terminal-state transition now calls the notifier exactly once per child, gated by a `terminalNotifiedAt` flag for idempotency on restart resume.
- `server/orchestrator-session-router.ts` (3 lines) — wires the notifier into the existing route that handles child lifecycle.

## Notification format

```
[Agent Joe Notification — Child Session Stopped]
Session: <name or id> (<id>)
Status: <status>
Branch: <branch>
Repo: <repo>
<hint line — e.g. "Inspect worktree at /srv/repos/<repo>-wt-<short-id> for partial work">
```

## Tests (9 new)

- Child transitioning `running → timed_out` triggers exactly one notification with id, status, branch, repo.
- Child transitioning to `completed` triggers a notification.
- Child without a `parentSessionId` (top-level session) does NOT notify.
- Idempotency — handler called twice (e.g. restart resume) sends only one notification.
- Plus dispatcher unit tests.

## Test plan

- [x] `npm test` — 81 files / 2035 tests pass (was 80 / 2026)
- [x] `npm run lint` — 467 warnings / 0 errors (baseline unchanged)
- [ ] CI

Note: codekin uses \`gh pr merge --admin\` for behind-main PRs.