### PR TITLE
fix(reliability): roll back dedup key on startRun failure; harden GitHub slug parser

### DIFF
--- a/server/commit-event-handler.test.ts
+++ b/server/commit-event-handler.test.ts
@@ -347,6 +347,21 @@ describe('CommitEventHandler', () => {
     expect(result.reason).toContain('engine boom')
   })
 
+  it('rolls back the dedup entry when startRun fails so the same hash can be retried', async () => {
+    enableRepoConfig()
+    mockState.startRun.mockRejectedValueOnce(new Error('engine boom'))
+
+    const first = await handler.handle(makeEvent({ commitHash: 'e'.repeat(40) }))
+    expect(first.accepted).toBe(false)
+    expect(first.reason).toContain('engine boom')
+
+    // The dedup key must have been removed — a second call with the same hash
+    // must not be rejected as a duplicate and must reach startRun.
+    const second = await handler.handle(makeEvent({ commitHash: 'e'.repeat(40) }))
+    expect(second.accepted).toBe(true)
+    expect(mockState.startRun).toHaveBeenCalledTimes(2)
+  })
+
   // -------------------------------------------------------------------------
   // shutdown / pruneExpired
   // -------------------------------------------------------------------------

--- a/server/commit-event-handler.ts
+++ b/server/commit-event-handler.ts
@@ -147,6 +147,8 @@ export class CommitEventHandler {
       console.log(`[commit-event] Dispatched commit-review run ${run.id} for ${event.repoPath} (${event.commitHash.slice(0, 8)})`)
       return { accepted: true, runId: run.id }
     } catch (err) {
+      // Roll back the dedup entry so a later retry isn't suppressed.
+      this.seenCommits.delete(dedupKey)
       const msg = err instanceof Error ? err.message : String(err)
       console.error(`[commit-event] Failed to start run for ${event.repoPath}:`, msg)
       return { accepted: false, reason: `Failed to start run: ${msg}` }

--- a/server/workflow-routes.test.ts
+++ b/server/workflow-routes.test.ts
@@ -157,6 +157,36 @@ describe('parseGitHubSlug', () => {
   it('handles repos with hyphens, underscores, and dots', () => {
     expect(parseGitHubSlug('git@github.com:my-org/my_repo.name.git')).toBe('my-org/my_repo.name')
   })
+
+  // Adversarial cases — the old regex matched any string containing "github.com"
+  // as a substring; the new implementation must reject all of these.
+  it('rejects URL where github.com appears only in the path (evil.com host)', () => {
+    expect(parseGitHubSlug('https://evil.com/github.com/foo/bar')).toBeNull()
+  })
+
+  it('rejects SSH-like string whose host is notgithub.com', () => {
+    expect(parseGitHubSlug('notgithub.com:foo/bar')).toBeNull()
+  })
+
+  it('rejects URL whose hostname is github.com.evil.com', () => {
+    expect(parseGitHubSlug('https://github.com.evil.com/foo/bar')).toBeNull()
+  })
+
+  it('parses SSH URL with .git suffix (adversarial baseline)', () => {
+    expect(parseGitHubSlug('git@github.com:foo/bar.git')).toBe('foo/bar')
+  })
+
+  it('parses HTTPS URL with .git suffix (adversarial baseline)', () => {
+    expect(parseGitHubSlug('https://github.com/foo/bar.git')).toBe('foo/bar')
+  })
+
+  it('parses HTTPS URL without .git suffix (adversarial baseline)', () => {
+    expect(parseGitHubSlug('https://github.com/foo/bar')).toBe('foo/bar')
+  })
+
+  it('parses www.github.com HTTPS URL', () => {
+    expect(parseGitHubSlug('https://www.github.com/foo/bar')).toBe('foo/bar')
+  })
 })
 
 describe('isValidCron', () => {

--- a/server/workflow-routes.ts
+++ b/server/workflow-routes.ts
@@ -73,8 +73,23 @@ const execFileAsync = promisify(execFile)
  * Returns null for non-GitHub remotes.
  */
 export function parseGitHubSlug(remoteUrl: string): string | null {
-  const match = remoteUrl.trim().match(/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/)
-  return match?.[1] ?? null
+  const url = remoteUrl.trim()
+
+  // SSH form: strictly anchored so "notgithub.com:..." cannot match.
+  const sshMatch = url.match(/^git@github\.com:([^/]+)\/([^/]+?)(?:\.git)?$/)
+  if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`
+
+  // HTTPS form: use the URL constructor so the hostname is checked exactly,
+  // preventing substring matches like "evil.com/github.com/...".
+  try {
+    const parsed = new URL(url)
+    if (parsed.hostname !== 'github.com' && parsed.hostname !== 'www.github.com') return null
+    const parts = parsed.pathname.replace(/\.git$/, '').split('/').filter(Boolean)
+    if (parts.length < 2) return null
+    return `${parts[0]}/${parts[1]}`
+  } catch {
+    return null
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes **W1** and **W2** from the 2026-04-30 daily code review audit:
`.codekin/reports/code-review/2026-04-30_code-review-daily.md`

### W1 — Commit dedup recorded before run start (`server/commit-event-handler.ts`)

The `seenCommits` entry was written **before** `engine.startRun()`, so a transient error from `startRun` permanently suppressed retries for that commit hash (for up to 1 hour).

**Fix**: delete the `seenCommits` entry in the `catch` block so the caller can retry. The entry is still written _before_ the `await` to preserve within-tick deduplication (concurrent calls in the same event-loop tick still deduplicate correctly).

Regression test added: stubs `startRun` to reject, asserts a second `handle()` call with the same hash is **not** rejected as a duplicate.

### W2 — GitHub slug parser too permissive (`server/workflow-routes.ts`)

`parseGitHubSlug` used the regex `/github\.com[:/]([^/]+\/[^/]+?)(?:\.git)?$/`, which matched any URL containing `github.com` as a substring (e.g. `https://evil.com/github.com/foo/bar`).

**Fix**:
- SSH form: fully-anchored regex `^git@github\.com:([^/]+)/([^/]+?)(?:\.git)?$`
- HTTPS form: `new URL()` constructor with strict `hostname === "github.com" || hostname === "www.github.com"` equality check

Adversarial test cases added for all specified inputs.

## Test plan

- [ ] `npm test` — all 2043 tests green (8 new vs. 2035 baseline)
- [ ] `npm run lint` — 0 errors
- [ ] Regression test for W1: second `handle()` call after `startRun` failure returns `accepted: true`
- [ ] Adversarial slug tests: `evil.com/github.com/...` → null, `github.com.evil.com` → null, `notgithub.com:foo/bar` → null

🤖 Generated with [Claude Code](https://claude.com/claude-code)