### PR TITLE
fix: default to quiet mode (no boot-time Claude spawns or 15m monitor)

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -175,6 +175,12 @@ describe('config', () => {
       const config = await loadConfig()
       expect(config.ORCHESTRATOR_MONITOR).toBe(true)
     })
+
+    it('is false for any other value', async () => {
+      process.env.CODEKIN_ORCHESTRATOR_MONITOR = 'yes'
+      const config = await loadConfig()
+      expect(config.ORCHESTRATOR_MONITOR).toBe(false)
+    })
   })
 
   describe('production mode', () => {

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -39,6 +39,8 @@ beforeEach(() => {
   delete process.env.SCREENSHOTS_DIR
   delete process.env.FRONTEND_DIST
   delete process.env.GH_ORG
+  delete process.env.CODEKIN_AUTO_RESTORE_SESSIONS
+  delete process.env.CODEKIN_ORCHESTRATOR_MONITOR
 
   // Reset mock implementations to defaults
   mockExistsSync.mockReturnValue(false)
@@ -128,6 +130,50 @@ describe('config', () => {
       process.env.GH_ORG = 'org-one,,org-two,'
       const config = await loadConfig()
       expect(config.GH_ORGS).toEqual(['org-one', 'org-two'])
+    })
+  })
+
+  describe('AUTO_RESTORE_SESSIONS (quiet mode)', () => {
+    it('defaults to false when env is unset', async () => {
+      const config = await loadConfig()
+      expect(config.AUTO_RESTORE_SESSIONS).toBe(false)
+    })
+
+    it('is true when CODEKIN_AUTO_RESTORE_SESSIONS=true', async () => {
+      process.env.CODEKIN_AUTO_RESTORE_SESSIONS = 'true'
+      const config = await loadConfig()
+      expect(config.AUTO_RESTORE_SESSIONS).toBe(true)
+    })
+
+    it('is true when CODEKIN_AUTO_RESTORE_SESSIONS=1', async () => {
+      process.env.CODEKIN_AUTO_RESTORE_SESSIONS = '1'
+      const config = await loadConfig()
+      expect(config.AUTO_RESTORE_SESSIONS).toBe(true)
+    })
+
+    it('is false for any other value', async () => {
+      process.env.CODEKIN_AUTO_RESTORE_SESSIONS = 'yes'
+      const config = await loadConfig()
+      expect(config.AUTO_RESTORE_SESSIONS).toBe(false)
+    })
+  })
+
+  describe('ORCHESTRATOR_MONITOR (quiet mode)', () => {
+    it('defaults to false when env is unset', async () => {
+      const config = await loadConfig()
+      expect(config.ORCHESTRATOR_MONITOR).toBe(false)
+    })
+
+    it('is true when CODEKIN_ORCHESTRATOR_MONITOR=true', async () => {
+      process.env.CODEKIN_ORCHESTRATOR_MONITOR = 'true'
+      const config = await loadConfig()
+      expect(config.ORCHESTRATOR_MONITOR).toBe(true)
+    })
+
+    it('is true when CODEKIN_ORCHESTRATOR_MONITOR=1', async () => {
+      process.env.CODEKIN_ORCHESTRATOR_MONITOR = '1'
+      const config = await loadConfig()
+      expect(config.ORCHESTRATOR_MONITOR).toBe(true)
     })
   })
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -115,6 +115,34 @@ export const TRUST_PROXY = process.env.TRUST_PROXY === 'true' || process.env.TRU
 export const GH_ORGS: string[] = (process.env.GH_ORG || '').split(',').map(s => s.trim()).filter(Boolean)
 
 // ---------------------------------------------------------------------------
+// Background activity ("quiet mode" defaults)
+// ---------------------------------------------------------------------------
+//
+// Codekin authenticates via the user's `claude` CLI, so any background
+// API call is billed against their personal subscription quota. Default
+// behaviour is therefore "make no Claude API calls until the user explicitly
+// asks for one." Each background source is opt-in via env var.
+
+function envFlag(name: string): boolean {
+  const v = process.env[name]
+  return v === 'true' || v === '1'
+}
+
+/**
+ * Auto-restart Claude processes that were alive at the previous shutdown
+ * (and the always-on orchestrator session) when the server boots.
+ * Default: off. Set CODEKIN_AUTO_RESTORE_SESSIONS=true to opt in.
+ */
+export const AUTO_RESTORE_SESSIONS = envFlag('CODEKIN_AUTO_RESTORE_SESSIONS')
+
+/**
+ * Run the orchestrator proactive monitor (15-minute polling that pokes the
+ * orchestrator Claude session for new reports and idle repos).
+ * Default: off. Set CODEKIN_ORCHESTRATOR_MONITOR=true to opt in.
+ */
+export const ORCHESTRATOR_MONITOR = envFlag('CODEKIN_ORCHESTRATOR_MONITOR')
+
+// ---------------------------------------------------------------------------
 // Orchestrator (Agent)
 // ---------------------------------------------------------------------------
 

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -47,7 +47,7 @@ import { createDocsRouter } from './docs-routes.js'
 import { createOrchestratorRouter } from './orchestrator-routes.js'
 import { ensureOrchestratorRunning, getOrchestratorSessionId, isOrchestratorSession } from './orchestrator-manager.js'
 import { OrchestratorMonitor } from './orchestrator-monitor.js'
-import { PORT as CONFIG_PORT, AUTH_TOKEN as configAuthToken, CORS_ORIGIN, FRONTEND_DIST, AGENT_DISPLAY_NAME, getAgentDisplayName, setAgentDisplayNameResolver, TRUST_PROXY, CLAUDE_BINARY } from './config.js'
+import { PORT as CONFIG_PORT, AUTH_TOKEN as configAuthToken, CORS_ORIGIN, FRONTEND_DIST, AGENT_DISPLAY_NAME, getAgentDisplayName, setAgentDisplayNameResolver, TRUST_PROXY, CLAUDE_BINARY, AUTO_RESTORE_SESSIONS, ORCHESTRATOR_MONITOR } from './config.js'
 
 // ---------------------------------------------------------------------------
 // CLI args (legacy bare-metal compat) and auth setup
@@ -556,14 +556,21 @@ server.listen(port, '0.0.0.0', () => {
   // Check for newer version on npm (non-blocking)
   void checkForUpdates()
 
-  // Auto-restart sessions that were active before the server went down
-  sessions.restoreActiveSessions()
-
-  // Start the orchestrator session (always-on)
-  try {
-    ensureOrchestratorRunning(sessions)
-  } catch (err) {
-    console.error('[orchestrator] Failed to start on boot:', err)
+  // Auto-restart sessions that were active before the server went down,
+  // and start the always-on orchestrator session. Both are opt-in: every
+  // boot-time Claude process consumes the user's subscription quota even
+  // when no human is connected. Quiet mode (the default) waits for an
+  // explicit user action before spawning anything.
+  if (AUTO_RESTORE_SESSIONS) {
+    sessions.restoreActiveSessions()
+    try {
+      ensureOrchestratorRunning(sessions)
+    } catch (err) {
+      console.error('[orchestrator] Failed to start on boot:', err)
+    }
+  } else {
+    console.log('[boot] Quiet mode: skipping session auto-restore and orchestrator auto-start.')
+    console.log('[boot]   Set CODEKIN_AUTO_RESTORE_SESSIONS=true to re-enable.')
   }
 
   // Wire up prompt listener: notify the orchestrator session when any child
@@ -631,10 +638,18 @@ server.listen(port, '0.0.0.0', () => {
       syncCommitHooks()
     }
 
-    // Start orchestrator proactive monitor with workflow engine events
+    // Wire up the orchestrator proactive monitor. The 15-min poll is opt-in
+    // because it pokes the orchestrator Claude session on a timer — the
+    // dominant source of idle-install token consumption. Workflow events
+    // are still delivered when the monitor is running.
     const monitor = new OrchestratorMonitor(sessions)
     monitor.setEngine(engine)
-    monitor.start()
+    if (ORCHESTRATOR_MONITOR) {
+      monitor.start()
+    } else {
+      console.log('[boot] Quiet mode: orchestrator proactive monitor disabled (15-min poll).')
+      console.log('[boot]   Set CODEKIN_ORCHESTRATOR_MONITOR=true to re-enable.')
+    }
     orchestratorMonitorRef.current = monitor
 
     console.log('[workflow] Workflow engine ready')


### PR DESCRIPTION
## Summary
- Codekin authenticates via the user's `claude` CLI, so every background API call is billed against their personal Pro/Max quota. Per a user bug report, the 15-min orchestrator monitor + auto-restore-on-boot were burning ~14M cache-read tokens/day on idle installs and triggering 5-hour rate-limit rejections with no human at the keyboard.
- Both behaviours are now **opt-in** via env vars; the defaults are off ("quiet mode"). When skipped, a one-line boot log explains how to re-enable.

## Changes
- `server/config.ts` — adds `AUTO_RESTORE_SESSIONS` (gated on `CODEKIN_AUTO_RESTORE_SESSIONS=true|1`) and `ORCHESTRATOR_MONITOR` (gated on `CODEKIN_ORCHESTRATOR_MONITOR=true|1`).
- `server/ws-server.ts` — gates three boot-time call sites:
  - `sessions.restoreActiveSessions()` — opt-in via `AUTO_RESTORE_SESSIONS`
  - `ensureOrchestratorRunning(sessions)` — opt-in via `AUTO_RESTORE_SESSIONS` (same flag, same intent: don't spawn Claude at boot)
  - `monitor.start()` — opt-in via `ORCHESTRATOR_MONITOR`
- Workflow events still wire through to the monitor (`setEngine`) so user-triggered workflow runs still notify the orchestrator if they happen to be active. Only the timer-driven poll is gated.
- `server/config.test.ts` — covers default + true + 1 + invalid values for both flags.

## Why this is the right default
The mental model shift: Codekin was designed as a server-side automation platform (where API costs hit an org account) and shipped as a personal-install npm package (where they hit one human's subscription). Always-on background AI was a sensible default in the first model and a quota-leaking default in the second. Quiet-by-default fixes the mismatch without removing any feature — operators who want the always-warm behaviour set two env vars.

## Test plan
- [x] `npm run build` — passes (tsc + vite)
- [x] `npm run lint` — 0 errors (warnings unchanged)
- [x] `npm test` — 2043 tests pass (config gains 7 new ones)
- [ ] Manual: boot server with no env vars → expect two `[boot] Quiet mode:` log lines and zero Claude processes spawned
- [ ] Manual: boot with `CODEKIN_AUTO_RESTORE_SESSIONS=true CODEKIN_ORCHESTRATOR_MONITOR=true` → behaviour matches pre-PR baseline

## Follow-up (separate PR)
Cap headless-session history/age (so re-enabling auto-restore doesn't grow per-poke cost over time) and add a rate-limit circuit breaker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)