### PR TITLE
fix: cap headless session lifetime + circuit-break on rate limits

### DIFF
--- a/bin/codekin.mjs
+++ b/bin/codekin.mjs
@@ -263,7 +263,7 @@ function serviceUninstallMac() {
     return
   }
   spawnSync('launchctl', ['unload', LAUNCHD_PLIST], { stdio: 'inherit' })
-  import('fs').then(fs => fs.unlinkSync(LAUNCHD_PLIST))
+  rmSync(LAUNCHD_PLIST, { force: true })
   console.log('Codekin service removed.')
 }
 
@@ -327,9 +327,7 @@ function serviceInstallLinux() {
 
 function serviceUninstallLinux() {
   spawnSync('systemctl', ['--user', 'disable', '--now', 'codekin'], { stdio: 'inherit' })
-  if (existsSync(SYSTEMD_SERVICE_FILE)) {
-    import('fs').then(fs => fs.unlinkSync(SYSTEMD_SERVICE_FILE))
-  }
+  rmSync(SYSTEMD_SERVICE_FILE, { force: true })
   spawnSync('systemctl', ['--user', 'daemon-reload'], { stdio: 'inherit' })
   console.log('Codekin service removed.')
 }
@@ -359,10 +357,16 @@ function cmdStop() {
     }
     const result = spawnSync('launchctl', ['unload', LAUNCHD_PLIST], { stdio: 'inherit' })
     if (result.status === 0) {
-      console.log('Codekin service stopped. The plist remains installed —')
-      console.log('  - to start it again now:    launchctl load ' + LAUNCHD_PLIST)
-      console.log('  - to start it again at login: nothing to do (RunAtLoad will pick it up)')
-      console.log('  - to remove permanently:     codekin service uninstall')
+      // launchctl unload (no -w) takes the agent out of the current session's
+      // launchd job list. The plist file stays in ~/Library/LaunchAgents/, so
+      // loginwindow loads it again at next user login (which fires RunAtLoad).
+      // The user has to take an explicit action to opt out of that.
+      console.log('Codekin service stopped (launchctl unload).')
+      console.log('Notes:')
+      console.log('  - Plist file is still at ' + LAUNCHD_PLIST + '.')
+      console.log('  - It will reload automatically at next user login (RunAtLoad re-fires).')
+      console.log('  - To resume now without waiting:     launchctl load ' + LAUNCHD_PLIST)
+      console.log('  - To stop permanently (no auto-load): codekin service uninstall')
     } else {
       console.error('Failed to stop launchd service.')
       process.exit(1)

--- a/bin/codekin.mjs
+++ b/bin/codekin.mjs
@@ -4,6 +4,7 @@
  *
  * Usage:
  *   codekin start                  Run server in foreground
+ *   codekin stop                   Stop the running background service
  *   codekin setup                  First-time setup wizard
  *   codekin service install        Install + start background service
  *   codekin service uninstall      Remove background service
@@ -216,8 +217,17 @@ ${envEntries}
 \t</dict>
 \t<key>RunAtLoad</key>
 \t<true/>
+\t<!--
+\t  KeepAlive as a dict (not <true/>) so a clean exit (e.g. \`codekin stop\`,
+\t  which sends SIGTERM and triggers gracefulShutdown → exit(0)) is NOT
+\t  respawned. Only crashes (non-zero exit) trigger restart, preserving
+\t  the daemon UX without making the process unkillable.
+\t-->
 \t<key>KeepAlive</key>
-\t<true/>
+\t<dict>
+\t\t<key>SuccessfulExit</key>
+\t\t<false/>
+\t</dict>
 \t<key>StandardOutPath</key>
 \t<string>${join(homedir(), '.codekin', 'server.log')}</string>
 \t<key>StandardErrorPath</key>
@@ -284,7 +294,9 @@ After=network.target
 Type=simple
 ExecStart=${runner} ${script}
 EnvironmentFile=${ENV_FILE}
-Restart=always
+# on-failure (not always) so \`codekin stop\` / \`systemctl --user stop\` exits
+# cleanly without an immediate respawn. Crashes still get restarted.
+Restart=on-failure
 RestartSec=5
 
 [Install]
@@ -330,6 +342,50 @@ function serviceStatusLinux() {
     printAccessUrl()
   } else {
     console.log('Codekin service is not running.')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Stop (cross-platform)
+// ---------------------------------------------------------------------------
+
+function cmdStop() {
+  const os = platform()
+  if (os === 'darwin') {
+    if (!existsSync(LAUNCHD_PLIST)) {
+      console.log('Codekin background service is not installed.')
+      console.log('If a foreground server is running, switch to its terminal and press Ctrl+C.')
+      return
+    }
+    const result = spawnSync('launchctl', ['unload', LAUNCHD_PLIST], { stdio: 'inherit' })
+    if (result.status === 0) {
+      console.log('Codekin service stopped. The plist remains installed —')
+      console.log('  - to start it again now:    launchctl load ' + LAUNCHD_PLIST)
+      console.log('  - to start it again at login: nothing to do (RunAtLoad will pick it up)')
+      console.log('  - to remove permanently:     codekin service uninstall')
+    } else {
+      console.error('Failed to stop launchd service.')
+      process.exit(1)
+    }
+  } else if (os === 'linux') {
+    if (!existsSync(SYSTEMD_SERVICE_FILE)) {
+      console.log('Codekin background service is not installed.')
+      console.log('If a foreground server is running, switch to its terminal and press Ctrl+C.')
+      return
+    }
+    const result = spawnSync('systemctl', ['--user', 'stop', 'codekin'], { stdio: 'pipe', encoding: 'utf-8' })
+    if (result.status === 0) {
+      console.log('Codekin service stopped. The unit remains installed —')
+      console.log('  - to start it again:     systemctl --user start codekin')
+      console.log('  - to remove permanently: codekin service uninstall')
+    } else {
+      const msg = (result.stderr || '').trim()
+      if (msg) console.error(msg)
+      process.exit(1)
+    }
+  } else {
+    console.error(`Service stop is not supported on ${os}. Press Ctrl+C in the foreground server's terminal.`)
+    process.exit(1)
   }
 }
 
@@ -445,6 +501,8 @@ const cmd = args[0]
 
 if (cmd === 'start') {
   cmdStart()
+} else if (cmd === 'stop') {
+  cmdStop()
 } else if (cmd === 'setup') {
   await cmdSetup({ regenerate: args.includes('--regenerate') })
 } else if (cmd === 'config') {
@@ -467,6 +525,7 @@ if (cmd === 'start') {
 
 Usage:
   codekin start                   Run server in foreground
+  codekin stop                    Stop the running background service
   codekin setup                   First-time setup wizard
   codekin setup --regenerate      Regenerate auth token
   codekin config                  Update settings

--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -71,6 +71,7 @@ export interface ClaudeProcessEvents {
   todo_update: [tasks: TaskItem[]]
   image: [base64: string, mediaType: string]
   result: [text: string, isError: boolean]
+  rate_limit: [event: Record<string, unknown>]
   error: [message: string]
   exit: [code: number | null, signal: string | null]
 }
@@ -319,7 +320,7 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
       console.log(`[event] type=${event.type} subtype=${subtype || '-'}`)
     }
     // Log all event types we DON'T handle to catch unknown protocol messages
-    if (!['system', 'stream_event', 'assistant', 'user', 'result', 'control_request'].includes(event.type)) {
+    if (!['system', 'stream_event', 'assistant', 'user', 'result', 'control_request', 'rate_limit_event'].includes(event.type)) {
       console.log(`[event-unhandled] type=${event.type} data=${JSON.stringify(event).slice(0, 300)}`)
     }
 
@@ -356,6 +357,10 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
         this.handleControlRequest(ctrlEvent)
         break
       }
+
+      case 'rate_limit_event':
+        this.emit('rate_limit', event as unknown as Record<string, unknown>)
+        break
 
     }
   }

--- a/server/orchestrator-monitor.ts
+++ b/server/orchestrator-monitor.ts
@@ -150,6 +150,14 @@ export class OrchestratorMonitor {
 
   /** Periodic poll — check for new reports and idle repos. */
   private async poll(): Promise<void> {
+    // Skip the entire poll if the rate-limit circuit breaker is open. This
+    // is the dominant source of background API calls; continuing to poke
+    // the orchestrator session during a cooldown just deepens the hole.
+    if (this.sessions.isRateLimited()) {
+      console.log('[orchestrator-monitor] rate-limit circuit breaker open — skipping poll')
+      return
+    }
+
     const repoPaths = this.discoverRepoPaths()
 
     // Check for new reports
@@ -255,6 +263,12 @@ export class OrchestratorMonitor {
 
   /** Deliver a notification to the orchestrator chat session. */
   private deliverToOrchestrator(notification: OrchestratorNotification): void {
+    // Don't push more API work at the orchestrator while the rate-limit
+    // circuit breaker is open. The notification stays in the buffer and
+    // can still be inspected via the API; it just isn't replayed as a
+    // chat message until the cooldown expires.
+    if (this.sessions.isRateLimited()) return
+
     const orchestratorId = getOrchestratorSessionId(this.sessions)
     if (!orchestratorId) return
 

--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -44,6 +44,7 @@ export interface SessionLifecycleDeps {
   onToolDoneEvent(session: Session, toolName: string, summary: string | undefined): void
   handleClaudeResult(session: Session, sessionId: string, result: string, isError: boolean): void
   buildSessionContext(session: Session): string | null
+  onRateLimitEvent(session: Session, sessionId: string, event: Record<string, unknown>): void
 }
 
 export class SessionLifecycle {
@@ -244,6 +245,7 @@ export class SessionLifecycle {
       session.planManager.onTurnEnd()
       this.deps.handleClaudeResult(session, sessionId, result, isError)
     })
+    cp.on('rate_limit', (event) => this.deps.onRateLimitEvent(session, sessionId, event))
     cp.on('error', (message) => this.deps.broadcast(session, { type: 'error', message }))
     cp.on('exit', (code, signal) => { cp.removeAllListeners(); this.handleClaudeExit(cp, session, sessionId, code, signal) })
   }

--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -3812,4 +3812,107 @@ describe('SessionManager', () => {
       expect(result).toEqual(mockResult)
     })
   })
+
+  describe('rate-limit circuit breaker', () => {
+    it('isRateLimited returns false initially', () => {
+      expect(sm.isRateLimited()).toBe(false)
+    })
+
+    it('engages cooldown when onRateLimitEvent fires', () => {
+      const s = sm.create('test', '/tmp')
+      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event', overageStatus: 'rejected' })
+      expect(sm.isRateLimited()).toBe(true)
+    })
+
+    it('clears after cooldown elapses', () => {
+      vi.useFakeTimers()
+      const s = sm.create('test', '/tmp')
+      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event' })
+      expect(sm.isRateLimited()).toBe(true)
+      // RATE_LIMIT_COOLDOWN_MS is 60 minutes; advance just past it
+      vi.advanceTimersByTime(60 * 60 * 1000 + 1)
+      expect(sm.isRateLimited()).toBe(false)
+      vi.useRealTimers()
+    })
+
+    it('broadcasts a notification only on the first hit during a cooldown window', () => {
+      const s = sm.create('test', '/tmp')
+      const ws = fakeWs()
+      sm.join(s.id, ws)
+
+      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event' })
+      const firstCallCount = ws.send.mock.calls.length
+
+      // A second event during the same cooldown should not re-broadcast
+      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event' })
+      expect(ws.send.mock.calls.length).toBe(firstCallCount)
+    })
+  })
+
+  describe('headless conversation cap', () => {
+    it('clears claudeSessionId when a headless session passes the turn cap', () => {
+      const s = sm.create('orch', '/tmp', { source: 'orchestrator' })
+      s.claudeSessionId = 'long-running-claude-id'
+      s._claudeTurnCount = 100 // MAX_HEADLESS_CONVERSATION_TURNS
+      ;(s as any).claudeProcess = fakeClaudeProcess(true)
+
+      ;(sm as any).handleClaudeResult(s, s.id, 'success', false)
+
+      expect(s.claudeSessionId).toBeNull()
+      expect(s._claudeTurnCount).toBe(0)
+    })
+
+    it('leaves interactive sessions untouched at the same turn count', () => {
+      const s = sm.create('manual', '/tmp')
+      s.claudeSessionId = 'manual-claude-id'
+      s._claudeTurnCount = 200
+      ;(s as any).claudeProcess = fakeClaudeProcess(true)
+
+      ;(sm as any).handleClaudeResult(s, s.id, 'success', false)
+
+      expect(s.claudeSessionId).toBe('manual-claude-id')
+    })
+
+    it('does not clear claudeSessionId for headless sessions below the cap', () => {
+      const s = sm.create('orch', '/tmp', { source: 'orchestrator' })
+      s.claudeSessionId = 'still-fresh'
+      s._claudeTurnCount = 10
+      ;(s as any).claudeProcess = fakeClaudeProcess(true)
+
+      ;(sm as any).handleClaudeResult(s, s.id, 'success', false)
+
+      expect(s.claudeSessionId).toBe('still-fresh')
+    })
+  })
+
+  describe('headless stale prune', () => {
+    it('prunes a non-orchestrator headless session older than HEADLESS_STALE_AGE_MS', () => {
+      const s = sm.create('webhook-old', '/tmp', { source: 'webhook' })
+      // Backdate to 31 days old
+      s.created = new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString()
+
+      ;(sm as any).reapIdleSessions()
+
+      expect(sm.get(s.id)).toBeUndefined()
+    })
+
+    it('keeps the orchestrator session even when older than the stale threshold', () => {
+      const s = sm.create('orch', '/tmp', { source: 'orchestrator' })
+      s.created = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString()
+
+      ;(sm as any).reapIdleSessions()
+
+      expect(sm.get(s.id)).toBeDefined()
+    })
+
+    it('keeps a recent headless session', () => {
+      const s = sm.create('webhook-fresh', '/tmp', { source: 'webhook' })
+      // 1 day old — well under the 30-day cap
+      s.created = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString()
+
+      ;(sm as any).reapIdleSessions()
+
+      expect(sm.get(s.id)).toBeDefined()
+    })
+  })
 })

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -54,6 +54,27 @@ const IDLE_SESSION_TIMEOUT_MS = 30 * 60 * 1000 // 30 minutes
 const IDLE_CHECK_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
 /** How old a dead session must be before automatic pruning (7 days). */
 const STALE_SESSION_AGE_MS = 7 * 24 * 60 * 60 * 1000
+/**
+ * How old a dead headless session (webhook/workflow/stepflow/agent) must be
+ * before automatic pruning. Longer than the interactive threshold because
+ * automation pipelines may legitimately leave session metadata around between
+ * runs. Orchestrator sessions are exempt (they're meant to be long-lived).
+ */
+const HEADLESS_STALE_AGE_MS = 30 * 24 * 60 * 60 * 1000
+/**
+ * Hard cap on the number of completed Claude turns a single headless session
+ * may resume across before its claudeSessionId is reset. This bounds the
+ * cache-read cost of long-lived background sessions (the orchestrator session
+ * in particular accumulates context every poll if not capped). When tripped,
+ * the next process spawn starts a fresh Claude conversation.
+ */
+const MAX_HEADLESS_CONVERSATION_TURNS = 100
+/**
+ * How long the circuit breaker pauses background activity after a Claude
+ * `rate_limit_event` arrives. Picked so a single rate-limit hit doesn't keep
+ * generating new traffic until the user notices.
+ */
+const RATE_LIMIT_COOLDOWN_MS = 60 * 60 * 1000
 /** Number of Claude turns before showing a context compression warning. */
 const CONTEXT_WARNING_TURN_THRESHOLD = 15
 /** Second warning at this threshold. */
@@ -129,6 +150,13 @@ export class SessionManager {
   private sessionLifecycle: SessionLifecycle
   /** Interval handle for the idle session reaper. */
   private _idleReaperInterval: ReturnType<typeof setInterval> | null = null
+  /**
+   * Timestamp (epoch ms) at which the rate-limit circuit breaker expires.
+   * Background pollers (e.g. the orchestrator monitor) check {@link isRateLimited}
+   * before doing API work, so a single rate-limit hit doesn't generate more
+   * traffic until either the cooldown elapses or the user clears it.
+   */
+  private _rateLimitedUntil = 0
 
   constructor() {
     this.archive = new SessionArchive()
@@ -168,6 +196,7 @@ export class SessionManager {
       onToolDoneEvent: (session, toolName, summary) => this.onToolDoneEvent(session, toolName, summary),
       handleClaudeResult: (session, sessionId, result, isError) => this.handleClaudeResult(session, sessionId, result, isError),
       buildSessionContext: (session) => this.buildSessionContext(session),
+      onRateLimitEvent: (session, sessionId, event) => this.onRateLimitEvent(session, sessionId, event),
     })
     this.sessionPersistence = new SessionPersistence(this.sessions)
     this.sessionNaming = new SessionNaming({
@@ -218,22 +247,64 @@ export class SessionManager {
       }
     }
 
-    // Prune stale sessions: no process, no clients, older than STALE_SESSION_AGE_MS
-    // Headless sessions are exempt from stale pruning — they are long-lived by design.
+    // Prune stale sessions: no process, no clients, older than the relevant
+    // age threshold. Interactive sessions and most headless sessions are
+    // pruned (with different thresholds). The orchestrator session is the
+    // only true singleton — it's exempt from age-based prune because its
+    // identity is recreated by the orchestrator manager if missing, and
+    // pruning it would silently drop accumulated memory.
     const staleIds: string[] = []
     for (const session of this.sessions.values()) {
-      if (isHeadlessSession(session)) continue
       if (session.claudeProcess?.isAlive()) continue
       if (session.clients.size > 0) continue
+      if (session.source === 'orchestrator') continue
+      const headless = isHeadlessSession(session)
+      const threshold = headless ? HEADLESS_STALE_AGE_MS : STALE_SESSION_AGE_MS
       const ageMs = now - new Date(session.created).getTime()
-      if (ageMs > STALE_SESSION_AGE_MS) {
+      if (ageMs > threshold) {
         staleIds.push(session.id)
       }
     }
     for (const id of staleIds) {
-      console.log(`[idle-reaper] pruning stale session=${id} (age > ${STALE_SESSION_AGE_MS / 86_400_000}d)`)
+      const s = this.sessions.get(id)
+      const days = s ? Math.round((now - new Date(s.created).getTime()) / 86_400_000) : 0
+      console.log(`[idle-reaper] pruning stale session=${id} source=${s?.source ?? '?'} age=${days}d`)
       this.delete(id)
     }
+  }
+
+  /**
+   * Whether the rate-limit circuit breaker is currently open.
+   * Background pollers (orchestrator monitor, future cron triggers) should
+   * check this before doing any Claude API work to avoid worsening a quota
+   * situation the user has already hit.
+   */
+  isRateLimited(): boolean {
+    return Date.now() < this._rateLimitedUntil
+  }
+
+  /**
+   * Handle a `rate_limit_event` from the Claude CLI stream.  Trips the
+   * circuit breaker and tells every connected client what happened so the
+   * user can stop the bleeding instead of discovering it in their billing
+   * console days later.
+   */
+  private onRateLimitEvent(session: Session, sessionId: string, event: Record<string, unknown>): void {
+    const now = Date.now()
+    const wasAlreadyTripped = now < this._rateLimitedUntil
+    this._rateLimitedUntil = now + RATE_LIMIT_COOLDOWN_MS
+    const minutes = Math.round(RATE_LIMIT_COOLDOWN_MS / 60_000)
+    const overage = typeof event.overageStatus === 'string' ? ` overageStatus=${event.overageStatus}` : ''
+    console.warn(`[rate-limit] session=${sessionId}${overage} — circuit breaker engaged for ${minutes}min`)
+    if (wasAlreadyTripped) return
+    const msg: WsServerMessage = {
+      type: 'system_message',
+      subtype: 'notification',
+      text: `Claude API rate limit hit. Pausing background activity (orchestrator monitor) for ${minutes} minutes so this idle install stops adding to your quota usage.`,
+    }
+    this.addToHistory(session, msg)
+    this.broadcast(session, msg)
+    this._globalBroadcast?.(msg)
   }
 
   // ---------------------------------------------------------------------------
@@ -963,6 +1034,21 @@ export class SessionManager {
     session.isProcessing = false
     session._claudeTurnCount++
     this._globalBroadcast?.({ type: 'sessions_updated' })
+
+    // Headless conversation cap: long-lived background sessions (orchestrator,
+    // workflow, etc.) accumulate context across every resume, and cache-read
+    // tokens grow with that context. Once a headless session has gone past
+    // MAX_HEADLESS_CONVERSATION_TURNS, drop claudeSessionId so the next process
+    // spawn starts a fresh Claude conversation and the per-call cost resets.
+    if (
+      isHeadlessSession(session) &&
+      session.claudeSessionId &&
+      session._claudeTurnCount > MAX_HEADLESS_CONVERSATION_TURNS
+    ) {
+      console.warn(`[headless-cap] session=${sessionId} source=${session.source} turns=${session._claudeTurnCount} > ${MAX_HEADLESS_CONVERSATION_TURNS} — clearing claudeSessionId so next spawn starts fresh`)
+      session.claudeSessionId = null
+      session._claudeTurnCount = 0
+    }
 
     // Attempt API retry for transient errors — returns true if a retry was scheduled
     if (isError && this.handleApiRetry(session, sessionId, result)) {


### PR DESCRIPTION
## Summary
Builds on #467 (quiet-mode defaults). Three layered guards so re-enabling background activity stays safe over time, plus a circuit breaker for rate-limit events and recovery UX for the runaway-token bug.

- **Headless conversation cap (100 turns)** — long-lived headless sessions (orchestrator above all) accumulate context across every resume; cache-read tokens grow with that context. After 100 completed Claude turns the session's `claudeSessionId` is reset so the next spawn starts a fresh Claude conversation. Bounds the per-call cost regardless of how long the install runs.
- **Headless stale-prune (30 days)** — non-orchestrator headless sessions (webhook/workflow/stepflow/agent) that have been dead and clientless for 30+ days are deleted. Prior behaviour exempted *all* headless sessions from age-based prune, so old metadata accumulated indefinitely. The orchestrator session is exempt (it's the only true singleton — its identity is recreated by the orchestrator manager if missing, so pruning would silently drop accumulated memory).
- **Rate-limit circuit breaker** — Claude's stream-json `rate_limit_event` is now plumbed through to a `SessionManager.isRateLimited()` flag with a 60-min cooldown. The orchestrator monitor checks it before polling **and** before delivering notifications. Connected clients get a one-time system message explaining what happened, so the user notices before their billing console does.
- **Recovery UX** — `codekin stop` subcommand + LaunchAgent change. macOS plist switched from `KeepAlive=true` to `KeepAlive: {SuccessfulExit: false}` so a clean SIGTERM is no longer respawned (crashes still restart). systemd unit switched from `Restart=always` → `Restart=on-failure` for parity. `codekin stop` wraps `launchctl unload` / `systemctl --user stop codekin` and prints next-step hints. Existing installs need to re-run `codekin service install` to pick up the new plist/unit.

## Why this matters
The bug report driving #467 showed an idle install burning ~14M cache-read tokens/day and hitting the 5-hour message limit. #467 stops the bleeding by defaulting background activity off, but anyone who opts back in (or runs a hosted/team install) needs the bleeding to stay stopped. (1) caps per-call cost growth, (2) cleans up old metadata, (3) actually reacts to rate-limit signals instead of polling through them. (4) ensures users can _escape_ a misbehaving install without manually editing plists.

## Changes
- `server/claude-process.ts` — emit a typed `'rate_limit'` event when `rate_limit_event` arrives in stdin; remove from the "unhandled" warning list.
- `server/session-lifecycle.ts` — wire `cp.on('rate_limit', ...)` to a new `onRateLimitEvent` dep.
- `server/session-manager.ts` —
  - `MAX_HEADLESS_CONVERSATION_TURNS = 100`, `HEADLESS_STALE_AGE_MS = 30d`, `RATE_LIMIT_COOLDOWN_MS = 1h`
  - `handleClaudeResult` clears `claudeSessionId` for headless sessions past the turn cap
  - `reapIdleSessions` now applies a per-source threshold (orchestrator exempt)
  - new `isRateLimited()` + `onRateLimitEvent()` private handler that broadcasts a notification once per cooldown window
- `server/orchestrator-monitor.ts` — `poll()` and `deliverToOrchestrator()` early-return when `isRateLimited()` is true.
- `bin/codekin.mjs` — `codekin stop` command + macOS plist `KeepAlive` dict + systemd `Restart=on-failure`.
- `server/session-manager.test.ts` — 10 new tests covering all three SessionManager behaviours (turn-cap reset, headless stale prune with orchestrator exemption, circuit-breaker engage/clear/de-dupe).

## Test plan
- [x] `npm run build` — passes
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 2053 tests pass (was 2043; +10 new)
- [x] `node bin/codekin.mjs` (help) and `node bin/codekin.mjs stop` — smoke-tested on Linux
- [ ] Manual macOS: `codekin service install` → verify new plist; `codekin stop` → confirm no respawn; reboot → confirm RunAtLoad starts it again
- [ ] Manual Linux: `codekin service install` → `codekin stop` → confirm process is gone and `systemctl --user start codekin` brings it back
- [ ] Manual: with `CODEKIN_ORCHESTRATOR_MONITOR=true`, simulate a `rate_limit_event` and verify the next 15-min poll is skipped with a `circuit breaker open` log line
- [ ] Manual: confirm a headless session passing 100 turns logs `[headless-cap]` and starts fresh on next spawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)