### PR TITLE
fix(rate-limit): make notification text honest about backoff vs quota

### DIFF
--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -285,9 +285,12 @@ export class SessionManager {
 
   /**
    * Handle a `rate_limit_event` from the Claude CLI stream.  Trips the
-   * circuit breaker and tells every connected client what happened so the
-   * user can stop the bleeding instead of discovering it in their billing
-   * console days later.
+   * circuit breaker and surfaces a notification to every connected client.
+   *
+   * The notification deliberately does NOT claim anything about *which*
+   * Anthropic limit was hit (5-hour session window vs. weekly bucket) or
+   * when it resets — the event payload doesn't tell us that, and the
+   * cooldown is a local Codekin backoff, not a quota reset.
    */
   private onRateLimitEvent(session: Session, sessionId: string, event: Record<string, unknown>): void {
     const now = Date.now()
@@ -300,7 +303,7 @@ export class SessionManager {
     const msg: WsServerMessage = {
       type: 'system_message',
       subtype: 'notification',
-      text: `Claude API rate limit hit. Pausing background activity (orchestrator monitor) for ${minutes} minutes so this idle install stops adding to your quota usage.`,
+      text: `Claude reported a rate-limit event. Codekin will skip background polls (orchestrator monitor) for the next ${minutes} min as a local backoff. This is not your Claude quota reset — check your Anthropic usage page for the actual 5-hour session and weekly limit windows.`,
     }
     this.addToHistory(session, msg)
     this.broadcast(session, msg)


### PR DESCRIPTION
## Summary
The rate-limit notification added in #468 was misleading. It said:

> Claude API rate limit hit. Pausing background activity (orchestrator monitor) for 60 minutes so this idle install stops adding to your quota usage.

Two wrong claims:
1. **\"60 minutes\" implied a quota window.** Claude Max plans have a 5-hour rolling session window AND weekly buckets (All models, Sonnet-only, Claude Design). A bare \`rate_limit_event\` doesn't tell us which limit was hit, and our 60-min cooldown matches none of them — it's a local Codekin backoff.
2. **\"stops adding to your quota usage\" is overstated.** Pausing the orchestrator monitor only stops Codekin's own background polling. Interactive sessions still consume quota. The phrase suggested a stronger guarantee than we deliver.

New text is honest about what we know and don't:

> Claude reported a rate-limit event. Codekin will skip background polls (orchestrator monitor) for the next 60 min as a local backoff. This is not your Claude quota reset — check your Anthropic usage page for the actual 5-hour session and weekly limit windows.

## Test plan
- [x] \`npm run build\` — passes
- [x] \`npm run lint\` — 0 errors
- [x] \`npm test\` — 246 tests pass in session-manager.test.ts (no test asserted on the old text, so no test churn needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)