### PR TITLE
fix(rate-limit): only trip circuit breaker on overageStatus=rejected

### DIFF
--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -3827,7 +3827,7 @@ describe('SessionManager', () => {
     it('clears after cooldown elapses', () => {
       vi.useFakeTimers()
       const s = sm.create('test', '/tmp')
-      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event' })
+      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event', overageStatus: 'rejected' })
       expect(sm.isRateLimited()).toBe(true)
       // RATE_LIMIT_COOLDOWN_MS is 60 minutes; advance just past it
       vi.advanceTimersByTime(60 * 60 * 1000 + 1)
@@ -3840,12 +3840,29 @@ describe('SessionManager', () => {
       const ws = fakeWs()
       sm.join(s.id, ws)
 
-      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event' })
+      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event', overageStatus: 'rejected' })
       const firstCallCount = ws.send.mock.calls.length
 
       // A second event during the same cooldown should not re-broadcast
-      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event' })
+      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event', overageStatus: 'rejected' })
       expect(ws.send.mock.calls.length).toBe(firstCallCount)
+    })
+
+    it('does NOT engage on informational rate_limit_event without overageStatus', () => {
+      // The Claude CLI emits status-style rate_limit_events around startup
+      // and after turns even when the user is well under quota (~8% session,
+      // ~14% weekly). Tripping the breaker on these is a false alarm.
+      const s = sm.create('test', '/tmp')
+      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event' })
+      expect(sm.isRateLimited()).toBe(false)
+    })
+
+    it('does NOT engage when overageStatus is anything other than "rejected"', () => {
+      const s = sm.create('test', '/tmp')
+      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event', overageStatus: 'warning' })
+      expect(sm.isRateLimited()).toBe(false)
+      ;(sm as any).onRateLimitEvent(s, s.id, { type: 'rate_limit_event', overageStatus: 'ok' })
+      expect(sm.isRateLimited()).toBe(false)
     })
   })
 

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -284,26 +284,42 @@ export class SessionManager {
   }
 
   /**
-   * Handle a `rate_limit_event` from the Claude CLI stream.  Trips the
-   * circuit breaker and surfaces a notification to every connected client.
+   * Handle a `rate_limit_event` from the Claude CLI stream.
    *
-   * The notification deliberately does NOT claim anything about *which*
-   * Anthropic limit was hit (5-hour session window vs. weekly bucket) or
-   * when it resets — the event payload doesn't tell us that, and the
-   * cooldown is a local Codekin backoff, not a quota reset.
+   * The CLI emits this event for several distinct situations — observed in
+   * practice with `overageStatus` either absent (informational status update,
+   * e.g. emitted around process startup / shortly after each turn) or set
+   * to a value like 'rejected' (the request was blocked by Anthropic's
+   * quota enforcement). Only the second case warrants tripping the circuit
+   * breaker: tripping on the informational variant fires false alarms even
+   * when the user is at 8% session / 14% weekly usage.
+   *
+   * Until we have an authoritative list of overageStatus values, treat
+   * 'rejected' as the only definitive "blocked" signal and log everything
+   * else for diagnostics.
    */
   private onRateLimitEvent(session: Session, sessionId: string, event: Record<string, unknown>): void {
+    const overageStatus = typeof event.overageStatus === 'string' ? event.overageStatus : null
+    // Always log so we can see what payloads the CLI actually sends —
+    // helpful for expanding the trigger list if we learn about more
+    // blocking statuses (e.g. 'exceeded'). Truncate to keep the line short.
+    console.log(`[rate-limit-event] session=${sessionId} overageStatus=${overageStatus ?? '(none)'} payload=${JSON.stringify(event).slice(0, 300)}`)
+
+    if (overageStatus !== 'rejected') {
+      // Informational / status-only event — don't engage the breaker.
+      return
+    }
+
     const now = Date.now()
     const wasAlreadyTripped = now < this._rateLimitedUntil
     this._rateLimitedUntil = now + RATE_LIMIT_COOLDOWN_MS
     const minutes = Math.round(RATE_LIMIT_COOLDOWN_MS / 60_000)
-    const overage = typeof event.overageStatus === 'string' ? ` overageStatus=${event.overageStatus}` : ''
-    console.warn(`[rate-limit] session=${sessionId}${overage} — circuit breaker engaged for ${minutes}min`)
+    console.warn(`[rate-limit] session=${sessionId} overageStatus=rejected — circuit breaker engaged for ${minutes}min`)
     if (wasAlreadyTripped) return
     const msg: WsServerMessage = {
       type: 'system_message',
       subtype: 'notification',
-      text: `Claude reported a rate-limit event. Codekin will skip background polls (orchestrator monitor) for the next ${minutes} min as a local backoff. This is not your Claude quota reset — check your Anthropic usage page for the actual 5-hour session and weekly limit windows.`,
+      text: `Claude rejected a request with rate-limit overage. Codekin will skip background polls (orchestrator monitor) for the next ${minutes} min as a local backoff. This is not your Claude quota reset — check your Anthropic usage page for the actual 5-hour session and weekly limit windows.`,
     }
     this.addToHistory(session, msg)
     this.broadcast(session, msg)


### PR DESCRIPTION
## Summary
The circuit breaker added in #468 was firing false alarms.

**Investigation**: on a deployed install with the user at 8% session / 14% weekly quota, \`/home/dev/.pm2/logs/codekin-out.log\` showed:

\`\`\`
[event] type=rate_limit_event subtype=-
[rate-limit] session=… — circuit breaker engaged for 60min
[event] type=rate_limit_event subtype=-
[rate-limit] session=… — circuit breaker engaged for 60min
…
\`\`\`

The \`[rate-limit]\` log line had no \`overageStatus=…\` printed — meaning \`event.overageStatus\` was undefined. The Claude CLI evidently emits \`rate_limit_event\` as an informational status update too (around startup / after turns), not only on hard blocks. The original bug report we built #468 for explicitly cited \`rate_limit_event ... overageStatus=rejected\` as the rejection signal — informational events without that status shouldn't trip the breaker.

## Change
\`server/session-manager.ts\`: \`onRateLimitEvent\` now:
- Always logs the full event payload (truncated to 300 chars) for diagnostics, so we can learn about other blocking statuses (e.g. \`exceeded\`) if they exist.
- Returns early without tripping unless \`overageStatus === 'rejected'\`.
- Updated user-facing notification text: \"Claude rejected a request with rate-limit overage…\" — accurate now that we only fire on actual rejection.

## Tests
- Updated existing tests to pass \`overageStatus: 'rejected'\` where they expect a trip.
- Added two new tests confirming informational events (no \`overageStatus\`, or \`'warning'\` / \`'ok'\`) leave the breaker open.
- \`npm test\` — 2063 pass (+2 new)
- \`npm run build\` — passes
- \`npm run lint\` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)