### PR TITLE
chore: security quick-wins + docs refresh (L1/M3/M4 + CHANGELOG + env vars + WORKFLOWS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,139 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Features
+## [0.6.5] - 2026-05-14
+
+### Added
+- Enforce single-branch report commit for AI workflows (#472)
+- Add ecosystem.config.cjs.example with interpreter pin (#471)
+- Notify parent session immediately when orchestrator child terminates (#462, #463)
+
+### Changed
+- Default to quiet mode — no boot-time Claude spawns or 15-minute monitor (#467)
+
+### Fixed
+- Only trip circuit breaker on `overageStatus=rejected` (#470)
+- Make rate-limit notification text honest about backoff vs quota (#469)
+- Cap headless session lifetime and circuit-break on rate limits (#468)
+- Roll back dedup key on `startRun` failure; harden GitHub slug parser (#465)
+- Fork audit branches from `origin/main` and restore main checkout (#457, #461)
+
+### Security
+- Sanitize commit-event prompt input, remove duplicate report write (#455)
+- Validate commit-event repoPath, `set_permission_mode` WS check, dep alignment (#454)
+- Canonicalize clone destination to prevent symlink escape (C1) (#453)
+- Validate `permissionMode` at runtime on session creation (#452)
+- Cron DoS, path traversal, dedup scoping, PATCH validation (#449)
+
+### Chores
+- Repo-health cleanup: orphaned dist, WS docs, tsconfig (#451)
+- Bump marked from 17 to 18.0.2 (#450)
+- Bump @multiplier-labs/stepflow to 0.3.4 (#445)
+- Add `isWorkflowReportsBranch` to workflow-loader mock (#448)
+- Add code-review and security audit reports for 2026-04-30 (#456)
+
+## [0.6.4] - 2026-04-28
+
+### Added
+- Workflow engine restart resume and orphan session handling (#437)
+- Unified ProcessCoordinator for session lifecycle (#404)
+- Auto-setup GitHub webhook for PR Review workflows (#391)
+- Add Claude Opus 4.7 to available models (#421)
+
+### Fixed
+- Single output path per audit + fresh branch per run (#441)
+- Silence passive-repo alert for repos with no enabled workflows (#436)
+- WS rate-limit bypass, gh call timeouts, and prompt-timeout docs alignment (#435)
+- hooksPath resolution and CORS PATCH method (#432)
+- Nested reports path, narrow CSP connect-src, and API docs drift (#426)
+- Canonicalize repos_path and namespace local repo storage by owner (#425)
+- Validate repoPath and cron expression on workflow/orchestrator routes (#423)
+- Add hard key caps to auth and webhook rate-limiter maps (#418)
+- Prevent JSON injection in commit-event-hook.sh (#417)
+- Prevent symlink bypass in spawn route (#419)
+- Harden docs browser root scope and persist canonical paths (#409)
+- Widen Edit Workflow modal to prevent day label clipping (#408)
+- Prevent spurious reconfigure when model is first assigned to a new session (#407)
+- Polish Edit Workflow modal layout (#401, #403, #405)
+- Streamline Edit Workflow modal layout (#401)
+- Address GPT review feedback on report commit robustness (#400)
+- Unify workflow report commit/push across MD and Stepflow systems (#398)
+- Add API rate limiter map cap and attachment file size limit (#397)
+- Harden path traversal, trust proxy, and image src allowlist (#394)
+- Improve Edit Workflow modal layout with two-column design (#393)
+- Roll window at boundary, not after (W5) (#438)
+- Guard realpathSync in clone route (W4) (#438)
+- Require Origin header in production WS handshake (W3) (#438)
+- Clean up hooks for fully-removed repos (W2) (#438)
+- Reject cron step value of 0 (W1) (#438)
+
+### Security
+- Harden settings repos-path and rate-limit child spawn (#431)
+
+### Refactoring
+- Decompose App.tsx into focused hooks (#416)
+- Split orchestrator-routes.ts into focused sub-routers (#415)
+
+### Tests
+- Cover server coverage gaps: stepflow-prompt, session-persistence, version-check, webhook-handler-base, tool-labels, orchestrator-learning-router, orchestrator-routes, webhook-routes, commit-event-handler, error-page (#440)
+- Cover auth, docs, session, workflow, and commit-event route handlers (#427, #428)
+
+### Documentation
+- Document H1 + M5 security error responses (#433)
+- Address 2026-04-22 docs-audit findings (#429)
+- Cleanup docs for Apr 15 audit — add PR review, cross-references, roadmap restructure (#414)
+- Document WebSocket rate limiting and workflow restart-resume (#439)
+- Session initiation audit report (#399)
+
+### Chores
+- Enforce strict @typescript-eslint/no-unsafe-* rules across codebase (#410, #411)
+- Align server TS version and widen ESLint server glob (#430)
+- Remove three unused exports (#434)
+- Remove leftover blank line from debug lifecycle log cleanup (#420)
+- Bump dompurify to 3.4.0 and better-sqlite3 to 12.9.0 (#424)
+
+## [0.6.3] - 2026-04-14
+
+### Fixed
+- Resolve duplicate model messages and mixed thinking text for OpenCode sessions (#385)
+- Persist OpenCode model selection across sessions (#384)
+- Only show model info once per session instead of every turn (#383)
+- Show 'Session started' immediately instead of empty chat on startup (#386)
+- Prevent model/session message cascade on OpenCode session start (#387, #388, #389)
+- Separate reasoning from text in OpenCode streaming for Kimi (#388)
+
+## [0.6.2] - 2026-04-12
+
+### Added
+- Provider selection and searchable model picker in workflows (#375)
+- GitHub webhook integration health checks and setup wizard (#373)
+
+### Fixed
+- Resolve deadlock preventing Claude session start (#382)
+- Overhaul session lifecycle to fix crashes, message loss, and duplicate notifications (#381)
+- Prevent message loss when Claude process exits before system_init (#380)
+- Prevent session restart loops from process lifecycle races (#379)
+- Preserve user input for session naming (#378)
+- Persist OpenCode provider when saving workflow config (#377)
+- Probe OpenCode availability on startup for accurate connection status (#376)
+- Tighten retry regex patterns and dedupe model dropdown entries (#372)
+- Set NODE_ENV=test in vitest config to prevent act-is-not-a-function failures (#371)
+
+## [0.6.1] - 2026-04-11
+
+### Added
 - **Connection status popup** — Real-time provider health indicators with disable/enable toggles (#346)
 - **PR Review workflow** — Add PR Review as event-driven workflow kind in Workflows UI (#334)
+- Show disconnected message for OpenCode sessions (#345)
+- Model picker with search, recents, and keyboard navigation (#368)
 
-### Fixes
+### Fixed
+- Resolve ESLint template literal error in claude-process (#369)
+- Address 5 small issues from audit reports (#366)
+- Validate model when switching between claude and opencode sessions (#363)
+- Add missing _isStarting property to restored sessions (#361)
+- Prevent symlink-based path traversal in docs and reports endpoints (#358)
+- Address 4 server correctness bugs found in code review (#359)
 - Restore `wss:`/`ws:` in CSP connect-src to unbreak WebSocket connections (#356)
 - Harden server security: auth token in headers only, rate limiting, CSP, WebSocket origin validation (#355)
 - Strip GIT_* env vars from OpenCode server to fix worktree git operations (#353)
@@ -21,7 +149,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prevent false session resets from aggressive zombie detection and leave grace period (#349)
 - Provider disabled overlay and input bar UX improvements (#348)
 - Disable input and show message when provider is disabled (#347)
-- Show disconnected message for OpenCode sessions (#345)
 - Use FilePartInput format for image attachments in OpenCode sessions (#343)
 - Strip user echo, handle reasoning deltas, and support text file attachments in OpenCode (#342)
 - Make model dropdown scrollable with max 10 visible items (#341)
@@ -31,6 +158,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Refactoring
 - Migrate to open-source @multiplier-labs/stepflow (#333)
+
+### Documentation
+- Update changelog and README to feature OpenCode support (#357)
 
 ## [0.6.0] - 2026-04-10
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,6 +46,8 @@ The server reads its configuration from environment variables defined in `server
 | `AUTH_TOKEN_FILE` | No | — | Path to file containing the auth token (legacy bare-metal deploy compat) |
 | `TRUST_PROXY` | No | `false` | Trust `X-Forwarded-For` headers (`true` or `1` to enable; set when behind a reverse proxy) |
 | `CODEKIN_AGENT_NAME` | No | `Joe` | Display name for the orchestrator agent |
+| `CODEKIN_AUTO_RESTORE_SESSIONS` | No | `false` | Auto-restart Claude processes that were alive at previous shutdown (`true` to opt in) |
+| `CODEKIN_ORCHESTRATOR_MONITOR` | No | `false` | Run the orchestrator proactive monitor (15-minute polling) (`true` to opt in) |
 
 ### Running Tests
 

--- a/docs/INSTALL-DISTRIBUTION.md
+++ b/docs/INSTALL-DISTRIBUTION.md
@@ -141,6 +141,8 @@ All configuration is via environment variables. Defaults suit a local install; o
 | `CORS_ORIGIN` | `http://localhost:5173` | Restrict CORS for remote access |
 | `GH_ORG` | — | Comma-separated GitHub orgs for repo listing |
 | `SCREENSHOTS_DIR` | `~/.codekin/screenshots` | Directory for uploaded file storage |
+| `CODEKIN_AUTO_RESTORE_SESSIONS` | `false` | Auto-restart Claude processes that were alive at previous shutdown (`true` to opt in) |
+| `CODEKIN_ORCHESTRATOR_MONITOR` | `false` | Run the orchestrator proactive monitor (15-minute polling) (`true` to opt in) |
 
 For webhook-specific environment variables (`GITHUB_WEBHOOK_SECRET`, `GITHUB_WEBHOOK_ENABLED`, etc.), see the [webhook setup section in SETUP.md](./SETUP.md#10-configure-github-webhooks-optional).
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -63,6 +63,20 @@ Contents of `~/.config/codekin/env`:
 # Webhook-specific vars are configured in Step 10.
 ```
 
+Key server environment variables (see `server/config.ts` for the full list):
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `32352` | Main server port |
+| `CORS_ORIGIN` | `http://localhost:5173` | Allowed CORS origin (must be set in production) |
+| `AUTH_TOKEN` | — | Shared auth token for WebSocket and REST API |
+| `REPOS_ROOT` | `~/repos` | Root directory for cloned repositories |
+| `DATA_DIR` | `~/.codekin` | Codekin data directory |
+| `TRUST_PROXY` | `false` | Trust `X-Forwarded-For` headers (set when behind a reverse proxy) |
+| `CODEKIN_AGENT_NAME` | `Joe` | Display name for the orchestrator agent |
+| `CODEKIN_AUTO_RESTORE_SESSIONS` | `false` | Auto-restart Claude processes that were alive at previous shutdown (`true` to opt in) |
+| `CODEKIN_ORCHESTRATOR_MONITOR` | `false` | Run the orchestrator proactive monitor (15-minute polling) (`true` to opt in) |
+
 Source it from `~/.bashrc` so it's available to all shells and systemd user services:
 
 ```bash

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -11,7 +11,7 @@ Every workflow follows the same four-step execution model:
 1. **validate_repo** — Verify the repo path exists and is a git repository. If a `sinceTimestamp` is provided, skip the run if there are no new commits since that time.
 2. **create_session** — Create a Codekin session scoped to the repo.
 3. **run_prompt** — Start Claude, send the workflow prompt, and wait for a result (10-minute timeout).
-4. **save_report** — Write the output as a dated Markdown file into the repo, then commit it.
+4. **save_report** — Write the output as a dated Markdown file into the repo, commit it to a single dedicated branch (forked fresh from `origin/main` each run), and push.
 
 Workflow runs are triggered by cron schedules configured per-repo via the workflow API.
 
@@ -162,7 +162,7 @@ Choose a `kind` that doesn't conflict with existing workflows. The convention is
 
 ## Report Output
 
-Each generated report is saved as:
+Each workflow run produces a single report file at a consistent output path:
 
 ```
 {repo}/{outputDir}/{YYYY-MM-DD}{filenameSuffix}
@@ -184,4 +184,4 @@ The file begins with an auto-generated header:
 {Claude output}
 ```
 
-After saving, the report is automatically staged and committed to the repository using the configured `commitMessage` + date suffix.
+After saving, the report is automatically staged and committed. All workflow report commits for a given repo land on a **single dedicated branch** (`codekin/reports`) which is forked fresh from `origin/main` at the start of each run. This avoids polluting the main branch with report commits and ensures each run uses a single consistent output path with no duplication (#441, #472).

--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -224,6 +224,10 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
     // a resume.  Uses the full binary path + exact session UUID to avoid
     // matching unrelated processes.
     if (this.resume) {
+      // Guard against non-UUID values being interpolated into the pkill pattern
+      if (!/^[0-9a-f-]{36}$/i.test(this.sessionId)) {
+        throw new Error(`[claude-spawn] sessionId is not a valid UUID: ${this.sessionId}`)
+      }
       try {
         const pattern = `${CLAUDE_BINARY} .*(--resume|--session-id) ${this.sessionId}(\\s|$)`
         execFileSync('pkill', ['-f', pattern], { timeout: 2000, stdio: 'ignore' })
@@ -232,7 +236,12 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
       }
     }
 
-    console.log(`[claude-spawn] cwd=${this.workingDir} args=${JSON.stringify(args)}`)
+    const redactedArgs = args.map((a, i) =>
+      i > 0 && /^[0-9a-f-]{36}$/i.test(a) && ['--session-id', '--resume'].includes(args[i - 1])
+        ? '<redacted>'
+        : a,
+    )
+    console.log(`[claude-spawn] cwd=${this.workingDir} args=${JSON.stringify(redactedArgs)}`)
     this.proc = spawn(CLAUDE_BINARY, args, {
       cwd: this.workingDir,
       stdio: ['pipe', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

Bundle of small security hardening + docs refresh items from the 2026-05-13/14 audit reports.

### Code Changes

1. **L1 — Prod CORS misconfig fatal** — Already implemented (`process.exit(1)` present in `server/config.ts`). No change needed.
2. **M3 — Assert UUID v4 before pkill pattern** — Added regex guard on `this.sessionId` before interpolating into the `pkill -f` pattern string in `server/claude-process.ts`. Throws a clear error if the value isn't a valid UUID.
3. **M4 — Redact session ID from spawn-args log** — The `[claude-spawn]` log line now masks UUID values following `--session-id` and `--resume` flags with `<redacted>`.

### Docs Changes

4. **CHANGELOG.md** — Filled in entries for v0.6.1 through v0.6.5 using `git log v0.6.0..HEAD`, grouped by Added/Changed/Fixed/Security/etc per Keep-a-Changelog.
5. **Env var docs** — Added `CODEKIN_AUTO_RESTORE_SESSIONS` and `CODEKIN_ORCHESTRATOR_MONITOR` (both opt-in, introduced in #467) to the env var tables in CONTRIBUTING.md, docs/SETUP.md, and docs/INSTALL-DISTRIBUTION.md.
6. **WORKFLOWS.md** — Updated step 4 (save_report) and Report Output section to reflect single-branch enforcement (#472) and consistent output paths (#441).

### Source Reports
- `.codekin/reports/security/2026-05-14_security-audit.md`
- `.codekin/reports/docs-audit/2026-05-13_docs-audit.md`

## Verification
- [x] `tsc --noEmit` passes
- [x] `npm test` — 2066 tests pass
- [x] `npm run build` succeeds

## Test plan
- [ ] Verify UUID assertion fires correctly by inspecting the guard in `claude-process.ts`
- [ ] Verify redacted log output doesn't leak session IDs
- [ ] Spot-check CHANGELOG entries against `git log` for accuracy
- [ ] Confirm env var tables render correctly in all three docs files

🤖 Generated with [Claude Code](https://claude.com/claude-code)