### PR TITLE
fix(security): server-side magic-byte validation for uploads (M2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "better-sqlite3": "^12.9.0",
         "express": "^5.1.0",
+        "file-type": "^22.0.1",
         "multer": "^2.0.0",
         "ws": "^8.18.0"
       },
@@ -362,6 +363,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@bramus/specificity": {
@@ -1859,6 +1870,29 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -3739,6 +3773,24 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-22.0.1.tgz",
+      "integrity": "sha512-ww5Mhre0EE+jmBvOXTmXAbEMuZE7uX4a3+oRCQFNj8w++g3ev913N6tXQz0XTXbueQ5TWQfm6BdaViEHHn8bhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/file-uri-to-path": {
@@ -7077,6 +7129,22 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -7239,6 +7307,24 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -7388,6 +7474,18 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "better-sqlite3": "^12.9.0",
     "express": "^5.1.0",
+    "file-type": "^22.0.1",
     "multer": "^2.0.0",
     "ws": "^8.18.0"
   },

--- a/server/upload-routes.test.ts
+++ b/server/upload-routes.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import express from 'express'
 import type { AddressInfo } from 'net'
 import type { Server } from 'http'
-import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync, existsSync } from 'fs'
+import { mkdtempSync, symlinkSync, rmSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 

--- a/server/upload-routes.test.ts
+++ b/server/upload-routes.test.ts
@@ -1,12 +1,12 @@
 /**
- * Tests for upload-routes — covers the localRepoPath helper plus the clone
- * route's handling of an unresolvable repos root (W4).
+ * Tests for upload-routes — covers the localRepoPath helper, clone route
+ * handling, and magic-byte file signature validation (M2).
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import express from 'express'
 import type { AddressInfo } from 'net'
 import type { Server } from 'http'
-import { mkdtempSync, symlinkSync, rmSync } from 'fs'
+import { mkdtempSync, mkdirSync, symlinkSync, writeFileSync, rmSync, existsSync } from 'fs'
 import { join } from 'path'
 import { tmpdir } from 'os'
 
@@ -16,7 +16,18 @@ import { tmpdir } from 'os'
 
 const mocks = vi.hoisted(() => ({
   realpathThrows: false,
+  screenshotsDir: '',
 }))
+
+vi.mock('./config.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./config.js')>()
+  return {
+    ...actual,
+    get SCREENSHOTS_DIR() {
+      return mocks.screenshotsDir || actual.SCREENSHOTS_DIR
+    },
+  }
+})
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>()
@@ -197,5 +208,96 @@ describe('POST /api/clone — symlink escape (C1)', () => {
     })
     // Boundary check passes; clone itself may fail (no gh credentials) — not 400
     expect(res.status).not.toBe(400)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /api/upload — magic-byte file signature validation (M2)
+// ---------------------------------------------------------------------------
+
+describe('POST /api/upload — magic-byte validation (M2)', () => {
+  let server: Server
+  let baseUrl: string
+  let screenshotsDir: string
+
+  // Minimal valid PNG: 1×1 pixel, RGBA
+  const VALID_PNG = Buffer.from(
+    '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c489' +
+    '0000000a49444154789c626000000002000198e195280000000049454e44ae426082',
+    'hex',
+  )
+
+  // Minimal valid JPEG (SOI + APP0 JFIF marker + EOI)
+  const VALID_JPEG = Buffer.from(
+    'ffd8ffe000104a46494600010100000100010000ffd9',
+    'hex',
+  )
+
+  beforeEach(async () => {
+    mocks.realpathThrows = false
+    screenshotsDir = mkdtempSync(join(tmpdir(), 'codekin-upload-test-'))
+    mocks.screenshotsDir = screenshotsDir
+
+    const app = express()
+    app.use(createUploadRouter(
+      verifyToken,
+      extractToken as unknown as (req: express.Request) => string | undefined,
+    ))
+    server = app.listen(0)
+    await new Promise<void>(res => server.once('listening', () => res()))
+    const port = (server.address() as AddressInfo).port
+    baseUrl = `http://127.0.0.1:${port}`
+  })
+
+  afterEach(async () => {
+    await new Promise<void>(res => server.close(() => res()))
+    rmSync(screenshotsDir, { recursive: true, force: true })
+    mocks.screenshotsDir = ''
+  })
+
+  function uploadFile(filename: string, mime: string, content: Buffer) {
+    const boundary = '----TestBoundary' + Date.now()
+    const header = `--${boundary}\r\nContent-Disposition: form-data; name="file"; filename="${filename}"\r\nContent-Type: ${mime}\r\n\r\n`
+    const footer = `\r\n--${boundary}--\r\n`
+    const body = Buffer.concat([Buffer.from(header), content, Buffer.from(footer)])
+    return fetch(`${baseUrl}/api/upload`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${AUTH_TOKEN}`,
+        'Content-Type': `multipart/form-data; boundary=${boundary}`,
+      },
+      body,
+    })
+  }
+
+  it('accepts a valid PNG file', async () => {
+    const res = await uploadFile('test.png', 'image/png', VALID_PNG)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { success: boolean; path: string }
+    expect(body.success).toBe(true)
+  })
+
+  it('rejects a file with PNG extension/mime but JPEG bytes (signature mismatch)', async () => {
+    const res = await uploadFile('fake.png', 'image/png', VALID_JPEG)
+    expect(res.status).toBe(400)
+    const body = await res.json() as { error: string }
+    expect(body.error).toContain('signature mismatch')
+    expect(body.error).toContain('image/jpeg')
+  })
+
+  it('accepts a markdown file (no magic-byte check for text types)', async () => {
+    const md = Buffer.from('# Hello\n\nThis is a test document.\n')
+    const res = await uploadFile('readme.md', 'text/markdown', md)
+    expect(res.status).toBe(200)
+    const body = await res.json() as { success: boolean }
+    expect(body.success).toBe(true)
+  })
+
+  it('rejects a file with unknown binary signature claiming to be PNG', async () => {
+    const garbage = Buffer.from('not a real image file at all')
+    const res = await uploadFile('bad.png', 'image/png', garbage)
+    expect(res.status).toBe(400)
+    const body = await res.json() as { error: string }
+    expect(body.error).toContain('signature mismatch')
   })
 })

--- a/server/upload-routes.ts
+++ b/server/upload-routes.ts
@@ -8,8 +8,9 @@
 import { Router } from 'express'
 import type { Request } from 'express'
 import multer from 'multer'
-import { mkdirSync, existsSync, lstatSync, readFileSync, readdirSync, realpathSync } from 'fs'
+import { mkdirSync, existsSync, lstatSync, readFileSync, readdirSync, realpathSync, unlinkSync } from 'fs'
 import { join, extname, sep } from 'path'
+import { fileTypeFromFile } from 'file-type'
 import { execFile } from 'child_process'
 import { promisify } from 'util'
 import { homedir } from 'os'
@@ -186,6 +187,8 @@ export function createUploadRouter(
   })
   const ALLOWED_MIME_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp', 'text/markdown']
   const ALLOWED_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.md']
+  /** Binary MIME types that have detectable file signatures (magic bytes). */
+  const BINARY_MIME_TYPES = new Set(['image/png', 'image/jpeg', 'image/gif', 'image/webp'])
   const upload = multer({
     storage,
     limits: { fileSize: 20 * 1024 * 1024 },
@@ -221,12 +224,32 @@ export function createUploadRouter(
       }
       next()
     })
-  }, (req, res) => {
+  }, async (req, res) => {
     if (!req.file) {
       res.status(400).json({ error: 'No file uploaded' })
       return
     }
     const filePath = join(SCREENSHOTS_DIR, req.file.filename)
+
+    // Magic-byte validation for binary types — prevents polyglot/disguised files
+    if (BINARY_MIME_TYPES.has(req.file.mimetype)) {
+      try {
+        const detected = await fileTypeFromFile(filePath)
+        if (!detected || detected.mime !== req.file.mimetype) {
+          unlinkSync(filePath)
+          const actual = detected ? detected.mime : 'unknown'
+          res.status(400).json({
+            error: `File signature mismatch: claimed ${req.file.mimetype} but detected ${actual}`,
+          })
+          return
+        }
+      } catch {
+        unlinkSync(filePath)
+        res.status(400).json({ error: 'Failed to verify file signature' })
+        return
+      }
+    }
+
     console.log(`Saved file: ${filePath}`)
     res.json({ success: true, path: filePath })
   })


### PR DESCRIPTION
## Summary

- Adds server-side file signature (magic byte) validation for uploaded binary files (PNG, JPEG, GIF, WEBP) using the `file-type` library
- Rejects uploads where the claimed MIME type doesn't match the actual file signature, returning HTTP 400 with a descriptive error
- Text-based types (markdown) continue to use extension/MIME checks only, as they have no detectable file signatures

## Threat model

An attacker could upload a malicious file (e.g., a polyglot SVG-with-script or a disguised executable) by setting the correct `Content-Type` header and file extension while the actual file content is something else entirely. The existing validation only checked client-supplied headers, which are trivially spoofable. This fix reads the actual file bytes after upload and verifies the magic byte signature matches the claimed type before accepting the file.

Ref: `.codekin/reports/security/2026-05-14_security-audit.md`, finding M2.

## Changes

- **`package.json`**: Added `file-type` as a production dependency
- **`server/upload-routes.ts`**: After multer saves the file, binary uploads are verified with `fileTypeFromFile()`. Mismatches cause the file to be deleted and a 400 error returned
- **`server/upload-routes.test.ts`**: Added 4 tests covering: valid PNG accepted, PNG-claimed-but-JPEG-bytes rejected, markdown passthrough, garbage-bytes-as-PNG rejected

## Test plan

- [x] `npm run build` passes (typecheck + vite build)
- [x] `npx vitest run` — all 2070 tests pass
- [x] New tests verify signature match/mismatch/passthrough scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)