### PR TITLE
fix: group nested worktrees under canonical main repo in sidebar

### DIFF
--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -3085,7 +3085,8 @@ describe('SessionManager', () => {
       mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: any, cb?: any) => {
         if (typeof cb === 'function') {
           if (args[0] === 'rev-parse') {
-            cb(null, '/repos/myproject\n', '')
+            // --git-common-dir returns the main repo's .git directory
+            cb(null, '/repos/myproject/.git\n', '')
           } else {
             cb(null, '', '')
           }
@@ -3107,7 +3108,8 @@ describe('SessionManager', () => {
       mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: any, cb?: any) => {
         if (typeof cb === 'function') {
           if (args[0] === 'rev-parse') {
-            cb(null, '/repos/myproject\n', '')
+            // --git-common-dir returns the main repo's .git directory
+            cb(null, '/repos/myproject/.git\n', '')
           } else if (args[0] === 'worktree' && args[1] === 'add') {
             cb(new Error('fatal: worktree add failed'), '', 'fatal: worktree add failed')
           } else {
@@ -3133,7 +3135,8 @@ describe('SessionManager', () => {
       mockExecFile.mockImplementation((_cmd: string, args: string[], _opts: any, cb?: any) => {
         if (typeof cb === 'function') {
           if (args[0] === 'rev-parse') {
-            cb(null, '/repos/myproject\n', '')
+            // --git-common-dir returns the main repo's .git directory
+            cb(null, '/repos/myproject/.git\n', '')
           } else {
             cb(null, '', '')
           }
@@ -3483,7 +3486,8 @@ describe('SessionManager', () => {
         gitCalls.push(args)
         if (typeof cb === 'function') {
           if (args[0] === 'rev-parse') {
-            cb(null, '/repos/myproject\n', '')
+            // --git-common-dir returns the main repo's .git directory
+            cb(null, '/repos/myproject/.git\n', '')
           } else if (args[0] === 'show-ref') {
             // Branch does not exist yet
             cb(new Error('not found'), '', '')
@@ -3511,7 +3515,8 @@ describe('SessionManager', () => {
         gitCalls.push(args)
         if (typeof cb === 'function') {
           if (args[0] === 'rev-parse') {
-            cb(null, '/repos/myproject\n', '')
+            // --git-common-dir returns the main repo's .git directory
+            cb(null, '/repos/myproject/.git\n', '')
           } else if (args[0] === 'show-ref') {
             // Branch already exists
             cb(null, '', '')
@@ -3538,7 +3543,8 @@ describe('SessionManager', () => {
         gitCalls.push(args)
         if (typeof cb === 'function') {
           if (args[0] === 'rev-parse') {
-            cb(null, '/repos/myproject\n', '')
+            // --git-common-dir returns the main repo's .git directory
+            cb(null, '/repos/myproject/.git\n', '')
           } else if (args[0] === 'show-ref') {
             // Branch exists
             cb(null, '', '')
@@ -3566,7 +3572,8 @@ describe('SessionManager', () => {
         gitCalls.push(args)
         if (typeof cb === 'function') {
           if (args[0] === 'rev-parse') {
-            cb(null, '/repos/myproject\n', '')
+            // --git-common-dir returns the main repo's .git directory
+            cb(null, '/repos/myproject/.git\n', '')
           } else if (args[0] === 'show-ref') {
             cb(null, '', '') // branch exists
           } else {
@@ -3593,7 +3600,8 @@ describe('SessionManager', () => {
         gitCalls.push(args)
         if (typeof cb === 'function') {
           if (args[0] === 'rev-parse') {
-            cb(null, '/repos/myproject\n', '')
+            // --git-common-dir returns the main repo's .git directory
+            cb(null, '/repos/myproject/.git\n', '')
           } else if (args[0] === 'show-ref') {
             cb(new Error('not found'), '', '') // branch doesn't exist
           } else {
@@ -3620,7 +3628,8 @@ describe('SessionManager', () => {
         gitCalls.push(args)
         if (typeof cb === 'function') {
           if (args[0] === 'rev-parse') {
-            cb(null, '/repos/myproject\n', '')
+            // --git-common-dir returns the main repo's .git directory
+            cb(null, '/repos/myproject/.git\n', '')
           } else if (args[0] === 'show-ref') {
             cb(null, '', '') // branch exists
           } else {

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -444,16 +444,25 @@ export class SessionManager {
     if (!session) return null
 
     try {
-      // Resolve the actual git repo root — workingDir may be a subdirectory
+      // Resolve the canonical (main) repo root.
+      // --git-common-dir points to the main repo's .git even when called from
+      // inside a worktree, so its parent is always the main repo working tree.
+      // (Plain --show-toplevel would return the *current* worktree path,
+      // causing nested worktrees and a separate sidebar group bug.)
       const env = cleanGitEnv()
-      const { stdout: repoRootRaw } = await execFileAsync('git', ['rev-parse', '--show-toplevel'], {
-        cwd: workingDir,
-        env,
-        timeout: 5000,
-      })
-      const repoRoot = repoRootRaw.trim()
-      if (!repoRoot || !path.isAbsolute(repoRoot)) {
-        console.error(`[worktree] Invalid repo root resolved: "${repoRoot}"`)
+      const { stdout: commonDirRaw } = await execFileAsync(
+        'git',
+        ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+        { cwd: workingDir, env, timeout: 5000 },
+      )
+      const commonDir = commonDirRaw.trim()
+      if (!commonDir || !path.isAbsolute(commonDir)) {
+        console.error(`[worktree] Invalid git common dir resolved: "${commonDir}"`)
+        return null
+      }
+      const repoRoot = path.dirname(commonDir)
+      if (!path.isAbsolute(repoRoot)) {
+        console.error(`[worktree] Invalid repo root derived from common dir: "${repoRoot}"`)
         return null
       }
 


### PR DESCRIPTION
## Summary

- `createWorktree()` resolved `repoRoot` via `git rev-parse --show-toplevel`, which from inside a worktree returns the worktree's own path rather than the main repo. The resulting session's `groupDir` then pointed at the parent worktree, causing the sidebar to display it as a separate repo group (e.g. `codekin-wt-69f7a2b7` alongside `codekin`).
- Switch to `git rev-parse --path-format=absolute --git-common-dir`; its parent is always the canonical main repo regardless of which worktree the command runs in. Used for both worktree placement and `groupDir`.
- Test mocks updated to return the `.git` common dir path.

## Test plan
- [x] `npx vitest run server/session-manager.test.ts` — all 248 tests pass
- [x] `npm run build` — typecheck + bundle clean
- [ ] Manual verification: spawn an orchestrator child against a repo path that is itself a worktree; confirm the child session appears under the main repo group (not a separate `*-wt-*` group)

🤖 Generated with [Claude Code](https://claude.com/claude-code)