### PR TITLE
fix: isolate session-naming claude -p from project context

### DIFF
--- a/server/session-naming.test.ts
+++ b/server/session-naming.test.ts
@@ -162,8 +162,11 @@ describe('SessionNaming', () => {
     expect(deps.rename).toHaveBeenCalledWith('s1', 'Fix Login Page Styling')
     expect(mockSpawn).toHaveBeenCalledWith(
       'claude',
-      ['-p', '--max-turns', '2', '--model', 'haiku'],
-      expect.objectContaining({ stdio: ['pipe', 'pipe', 'pipe'] }),
+      ['-p', '--max-turns', '1', '--model', 'haiku', '--tools', ''],
+      expect.objectContaining({
+        stdio: ['pipe', 'pipe', 'pipe'],
+        cwd: expect.any(String),
+      }),
     )
   })
 

--- a/server/session-naming.ts
+++ b/server/session-naming.ts
@@ -8,6 +8,7 @@
  */
 
 import { spawn } from 'node:child_process'
+import { tmpdir } from 'node:os'
 import type { Session, WsServerMessage } from './types.js'
 import { CLAUDE_BINARY } from './config.js'
 
@@ -48,10 +49,13 @@ function buildNamingEnv(): Record<string, string> {
 /** Generate a session name by spawning `claude -p` in one-shot mode. */
 function generateNameViaCLI(prompt: string): Promise<string> {
   return new Promise((resolve, reject) => {
-    // --max-turns 2: one turn to receive/process the prompt, one to reply with the name.
-    // Using 1 would sometimes cause the CLI to exit before producing output.
-    const proc = spawn(CLAUDE_BINARY, ['-p', '--max-turns', '2', '--model', 'haiku'], {
+    // Run in tmpdir so no project CLAUDE.md/hooks/skills get auto-loaded —
+    // those would inject unrelated context and the model ends up responding
+    // to that instead of the naming prompt. --tools "" disables tools so the
+    // model can't burn its single turn on a tool call.
+    const proc = spawn(CLAUDE_BINARY, ['-p', '--max-turns', '1', '--model', 'haiku', '--tools', ''], {
       stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: tmpdir(),
       env: buildNamingEnv(),
     })
 


### PR DESCRIPTION
## Summary
- Session naming was spawning \`claude -p\` without setting \`cwd\`, so it inherited the server process's working directory (a codekin checkout). Claude Code auto-loaded the project's \`CLAUDE.md\`, hooks, and skills, then responded to *that* context instead of the naming prompt — producing 40+ word essays like "I see the test failures are related to session cleanup timer functionality…" that failed the name validator. Every session ended up stuck as **"new session"** in the sidebar.
- \`--max-turns 2\` made it worse: the model had room to attempt tool calls, exhaust its turn budget, and time out the 15s window.

**Fix:** spawn in \`os.tmpdir()\` (no project files auto-load), pass \`--tools ""\` to disable tools, and drop \`--max-turns\` to 1.

Repro from production logs (\`~/.pm2/logs/codekin-out.log\`):
\`\`\`
[session-name] attempt 1 failed: claude -p timed out
[session-name] attempt 5 failed: claude -p timed out
[session-name] invalid name (259 chars, 43 words): "I see the test failures are related to session cleanup timer functionality. Wou..."
\`\`\`

After the fix, an end-to-end repro returns a clean 4-word name in ~13s on a cold cache (well under the 15s timeout).

## Test plan
- [x] \`npx vitest run server/session-naming.test.ts\` — 15/15 pass
- [x] \`npx vitest run server/session-manager.test.ts\` — 248/248 pass
- [x] \`npx tsc -b\` — clean
- [ ] After deploy, confirm new sessions get descriptive names within ~20s of the first response

🤖 Generated with [Claude Code](https://claude.com/claude-code)