### PR TITLE
fix: mock child_process in clone test to prevent CI timeout

### DIFF
--- a/server/upload-routes.test.ts
+++ b/server/upload-routes.test.ts
@@ -40,6 +40,27 @@ vi.mock('fs', async (importOriginal) => {
   }
 })
 
+// Stub child_process.execFile so `gh repo clone` fails instantly instead of
+// spawning a real process (which hangs in CI without GH_TOKEN).
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  return {
+    ...actual,
+    execFile: Object.assign(
+      (...args: unknown[]) => {
+        const cb = typeof args[args.length - 1] === 'function'
+          ? (args[args.length - 1] as (err: Error | null) => void)
+          : null
+        if (cb) {
+          process.nextTick(() => cb(new Error('gh stubbed in test')))
+        }
+      },
+      // Preserve custom promisify so util.promisify(execFile) works
+      { __promisify__: (..._args: unknown[]) => Promise.reject(new Error('gh stubbed in test')) },
+    ),
+  }
+})
+
 // Imported after vi.mock so the router picks up the mocked fs.
 import { localRepoPath, createUploadRouter } from './upload-routes.js'
 


### PR DESCRIPTION
## Summary
- The `allows clone when owner dir does not exist` test in `upload-routes.test.ts` was calling the real `gh repo clone` command, which takes >5s to fail in CI without `GH_TOKEN` — exceeding vitest's default 5000ms timeout (CI run #1174, both Node 20 and 22 matrices).
- Added a `vi.mock('child_process')` that stubs `execFile` to reject immediately, since the test only validates path-escape boundary logic (status != 400), not actual cloning.
- All 2070 tests pass; lint unchanged (0 errors).

## Test plan
- [x] `npx vitest run server/upload-routes.test.ts` — all 12 tests pass (73ms total, previously timed out at 10s+)
- [x] `npx vitest run` — full suite: 2070 passed, 0 failed
- [x] `npm run lint` — 0 errors
- [ ] CI passes on this PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)