### PR TITLE
fix: group webhook/stepflow sessions under canonical repo node

### DIFF
--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -255,4 +255,26 @@ describe('config', () => {
       expect(config.resolveRepoPathInRoot('/srv/repos/nonexistent')).toBeNull()
     })
   })
+
+  describe('resolveRepoGroupDir', () => {
+    it('prefers the owner-namespaced path when it exists', async () => {
+      process.env.REPOS_ROOT = '/srv/repos'
+      mockExistsSync.mockImplementation((p: unknown) =>
+        p === '/srv/repos' || p === '/srv/repos/Toggl/toggl_focus_fe')
+
+      const config = await loadConfig()
+      expect(config.resolveRepoGroupDir('Toggl/toggl_focus_fe', 'toggl_focus_fe'))
+        .toBe('/srv/repos/Toggl/toggl_focus_fe')
+    })
+
+    it('falls back to the flat path for older non-namespaced clones', async () => {
+      process.env.REPOS_ROOT = '/srv/repos'
+      // Only REPOS_ROOT exists; the owner-namespaced path does not.
+      mockExistsSync.mockImplementation((p: unknown) => p === '/srv/repos')
+
+      const config = await loadConfig()
+      expect(config.resolveRepoGroupDir('Toggl/toggl_focus_fe', 'toggl_focus_fe'))
+        .toBe('/srv/repos/toggl_focus_fe')
+    })
+  })
 })

--- a/server/config.ts
+++ b/server/config.ts
@@ -80,6 +80,24 @@ export function resolveRepoPathInRoot(repoPath: string): string | null {
   return resolved
 }
 
+/**
+ * Resolve the canonical local repo directory used to group sessions in the
+ * sidebar. Repos are cloned owner-namespaced (`REPOS_ROOT/owner/name`, see
+ * `localRepoPath` in upload-routes), and manual sessions group under that same
+ * path. Automated sessions (webhook, stepflow) must use the owner-namespaced
+ * path too — otherwise a flat `REPOS_ROOT/name` groupDir produces a second,
+ * duplicate repo node in the sidebar. Falls back to the flat layout for older
+ * flat clones that predate owner-namespacing.
+ *
+ * @param fullName GitHub `owner/name` (e.g. `repository.full_name`).
+ * @param repoName Bare repo name (e.g. `repository.name`).
+ */
+export function resolveRepoGroupDir(fullName: string, repoName: string): string {
+  const nested = `${REPOS_ROOT}/${fullName}`
+  if (existsSync(nested)) return nested
+  return `${REPOS_ROOT}/${repoName}`
+}
+
 /** Codekin data directory (sessions, approvals, workflows, etc.). */
 export const DATA_DIR = process.env.DATA_DIR || join(homedir(), '.codekin')
 

--- a/server/stepflow-handler.ts
+++ b/server/stepflow-handler.ts
@@ -73,7 +73,7 @@ import type {
 import { buildStepflowPrompt } from './stepflow-prompt.js'
 import { createWorkspace, cleanupWorkspace, commitReportsFromWorkspace } from './webhook-workspace.js'
 import { WebhookHandlerBase } from './webhook-handler-base.js'
-import { REPOS_ROOT } from './config.js'
+import { resolveRepoGroupDir } from './config.js'
 
 /**
  * How long an event may remain in `'processing'` before the watchdog marks it
@@ -355,7 +355,7 @@ export class StepflowHandler extends WebhookHandlerBase<StepflowEvent, StepflowE
 
     // Group under the canonical repo path so the UI places this session
     // alongside manual sessions for the same repo.
-    const groupDir = `${REPOS_ROOT}/${repoName}`
+    const groupDir = resolveRepoGroupDir(req.repo, repoName)
     const sessionName = `stepflow/${repoName}/${req.branch}/${kind}`
     this.sessions.create(sessionName, workspacePath, {
       source: 'stepflow',

--- a/server/webhook-handler.ts
+++ b/server/webhook-handler.ts
@@ -31,7 +31,7 @@ import { loadPrCache, ensureCacheDir, archivePrCache, deletePrCache } from './we
 import { buildPrompt } from './webhook-prompt.js'
 import { createWorkspace, cleanupWorkspace } from './webhook-workspace.js'
 import { WebhookHandlerBase } from './webhook-handler-base.js'
-import { REPOS_ROOT } from './config.js'
+import { resolveRepoGroupDir } from './config.js'
 
 /** How long an event can stay in 'processing' before the watchdog marks it as error. */
 const PROCESSING_TIMEOUT_MS = 5 * 60 * 1000
@@ -382,7 +382,7 @@ export class WebhookHandler extends WebhookHandlerBase<WebhookEvent, WebhookEven
     // --- Create session ---
     // Use the canonical repo path as groupDir so the frontend groups webhook
     // sessions under the same tab as manual sessions for the same repo.
-    const groupDir = `${REPOS_ROOT}/${repoName}`
+    const groupDir = resolveRepoGroupDir(repo, repoName)
     const sessionName = `webhook/${repoName}/${wr.head_branch}/${wr.name}`
     this.sessions.create(sessionName, workspacePath, {
       source: 'webhook',
@@ -663,7 +663,7 @@ export class WebhookHandler extends WebhookHandlerBase<WebhookEvent, WebhookEven
     }
 
     // --- Create session ---
-    const groupDir = `${REPOS_ROOT}/${repoName}`
+    const groupDir = resolveRepoGroupDir(repo, repoName)
     const sessionName = `review/${repoName}/PR-${prNumber}`
     this.sessions.create(sessionName, workspacePath, {
       source: 'webhook',


### PR DESCRIPTION
## Summary
- Webhook- and stepflow-initiated sessions appeared as a **second, duplicate repo node** in the sidebar for the same repo (see issue: same repo shown twice when GitHub webhooks spawn CI-fix sessions).
- Root cause: the sidebar groups by `groupKey(s) = s.groupDir ?? s.workingDir`. Webhook/stepflow handlers built `groupDir` as `${REPOS_ROOT}/${repoName}` (bare name), but repos are cloned **owner-namespaced** (`${REPOS_ROOT}/owner/name`, per `localRepoPath`), which is what manual sessions group under. The two differing paths produced two nodes with the same display name.
- Fix: added a shared `resolveRepoGroupDir(fullName, repoName)` helper in `server/config.ts` that prefers the owner-namespaced path and falls back to the flat layout for older clones. Wired into both webhook paths (CI triage + PR review) and the stepflow handler.

## Note
This corrects grouping for **new** sessions. Sessions already persisted with the old flat `groupDir` will keep showing separately until recreated; a one-time `sessions.json` migration could be added separately if desired.

## Test plan
- [x] `tsc -b` typecheck passes
- [x] `eslint` clean on changed files (only pre-existing warnings)
- [x] `vitest` — webhook (56), stepflow (43), config (27, incl. 2 new `resolveRepoGroupDir` cases) pass
- [ ] Manual: trigger a CI-failure webhook for a repo with an existing manual session; confirm the webhook session nests under the same sidebar node

🤖 Generated with [Claude Code](https://claude.com/claude-code)