### PR TITLE
fix: surface and resume archived sessions across repo clone paths

### DIFF
--- a/server/session-archive.test.ts
+++ b/server/session-archive.test.ts
@@ -145,6 +145,23 @@ describe('SessionArchive', () => {
       expect(result.map(r => r.id).sort()).toEqual(['direct-1', 'wt-1', 'wt-2'])
     })
 
+    it('matches sessions by repo basename when archived under a different parent path', () => {
+      // Same repo, two checkouts: an older/alternate clone and the current root.
+      archive.archive({ ...baseSession, id: 'alt-1', workingDir: '/srv/repos/project', groupDir: '/srv/repos/project' })
+      // Worktree of the current clone.
+      archive.archive({ ...baseSession, id: 'wt-1', workingDir: '/srv/repos/Org/project-wt-abc', groupDir: '/srv/repos/Org/project' })
+      // Unrelated repo with a different basename must NOT match.
+      archive.archive({ ...baseSession, id: 'other-1', workingDir: '/srv/repos/Org/other', groupDir: '/srv/repos/Org/other' })
+
+      const result = archive.list('/srv/repos/Org/project')
+      expect(result.map(r => r.id).sort()).toEqual(['alt-1', 'wt-1'])
+    })
+
+    it('does not match a repo whose name is a substring of the filter basename', () => {
+      archive.archive({ ...baseSession, id: 'sub-1', workingDir: '/srv/repos/proj', groupDir: '/srv/repos/proj' })
+      expect(archive.list('/srv/repos/project')).toEqual([])
+    })
+
     it('includes all ArchivedSessionInfo fields', () => {
       archive.archive(baseSession)
       const item = archive.list()[0]

--- a/server/session-archive.ts
+++ b/server/session-archive.ts
@@ -110,14 +110,24 @@ export class SessionArchive {
 
   /** List archived sessions (metadata only, no history). Optionally filtered by workingDir. */
   list(workingDir?: string): ArchivedSessionInfo[] {
+    // Match by exact path, but also by repo basename so a session archived from
+    // a different checkout of the same repo (a separate clone, or an older path
+    // before the repo was moved) still surfaces. The sidebar groups a repo under
+    // its canonical root (group_dir), so we compare the trailing path segment of
+    // group_dir (falling back to working_dir) against the requested basename.
+    // Trade-off: two distinct repos that share a basename (e.g. org-a/api and
+    // org-b/api) would share an archive list. No such collision exists today.
+    const basename = workingDir ? (workingDir.replace(/\/+$/, '').split('/').pop() ?? workingDir) : ''
+    const likeBasename = '%/' + basename.replace(/[\\%_]/g, c => '\\' + c)
     const rows = workingDir
       ? this.db.prepare(`
           SELECT id, name, working_dir, group_dir, source, created, archived_at,
                  json_array_length(output_history) as message_count
           FROM archived_sessions
           WHERE working_dir = ? OR group_dir = ?
+             OR COALESCE(group_dir, working_dir) LIKE ? ESCAPE '\\'
           ORDER BY archived_at DESC
-        `).all(workingDir, workingDir)
+        `).all(workingDir, workingDir, likeBasename)
       : this.db.prepare(`
       SELECT id, name, working_dir, group_dir, source, created, archived_at,
              json_array_length(output_history) as message_count

--- a/src/components/ArchivedSessionsPanel.tsx
+++ b/src/components/ArchivedSessionsPanel.tsx
@@ -138,7 +138,9 @@ export function ArchivedSessionsPanel({ token, visible, fontSize, workingDir, re
     if (!viewing || !onNewSessionFromArchive) return
     const messages = rebuildFromHistory(viewing.outputHistory)
     const context = buildContextSummary(messages, displayName(viewing))
-    onNewSessionFromArchive(viewing.workingDir, context)
+    // Prefer the canonical repo root (groupDir). The raw workingDir of a worktree
+    // session points at a now-deleted worktree path that matches no live repo.
+    onNewSessionFromArchive(viewing.groupDir ?? viewing.workingDir, context)
     setViewing(null)
     onClose?.()
   }, [viewing, onNewSessionFromArchive, onClose])

--- a/src/hooks/useSessionOrchestration.test.ts
+++ b/src/hooks/useSessionOrchestration.test.ts
@@ -301,4 +301,21 @@ describe('useSessionOrchestration', () => {
     expect(params.wsCreateSession).toHaveBeenCalledWith('hub:repo1', '/repo', false, 'default', undefined)
     unmount()
   })
+
+  it('handleNewSessionFromArchive: resolves repo by basename when path differs (worktree/alt clone)', () => {
+    // Registered repo lives at one path; the archived session was created from a
+    // different checkout of the same repo (e.g. a separate clone). Resume should
+    // still create a session in the canonical registered repo.
+    const repo = makeRepo({ id: 'repo1', workingDir: '/srv/repos/Org/project' })
+    params.repos = [repo]
+    params.useWorktreeRef = { current: false }
+    params.permissionModeRef = { current: 'default' }
+    const { result, unmount } = renderHook(() => useSessionOrchestration(params))
+
+    act(() => result.current.handleNewSessionFromArchive('/srv/repos/project', 'archived context'))
+
+    expect(params.pendingContextRef.current).toBe('archived context')
+    expect(params.wsCreateSession).toHaveBeenCalledWith('hub:repo1', '/srv/repos/Org/project', false, 'default', undefined)
+    unmount()
+  })
 })

--- a/src/hooks/useSessionOrchestration.ts
+++ b/src/hooks/useSessionOrchestration.ts
@@ -143,13 +143,20 @@ export function useSessionOrchestration({
   }, [activeWorkingDir, repos, clearMessages, leaveSession, wsCreateSession, permissionModeRef, useWorktreeRef, providerRef])
 
   const handleNewSessionFromArchive = useCallback((workingDir: string, context: string) => {
-    const repo = repos.find(r => r.workingDir === workingDir)
+    // The archived workingDir may be a worktree path or an alternate clone path
+    // that no longer matches any registered repo. Fall back to basename matching,
+    // then to the active repo, so resume never silently no-ops.
+    const basename = (p: string) => p.replace(/\/+$/, '').split('/').pop() ?? p
+    const repo =
+      repos.find(r => r.workingDir === workingDir) ??
+      repos.find(r => basename(r.workingDir) === basename(workingDir)) ??
+      repos.find(r => r.workingDir === activeWorkingDir)
     if (!repo) return
     pendingContextRef.current = context
     clearMessages()
     leaveSession()
     wsCreateSession(`hub:${repo.id}`, repo.workingDir, useWorktreeRef.current, permissionModeRef.current, providerRef?.current)
-  }, [repos, clearMessages, leaveSession, wsCreateSession, pendingContextRef, permissionModeRef, useWorktreeRef, providerRef])
+  }, [repos, activeWorkingDir, clearMessages, leaveSession, wsCreateSession, pendingContextRef, permissionModeRef, useWorktreeRef, providerRef])
 
   return {
     activeSession,


### PR DESCRIPTION
## Summary

Fixes two archived-session bugs that hit repos checked out at more than one path (e.g. codekin, which has a webhook/workflow clone at `/srv/repos/codekin` and the interactive checkout at `/srv/repos/Multiplier-Labs/codekin`):

1. **Closed sessions didn't appear in the archived list.** The archive list query keyed strictly on the absolute path (`working_dir = ? OR group_dir = ?`). Sessions archived from a different checkout of the same repo never matched the sidebar's canonical group path, so they were invisible. Now `list()` also matches by repo basename via `COALESCE(group_dir, working_dir)`, so archives from any checkout of the same repo surface.

2. **"Continue in new session" silently did nothing.** `handleNewSessionFromArchive` looked up the repo with `repos.find(r => r.workingDir === workingDir)` using the archived session's raw `workingDir` — which for worktree sessions is a now-deleted worktree path, and for alternate clones a path no live repo matches — then `return`ed when nothing matched. Now the panel passes the canonical `groupDir`, and the handler resolves the repo by exact path → basename → active repo before falling through.

### Trade-off
Basename matching means two genuinely distinct repos sharing a basename (e.g. `org-a/api` and `org-b/api`) would share an archive list. No such collision exists in the current repo set; exact-path matches are always tried first.

## Test plan

- [x] `npm test` — 2074 passed (added basename-match + substring-safety tests for `list()`, and a basename-resolve test for resume)
- [x] `npm run build` — typecheck + production build clean
- [x] `npm run lint` — 0 errors
- [ ] Manually verify codekin closed sessions now appear in the sidebar archive and "Continue in new session" spawns a seeded session

🤖 Generated with [Claude Code](https://claude.com/claude-code)