### PR TITLE
fix: start new sessions on latest model + surface reconnect notices

### DIFF
--- a/server/anthropic-models.ts
+++ b/server/anthropic-models.ts
@@ -179,6 +179,18 @@ async function fetchViaCli(): Promise<ClaudeModelInfo[] | null> {
 // ---------------------------------------------------------------------------
 
 /**
+ * Synchronously return the best-known default Claude model ID — the first
+ * (newest) entry of the discovered list, or the hardcoded fallback's first
+ * entry when discovery hasn't completed yet. This matches the model the
+ * frontend auto-selects (the [0] of the same list), so new sessions start on
+ * it directly instead of letting the CLI pick a stale default and forcing a
+ * disruptive model-switch restart that drops the user's first message.
+ */
+export function getDefaultClaudeModel(): string {
+  return (cache?.models[0] ?? FALLBACK_MODELS[0]).id
+}
+
+/**
  * Return available Claude models. Uses cached results when valid.
  * Called by the GET /api/claude/models endpoint.
  */

--- a/server/ws-message-handler.ts
+++ b/server/ws-message-handler.ts
@@ -9,7 +9,7 @@ import { realpathSync as fsRealpathSync } from 'fs'
 import { homedir as osHomedir } from 'os'
 import { resolve as pathResolve } from 'path'
 import type { WebSocket } from 'ws'
-import { triggerCliProbeIfNeeded } from './anthropic-models.js'
+import { getDefaultClaudeModel, triggerCliProbeIfNeeded } from './anthropic-models.js'
 import { REPOS_ROOT } from './config.js'
 import type { SessionManager } from './session-manager.js'
 import { VALID_PERMISSION_MODES, VALID_PROVIDERS } from './types.js'
@@ -53,7 +53,13 @@ export function handleWsMessage(msg: WsClientMessage, ctx: WsHandlerContext): vo
         send({ type: 'error', message: `Invalid permission mode: ${msg.permissionMode}` })
         break
       }
-      const session = sessions.create(msg.name, msg.workingDir, { model: msg.model, permissionMode: msg.permissionMode, allowedTools: msg.allowedTools, provider: msg.provider })
+      // Default new Claude sessions to the latest known model so the CLI starts
+      // on it directly. Without this the CLI picks a stale default (e.g. opus-4-6)
+      // and the client's model-validation effect switches it post-start, which
+      // restarts the process and drops the user's first message.
+      const provider = msg.provider ?? 'claude'
+      const model = msg.model ?? (provider === 'claude' ? getDefaultClaudeModel() : undefined)
+      const session = sessions.create(msg.name, msg.workingDir, { model, permissionMode: msg.permissionMode, allowedTools: msg.allowedTools, provider: msg.provider })
       session.clients.add(ws)
       clientSessions.set(ws, session.id)
 

--- a/src/hooks/useChatSocket.ts
+++ b/src/hooks/useChatSocket.ts
@@ -19,6 +19,11 @@ import { useWsConnection } from './useWsConnection'
 /** Max chat messages kept in the browser before trimming older entries. */
 const MAX_BROWSER_MESSAGES = 500
 
+/** Shown in the chat while the socket is down (e.g. the Codekin server restarted). */
+const DISCONNECT_TEXT = 'Connection to Codekin lost. Reconnecting…'
+/** Persistent marker added once the session rejoins after a drop. */
+const RECONNECT_TEXT = 'Reconnected to Codekin'
+
 /** Monotonically increasing counter for stable React keys across trims. */
 let msgKeyCounter = 0
 function nextKey(): string { return `m${++msgKeyCounter}` }
@@ -177,6 +182,8 @@ export function useChatSocket({
   const [thinkingSummary, setThinkingSummary] = useState<string | null>(null)
   const promptState = usePromptState()
   const currentSessionId = useRef<string | null>(null)
+  /** True after the socket drops (e.g. server restart) until the session rejoins. */
+  const wasDisconnectedRef = useRef(false)
   const [renderSessionId, setRenderSessionId] = useState<string | null>(null)
   const activePrompt = promptState.getActive(renderSessionId)
   const promptQueueSize = promptState.getQueueSize(renderSessionId)
@@ -345,6 +352,13 @@ export function useChatSocket({
             }
           }
         }
+        // If we rejoined after a connection drop (e.g. server restart), append a
+        // persistent marker so the user sees that the outage happened — the
+        // transient DISCONNECT_TEXT bubble is wiped by this history rebuild.
+        if (wasDisconnectedRef.current) {
+          wasDisconnectedRef.current = false
+          rebuilt.push({ type: 'system', subtype: 'init', text: RECONNECT_TEXT, key: nextKey() })
+        }
         setPlanningMode(restoredPlanMode)
         setTasks(restoredTasks)
         setMessages(trimMessages(rebuilt))
@@ -408,6 +422,17 @@ export function useChatSocket({
     if (rafRef.current) {
       cancelAnimationFrame(rafRef.current)
       rafRef.current = null
+    }
+    // Surface a visible notice when the connection drops (e.g. the Codekin
+    // server restarted). Only while viewing a session, and de-duped so repeated
+    // close events don't stack. Cleared/replaced once the session rejoins.
+    if (currentSessionId.current) {
+      wasDisconnectedRef.current = true
+      setMessages(prev => {
+        const last = prev[prev.length - 1]
+        if (prev.length > 0 && last.type === 'system' && last.subtype === 'exit' && last.text === DISCONNECT_TEXT) return prev
+        return trimMessages([...prev, { type: 'system', subtype: 'exit', text: DISCONNECT_TEXT, key: nextKey() }])
+      })
     }
   }, [])
 


### PR DESCRIPTION
## Summary
Fixes two session bugs reported from the UI:

1. **First message ignored on new sessions / wrong model shown.** New sessions were created with no model, so the Claude CLI started on its stale default (`claude-opus-4-6[1m]`). The client's model-validation effect then switched it to the latest model post-start, which triggered a reconfigure **restart** of the live process and dropped the user's in-flight first message (so the first prompt got no response; only the second worked). Now the server defaults new Claude sessions to the latest known model (`getDefaultClaudeModel()`), matching what the client validates to — no post-start restart, first message is delivered.

2. **No notice when Codekin restarts.** On a server restart the WebSocket just closes silently. Added a visible "Connection to Codekin lost. Reconnecting…" notice on drop and a persistent "Reconnected to Codekin" marker after the session rejoins.

## Changes
- `server/anthropic-models.ts` — add `getDefaultClaudeModel()` (newest discovered model, or hardcoded fallback).
- `server/ws-message-handler.ts` — default new Claude sessions to that model.
- `src/hooks/useChatSocket.ts` — disconnect/reconnect chat notices.

## Test plan
- [x] `npm run build` (typecheck + bundle) passes
- [x] Full test suite: 2071 tests pass
- [x] Lint: no net-new warnings
- [ ] Manual: create a new session, send first message → gets a response on the latest model (no dropped first message)
- [ ] Manual: restart the backend → chat shows "Connection lost" then "Reconnected"

🤖 Generated with [Claude Code](https://claude.com/claude-code)