### PR TITLE
fix: resilient session auto-naming (rate limits + chatty replies)

### DIFF
--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -203,6 +203,7 @@ export class SessionManager {
       getSession: (id) => this.sessions.get(id),
       hasSession: (id) => this.sessions.has(id),
       rename: (sessionId, newName) => this.rename(sessionId, newName),
+      isRateLimited: () => this.isRateLimited(),
     })
     this.sessionPersistence.restoreFromDisk()
     // Wire PlanManager events and coordinators for restored sessions

--- a/server/session-naming.test.ts
+++ b/server/session-naming.test.ts
@@ -40,6 +40,7 @@ function makeDeps(overrides: Partial<SessionNamingDeps> = {}): SessionNamingDeps
     getSession: vi.fn(() => undefined),
     hasSession: vi.fn(() => true),
     rename: vi.fn(() => true),
+    isRateLimited: vi.fn(() => false),
     ...overrides,
   }
 }
@@ -150,6 +151,24 @@ describe('SessionNaming', () => {
     vi.useRealTimers()
   })
 
+  // 6b. executeSessionNaming — defers (no CLI call, no attempt) while rate-limited
+  it('defers naming without spawning or counting an attempt when rate-limited', async () => {
+    vi.useFakeTimers()
+    const session = fakeSession({ _namingAttempts: 0 })
+    const deps = makeDeps({
+      getSession: vi.fn(() => session),
+      isRateLimited: vi.fn(() => true),
+    })
+    const naming = new SessionNaming(deps)
+
+    await naming.executeSessionNaming('s1')
+
+    expect(mockSpawn).not.toHaveBeenCalled()
+    expect(session._namingAttempts).toBe(0)
+    expect(session._namingTimer).toBeDefined()
+    vi.useRealTimers()
+  })
+
   // 7. executeSessionNaming — successful naming with valid CLI response
   it('renames session when CLI returns a valid name', async () => {
     const session = fakeSession()
@@ -162,7 +181,7 @@ describe('SessionNaming', () => {
     expect(deps.rename).toHaveBeenCalledWith('s1', 'Fix Login Page Styling')
     expect(mockSpawn).toHaveBeenCalledWith(
       'claude',
-      ['-p', '--max-turns', '1', '--model', 'haiku', '--tools', ''],
+      ['-p', '--max-turns', '1', '--model', 'haiku', '--tools', '', '--system-prompt', expect.any(String)],
       expect.objectContaining({
         stdio: ['pipe', 'pipe', 'pipe'],
         cwd: expect.any(String),

--- a/server/session-naming.ts
+++ b/server/session-naming.ts
@@ -17,14 +17,30 @@ const MAX_NAMING_ATTEMPTS = 5
 /** Back-off delays for naming retries: 20s, 60s, 120s, 240s, 240s */
 const NAMING_DELAYS = [20_000, 60_000, 120_000, 240_000, 240_000]
 
-/** Timeout for the claude -p process (15 seconds). */
-const CLI_TIMEOUT_MS = 15_000
+/** Timeout for the claude -p process. Standalone the call returns in ~5s, but
+ *  in production it runs concurrently with the session's live Claude process and
+ *  shares the same subscription/rate-limit budget, so it needs more headroom. */
+const CLI_TIMEOUT_MS = 30_000
+
+/** Terse system prompt that replaces Claude Code's default assistant persona.
+ *  Without it, Haiku treats the naming prompt conversationally ("Hey! I'm ready
+ *  to help…" / "I need to know what you're working on…") and the chatty reply
+ *  fails the name validator, wasting an attempt. */
+const NAMING_SYSTEM_PROMPT =
+  'You generate short titles for coding sessions. Output ONLY a 3-6 word title ' +
+  'summarizing the work, in Title Case. No quotes, no punctuation, no explanation, ' +
+  'no questions, no preamble. If the context is thin, make your best guess from ' +
+  'whatever text is available.'
 
 /** Callback interface for SessionNaming to interact with SessionManager. */
 export interface SessionNamingDeps {
   getSession(id: string): Session | undefined
   hasSession(id: string): boolean
   rename(sessionId: string, newName: string): boolean
+  /** Whether the rate-limit circuit breaker is currently open. When true,
+   *  naming is deferred — firing claude -p into a rate-limited account just
+   *  hangs until the 30s timeout and worsens the quota situation. */
+  isRateLimited(): boolean
 }
 
 /** Build a minimal env for claude -p that includes auth/config paths
@@ -53,7 +69,7 @@ function generateNameViaCLI(prompt: string): Promise<string> {
     // those would inject unrelated context and the model ends up responding
     // to that instead of the naming prompt. --tools "" disables tools so the
     // model can't burn its single turn on a tool call.
-    const proc = spawn(CLAUDE_BINARY, ['-p', '--max-turns', '1', '--model', 'haiku', '--tools', ''], {
+    const proc = spawn(CLAUDE_BINARY, ['-p', '--max-turns', '1', '--model', 'haiku', '--tools', '', '--system-prompt', NAMING_SYSTEM_PROMPT], {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: tmpdir(),
       env: buildNamingEnv(),
@@ -124,6 +140,14 @@ export class SessionNaming {
     const session = this.deps.getSession(sessionId)
     if (!session) return
     if (!session.name.startsWith('hub:')) return
+
+    // Defer (without counting an attempt) while the rate-limit breaker is open —
+    // a claude -p call here would just hang until timeout and worsen the quota
+    // situation. Re-checks on the next scheduled tick once the breaker clears.
+    if (this.deps.isRateLimited()) {
+      this.scheduleSessionNaming(sessionId)
+      return
+    }
 
     session._namingAttempts++
 


### PR DESCRIPTION
## Summary

New sessions were getting stuck as `new session` because the `claude -p` auto-naming call was failing in production. pm2 logs (id 2) showed three failure modes:

1. **Timeouts** — `claude -p timed out` at the 15s ceiling. Standalone the call returns in ~5s, but in production it runs concurrently with the session's live Claude process and shares the same subscription/rate-limit budget; under throttling the CLI retries 429s internally and blows past 15s. Naming was **not** gated by the rate-limit circuit breaker added in #468–#470.
2. **Chatty replies** — Haiku ignored "Reply with ONLY the session name" and replied conversationally (`"I need to know what you're working on…"`), failing the name validator and wasting an attempt.
3. **Intermittent exit-1s** under the same quota pressure.

## Changes

- **`--system-prompt`**: replace Claude Code's default assistant persona with a terse title-only directive. Reproduced + verified this stops the chatty replies even on thin context.
- **Circuit-breaker gating**: `executeSessionNaming` now defers (without counting an attempt) while `isRateLimited()` is open, retrying once the breaker clears — instead of hanging into a throttled account.
- **Timeout** raised 15s → 30s for headroom under concurrent load.

## Test plan

- [x] `npm run build` (tsc + vite) passes
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 2072 tests pass (added a rate-limit deferral test)
- [x] Manual end-to-end `claude -p` with new args returns a clean bare title

🤖 Generated with [Claude Code](https://claude.com/claude-code)