### PR TITLE
fix: group AI workflow sessions under canonical repo in sidebar

### DIFF
--- a/server/workflow-loader.test.ts
+++ b/server/workflow-loader.test.ts
@@ -495,6 +495,25 @@ Prompt.
         expect(result.lastCommit).toBe('abc123 latest commit')
         expect(result.branch).toBe('develop')
       })
+
+      it('returns the symlink-resolved canonical repoPath, not the raw input', async () => {
+        // Simulate a symlinked repos root: input path differs from realpath.
+        // The resolved path must propagate downstream so the workflow session's
+        // groupDir matches the realpath-based key used by manual/worktree
+        // sessions (otherwise the sidebar shows a duplicate repo group).
+        mockRealpathSync.mockReturnValue('/tmp/canonical/repo')
+        mockExecFileSync
+          .mockReturnValueOnce(Buffer.from('main\n'))
+          .mockReturnValueOnce(Buffer.from('abc123 latest commit\n'))
+
+        const handler = registeredDef.steps[0].handler
+        const result = await handler(
+          { repoPath: '/tmp/symlink/repo', repoName: 'test' },
+          { runId: 'r1', run: {}, abortSignal: new AbortController().signal }
+        )
+
+        expect(result.repoPath).toBe('/tmp/canonical/repo')
+      })
     })
 
     describe('create_session step', () => {

--- a/server/workflow-loader.ts
+++ b/server/workflow-loader.ts
@@ -291,7 +291,12 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
             }
 
             console.log(`[workflow:${def.kind}] Validated repo: ${repoPath} (${branch}) — ${lastCommit}`)
-            return { branch, lastCommit, repoPath, repoName: input.repoName }
+            // Propagate the symlink-resolved canonical path downstream so the
+            // session's groupDir matches the realpath-based grouping key used by
+            // manual/worktree/webhook sessions (git --git-common-dir yields a
+            // resolved path). Otherwise a symlinked REPOS_ROOT produces a
+            // duplicate repo group in the sidebar.
+            return { branch, lastCommit, repoPath: resolvedPath, repoName: input.repoName }
           } catch (err) {
             if (err instanceof Error && err.name === 'WorkflowSkipped') throw err
             throw new Error(`Not a valid git repository: ${repoPath}`, { cause: err })


### PR DESCRIPTION
## Summary
- Fixes a bug where initiating an AI workflow session (e.g. `review:codekin`) created a **second duplicate repo group** in the sidebar instead of nesting under the existing repo section.
- **Root cause**: workflow sessions stored the raw, un-normalized `repoPath` as `groupDir` (`server/workflow-loader.ts:313`), while manual/worktree/webhook/stepflow sessions use a realpath-resolved canonical path. When `REPOS_ROOT` is reached via a symlink (`~/repos` → `/srv/repos` in this environment), the two path strings differ, and `groupKey()`'s plain string comparison (`src/hooks/useSessionOrchestration.ts:12`) yields two distinct groups for the same repo.
- **Fix**: propagate the already-computed `realpathSync(repoPath)` from the `validate_repo` step downstream, so the workflow session's `groupDir` (and `workingDir`) matches the canonical key used by every other session type. This mirrors the existing canonicalization in `webhook-handler.ts` / `stepflow-handler.ts` and the worktree fix in #476.

## Test plan
- [x] Added regression test asserting `validate_repo` returns the symlink-resolved canonical `repoPath`, not the raw input
- [x] `npm test` — 2072 passed
- [x] `npm run build` — clean
- [x] `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)