### PR TITLE
Revert #485: workflow groupDir realpath normalization

### DIFF
--- a/server/workflow-loader.test.ts
+++ b/server/workflow-loader.test.ts
@@ -495,25 +495,6 @@ Prompt.
         expect(result.lastCommit).toBe('abc123 latest commit')
         expect(result.branch).toBe('develop')
       })
-
-      it('returns the symlink-resolved canonical repoPath, not the raw input', async () => {
-        // Simulate a symlinked repos root: input path differs from realpath.
-        // The resolved path must propagate downstream so the workflow session's
-        // groupDir matches the realpath-based key used by manual/worktree
-        // sessions (otherwise the sidebar shows a duplicate repo group).
-        mockRealpathSync.mockReturnValue('/tmp/canonical/repo')
-        mockExecFileSync
-          .mockReturnValueOnce(Buffer.from('main\n'))
-          .mockReturnValueOnce(Buffer.from('abc123 latest commit\n'))
-
-        const handler = registeredDef.steps[0].handler
-        const result = await handler(
-          { repoPath: '/tmp/symlink/repo', repoName: 'test' },
-          { runId: 'r1', run: {}, abortSignal: new AbortController().signal }
-        )
-
-        expect(result.repoPath).toBe('/tmp/canonical/repo')
-      })
     })
 
     describe('create_session step', () => {

--- a/server/workflow-loader.ts
+++ b/server/workflow-loader.ts
@@ -291,12 +291,7 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
             }
 
             console.log(`[workflow:${def.kind}] Validated repo: ${repoPath} (${branch}) — ${lastCommit}`)
-            // Propagate the symlink-resolved canonical path downstream so the
-            // session's groupDir matches the realpath-based grouping key used by
-            // manual/worktree/webhook sessions (git --git-common-dir yields a
-            // resolved path). Otherwise a symlinked REPOS_ROOT produces a
-            // duplicate repo group in the sidebar.
-            return { branch, lastCommit, repoPath: resolvedPath, repoName: input.repoName }
+            return { branch, lastCommit, repoPath, repoName: input.repoName }
           } catch (err) {
             if (err instanceof Error && err.name === 'WorkflowSkipped') throw err
             throw new Error(`Not a valid git repository: ${repoPath}`, { cause: err })


### PR DESCRIPTION
## Summary
Reverts #485.

PR #485 normalized the workflow session's `groupDir` with `realpathSync`, on the theory that the duplicate sidebar repo group was caused by a symlinked `REPOS_ROOT` (`~/repos` → `/srv/repos`). That diagnosis was wrong for the reported case.

The actual cause is **two separate physical clones of the same repo** at different canonical paths (`/srv/repos/codekin` for workflow audits vs `/srv/repos/Multiplier-Labs/codekin` for interactive sessions). Both paths are already canonical, so realpath normalization is a no-op here and does not fix the duplicate group.

The real issue is being addressed operationally by retargeting the affected workflow schedules to the dev clone, so this code change is unnecessary. Reverting to keep history accurate.

## Test plan
- [x] Pure `git revert` of the squashed commit — restores prior behavior
- [ ] CI green