### PR TITLE
Make coverage honest (coverage.all) and start covering React components

### DIFF
--- a/server/orchestrator-memory.test.ts
+++ b/server/orchestrator-memory.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Tests for OrchestratorMemory — the SQLite/FTS5 durable memory + trust store.
+ *
+ * Uses an in-memory database (`:memory:`) so each test is hermetic and leaves
+ * no files behind. orchestrator-manager is mocked to supply only ORCHESTRATOR_DIR,
+ * isolating this unit from the rest of the orchestrator subsystem.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+vi.mock('./orchestrator-manager.js', () => ({
+  ORCHESTRATOR_DIR: '/tmp/codekin-orch-memory-test',
+}))
+
+import { OrchestratorMemory, type MemoryItem } from './orchestrator-memory.js'
+
+type NewItem = Omit<MemoryItem, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }
+
+function makeItem(overrides: Partial<NewItem> = {}): NewItem {
+  return {
+    memoryType: 'decision',
+    scope: null,
+    title: 'Default title',
+    content: 'Default content',
+    sourceRef: null,
+    confidence: 0.8,
+    expiresAt: null,
+    isPinned: false,
+    tags: [],
+    ...overrides,
+  }
+}
+
+describe('OrchestratorMemory', () => {
+  let mem: OrchestratorMemory
+
+  beforeEach(() => {
+    mem = new OrchestratorMemory(':memory:')
+  })
+
+  afterEach(() => {
+    mem.close()
+  })
+
+  // -------------------------------------------------------------------------
+  // Memory CRUD
+  // -------------------------------------------------------------------------
+
+  describe('memory CRUD', () => {
+    it('round-trips all fields through upsert + get', () => {
+      const id = mem.upsert(makeItem({
+        memoryType: 'user_preference',
+        scope: '/repos/codekin',
+        title: 'Prefers terse replies',
+        content: 'User asked to skip trailing summaries',
+        sourceRef: 'session-123',
+        confidence: 0.95,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        isPinned: true,
+        tags: ['style', 'communication'],
+      }))
+
+      const got = mem.get(id)
+      expect(got).not.toBeNull()
+      expect(got).toMatchObject({
+        id,
+        memoryType: 'user_preference',
+        scope: '/repos/codekin',
+        title: 'Prefers terse replies',
+        content: 'User asked to skip trailing summaries',
+        sourceRef: 'session-123',
+        confidence: 0.95,
+        expiresAt: '2099-01-01T00:00:00.000Z',
+        isPinned: true,
+        tags: ['style', 'communication'],
+      })
+      expect(got!.createdAt).toBeTruthy()
+      expect(got!.updatedAt).toBeTruthy()
+    })
+
+    it('generates an id when none is supplied', () => {
+      const id = mem.upsert(makeItem())
+      expect(id).toBeTruthy()
+      expect(mem.get(id)).not.toBeNull()
+    })
+
+    it('updates an existing item in place when the same id is reused', () => {
+      const id = mem.upsert(makeItem({ content: 'first' }))
+      const sameId = mem.upsert(makeItem({ id, content: 'second' }))
+
+      expect(sameId).toBe(id)
+      expect(mem.get(id)!.content).toBe('second')
+      expect(mem.list()).toHaveLength(1)
+    })
+
+    it('returns null from get for an unknown id', () => {
+      expect(mem.get('nope')).toBeNull()
+    })
+
+    it('delete removes an item and reports whether anything changed', () => {
+      const id = mem.upsert(makeItem())
+      expect(mem.delete(id)).toBe(true)
+      expect(mem.get(id)).toBeNull()
+      expect(mem.delete(id)).toBe(false)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // list() filters
+  // -------------------------------------------------------------------------
+
+  describe('list filters', () => {
+    it('filters by memoryType', () => {
+      mem.upsert(makeItem({ memoryType: 'decision', content: 'd' }))
+      mem.upsert(makeItem({ memoryType: 'journal', content: 'j' }))
+
+      const decisions = mem.list({ memoryType: 'decision' })
+      expect(decisions).toHaveLength(1)
+      expect(decisions[0].content).toBe('d')
+    })
+
+    it('filters by an explicit non-null scope', () => {
+      mem.upsert(makeItem({ scope: '/repo/a', content: 'a' }))
+      mem.upsert(makeItem({ scope: '/repo/b', content: 'b' }))
+
+      const scoped = mem.list({ scope: '/repo/a' })
+      expect(scoped).toHaveLength(1)
+      expect(scoped[0].content).toBe('a')
+    })
+
+    it('filters for global (null) scope distinctly from repo-scoped items', () => {
+      mem.upsert(makeItem({ scope: null, content: 'global' }))
+      mem.upsert(makeItem({ scope: '/repo/a', content: 'scoped' }))
+
+      const globals = mem.list({ scope: null })
+      expect(globals).toHaveLength(1)
+      expect(globals[0].content).toBe('global')
+    })
+
+    it('filters to pinned items only', () => {
+      mem.upsert(makeItem({ isPinned: true, content: 'pinned' }))
+      mem.upsert(makeItem({ isPinned: false, content: 'loose' }))
+
+      const pinned = mem.list({ pinnedOnly: true })
+      expect(pinned).toHaveLength(1)
+      expect(pinned[0].content).toBe('pinned')
+    })
+
+    it('respects the limit', () => {
+      mem.upsert(makeItem({ content: '1' }))
+      mem.upsert(makeItem({ content: '2' }))
+      mem.upsert(makeItem({ content: '3' }))
+      expect(mem.list({ limit: 2 })).toHaveLength(2)
+    })
+
+    it('orders results by most-recently-updated first', () => {
+      vi.useFakeTimers()
+      try {
+        vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+        mem.upsert(makeItem({ content: 'older' }))
+        vi.setSystemTime(new Date('2026-01-02T00:00:00.000Z'))
+        mem.upsert(makeItem({ content: 'newer' }))
+
+        const list = mem.list()
+        expect(list.map(i => i.content)).toEqual(['newer', 'older'])
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Full-text search
+  // -------------------------------------------------------------------------
+
+  describe('search', () => {
+    it('finds an item by a term in its content', () => {
+      mem.upsert(makeItem({ content: 'migration rollback procedure documented' }))
+      mem.upsert(makeItem({ content: 'unrelated note about styling' }))
+
+      const hits = mem.search('rollback')
+      expect(hits).toHaveLength(1)
+      expect(hits[0].content).toContain('rollback')
+    })
+
+    it('finds an item by a term in its title', () => {
+      mem.upsert(makeItem({ title: 'Postgres connection pooling', content: 'body' }))
+
+      const hits = mem.search('pooling')
+      expect(hits).toHaveLength(1)
+      expect(hits[0].title).toBe('Postgres connection pooling')
+    })
+
+    it('returns an empty array when nothing matches', () => {
+      mem.upsert(makeItem({ content: 'something concrete' }))
+      expect(mem.search('zzznonexistent')).toEqual([])
+    })
+
+    it('respects the search limit', () => {
+      mem.upsert(makeItem({ content: 'caching layer one' }))
+      mem.upsert(makeItem({ content: 'caching layer two' }))
+      mem.upsert(makeItem({ content: 'caching layer three' }))
+      expect(mem.search('caching', 2)).toHaveLength(2)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // expireStale
+  // -------------------------------------------------------------------------
+
+  describe('expireStale', () => {
+    it('removes only items whose expiresAt is in the past', () => {
+      mem.upsert(makeItem({ content: 'expired', expiresAt: '2000-01-01T00:00:00.000Z' }))
+      mem.upsert(makeItem({ content: 'future', expiresAt: '2999-01-01T00:00:00.000Z' }))
+      mem.upsert(makeItem({ content: 'never', expiresAt: null }))
+
+      const removed = mem.expireStale()
+      expect(removed).toBe(1)
+
+      const remaining = mem.list().map(i => i.content).sort()
+      expect(remaining).toEqual(['future', 'never'])
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Trust records
+  // -------------------------------------------------------------------------
+
+  describe('trust records', () => {
+    it('creates a record with defaults on first getTrust', () => {
+      const trust = mem.getTrust('spawn_fix_session', 'dependency_update', null)
+      expect(trust).toMatchObject({
+        action: 'spawn_fix_session',
+        category: 'dependency_update',
+        severity: 'medium',
+        repo: null,
+        approvalCount: 0,
+        rejectionCount: 0,
+        pinnedLevel: null,
+      })
+      expect(trust.id).toBeTruthy()
+    })
+
+    it('returns the same persisted record on subsequent getTrust calls', () => {
+      const first = mem.getTrust('a', 'b', null)
+      const second = mem.getTrust('a', 'b', null)
+      expect(second.id).toBe(first.id)
+    })
+
+    it('recordApproval increments approvalCount and stamps lastApprovedAt', () => {
+      const t = mem.recordApproval('a', 'b', null)
+      expect(t.approvalCount).toBe(1)
+      expect(t.lastApprovedAt).toBeTruthy()
+      // Persisted, not just returned
+      expect(mem.getTrust('a', 'b', null).approvalCount).toBe(1)
+    })
+
+    it('recordRejection resets approvals, bumps rejections, and clears the pin', () => {
+      mem.recordApproval('a', 'b', null)
+      mem.recordApproval('a', 'b', null)
+      mem.pinTrust('a', 'b', null, 'silent')
+
+      const t = mem.recordRejection('a', 'b', null)
+      expect(t.approvalCount).toBe(0)
+      expect(t.rejectionCount).toBe(1)
+      expect(t.pinnedLevel).toBeNull()
+
+      const persisted = mem.getTrust('a', 'b', null)
+      expect(persisted.approvalCount).toBe(0)
+      expect(persisted.pinnedLevel).toBeNull()
+    })
+
+    it('resetAllTrust clears approval counts and pins', () => {
+      mem.recordApproval('a', 'b', null)
+      mem.pinTrust('a', 'b', null, 'silent')
+      mem.resetAllTrust()
+
+      const t = mem.getTrust('a', 'b', null)
+      expect(t.approvalCount).toBe(0)
+      expect(t.pinnedLevel).toBeNull()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // computeTrustLevel
+  // -------------------------------------------------------------------------
+
+  describe('computeTrustLevel', () => {
+    it('returns a user-pinned level regardless of approval count', () => {
+      mem.pinTrust('a', 'b', null, 'silent')
+      expect(mem.computeTrustLevel('a', 'b', 'low', null)).toBe('silent')
+    })
+
+    it('escalates ask → notify_do → silent for low-severity actions', () => {
+      const level = () => mem.computeTrustLevel('a', 'b', 'low', null)
+      expect(level()).toBe('ask') // 0 approvals
+      mem.recordApproval('a', 'b', null)
+      mem.recordApproval('a', 'b', null)
+      expect(level()).toBe('notify_do') // 2 approvals
+      mem.recordApproval('a', 'b', null)
+      mem.recordApproval('a', 'b', null)
+      mem.recordApproval('a', 'b', null)
+      expect(level()).toBe('silent') // 5 approvals
+    })
+
+    it('never reaches silent for high-severity actions', () => {
+      for (let i = 0; i < 8; i++) mem.recordApproval('a', 'b', null)
+      expect(mem.computeTrustLevel('a', 'b', 'high', null)).toBe('notify_do')
+      expect(mem.computeTrustLevel('a', 'b', 'critical', null)).toBe('notify_do')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Global override + listing
+  // -------------------------------------------------------------------------
+
+  describe('global override and listing', () => {
+    it('falls back to a pinned global record for a repo with no specific record', () => {
+      mem.pinTrust('a', 'b', null, 'silent') // global pin
+
+      const trust = mem.getTrust('a', 'b', '/repo/x')
+      expect(trust.repo).toBeNull()
+      expect(trust.pinnedLevel).toBe('silent')
+    })
+
+    it('listTrustRecords includes the computed effective level', () => {
+      mem.recordApproval('a', 'b', null)
+      mem.recordApproval('a', 'b', null)
+
+      const records = mem.listTrustRecords()
+      expect(records).toHaveLength(1)
+      expect(records[0].effectiveLevel).toBe('notify_do')
+    })
+  })
+})

--- a/server/orchestrator-session-router.test.ts
+++ b/server/orchestrator-session-router.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for createSessionRouter — orchestrator session/children routes.
+ *
+ * Focus areas (previously near-zero coverage):
+ *   - the per-IP spawn rate limiter (security control: each spawn allocates a
+ *     real subprocess, so the 20-per-window cap must hold)
+ *   - auth guards on protected routes
+ *   - spawn-request validation branches (these all return before any real
+ *     children.spawn call, so no subprocess is ever started in these tests)
+ *
+ * Mocks mirror orchestrator-routes.test.ts so the suite never touches ~/.codekin
+ * or the real repos root.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import express from 'express'
+import type { Request } from 'express'
+import type { AddressInfo } from 'net'
+import type { Server } from 'http'
+
+vi.mock('./orchestrator-manager.js', () => ({
+  ORCHESTRATOR_DIR: '/tmp/orch-session-test',
+  getOrCreateOrchestratorId: vi.fn(() => 'orch-session-id'),
+  getOrchestratorSessionId: vi.fn(() => null),
+  ensureOrchestratorRunning: vi.fn(() => 'orch-session-id'),
+}))
+
+vi.mock('./config.js', () => ({
+  REPOS_ROOT: '/tmp/repos',
+  resolveRepoPathInRoot: vi.fn(() => null),
+  getAgentDisplayName: vi.fn(() => 'Joe'),
+}))
+
+vi.mock('./orchestrator-reports.js', () => ({
+  scanRepoReports: vi.fn(() => []),
+  readReport: vi.fn(() => null),
+  getReportsSince: vi.fn(() => []),
+}))
+
+import { createSessionRouter } from './orchestrator-session-router.js'
+import type { SessionManager } from './session-manager.js'
+import type { OrchestratorMemory } from './orchestrator-memory.js'
+import type { OrchestratorChildManager } from './orchestrator-children.js'
+
+async function startApp(router: express.Router): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const app = express()
+  app.use(express.json())
+  app.use(router)
+  return await new Promise((resolve) => {
+    const server: Server = app.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as AddressInfo
+      resolve({
+        baseUrl: `http://127.0.0.1:${addr.port}`,
+        close: () => new Promise((r) => server.close(() => r())),
+      })
+    })
+  })
+}
+
+function makeMemory(): OrchestratorMemory {
+  return { list: vi.fn(() => []) } as unknown as OrchestratorMemory
+}
+
+function makeChildren(): OrchestratorChildManager {
+  return {
+    list: vi.fn(() => []),
+    get: vi.fn(() => null),
+    activeCount: vi.fn(() => 0),
+    spawn: vi.fn(),
+  } as unknown as OrchestratorChildManager
+}
+
+function makeSessions(): SessionManager {
+  return { get: vi.fn(() => undefined) } as unknown as SessionManager
+}
+
+const VALID_SPAWN = { repo: '/tmp/repos/x', task: 'do a thing', branchName: 'fix/thing' }
+
+describe('createSessionRouter', () => {
+  let server: { baseUrl: string; close: () => Promise<void> }
+  let children: OrchestratorChildManager
+
+  function mount(verifyAuth: (req: Request) => boolean): Promise<void> {
+    children = makeChildren()
+    const router = createSessionRouter(verifyAuth, makeSessions(), makeMemory(), children)
+    return startApp(router).then((s) => { server = s })
+  }
+
+  afterEach(async () => {
+    await server?.close()
+    vi.clearAllMocks()
+  })
+
+  // -------------------------------------------------------------------------
+  // Spawn rate limiter
+  // -------------------------------------------------------------------------
+
+  describe('spawn rate limiter', () => {
+    it('rejects with 429 once the per-IP window budget (20) is exhausted', async () => {
+      await mount(() => true)
+      const post = () =>
+        fetch(`${server.baseUrl}/api/orchestrator/children`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: '{}', // missing fields -> handler returns 400 (no spawn), but limiter still counts it
+        })
+
+      // First 20 reach the handler and 400 on validation.
+      const statuses: number[] = []
+      for (let i = 0; i < 20; i++) statuses.push((await post()).status)
+      expect(statuses.every((s) => s === 400)).toBe(true)
+
+      // 21st is blocked by the rate limiter before the handler runs.
+      const blocked = await post()
+      expect(blocked.status).toBe(429)
+      const body = await blocked.json()
+      expect(body).toMatchObject({ error: 'Too Many Requests' })
+      expect(body.retryAfter).toBeGreaterThan(0)
+
+      // The over-limit request never reached the spawn path.
+      expect(children.spawn).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Auth guards
+  // -------------------------------------------------------------------------
+
+  describe('auth guards', () => {
+    it('returns 401 for the children list when auth fails', async () => {
+      await mount(() => false)
+      const res = await fetch(`${server.baseUrl}/api/orchestrator/children`)
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 401 for status when auth fails', async () => {
+      await mount(() => false)
+      const res = await fetch(`${server.baseUrl}/api/orchestrator/status`)
+      expect(res.status).toBe(401)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Spawn validation (no real subprocess is ever spawned)
+  // -------------------------------------------------------------------------
+
+  describe('spawn validation', () => {
+    beforeEach(async () => { await mount(() => true) })
+
+    async function spawn(body: unknown) {
+      return fetch(`${server.baseUrl}/api/orchestrator/children`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+    }
+
+    it('400s when required fields are missing', async () => {
+      const res = await spawn({ repo: '/tmp/repos/x' })
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toMatch(/Missing required fields/)
+      expect(children.spawn).not.toHaveBeenCalled()
+    })
+
+    it('400s on a branchName that fails the safe-charset check', async () => {
+      const res = await spawn({ ...VALID_SPAWN, branchName: 'bad branch; rm -rf' })
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toMatch(/Invalid branchName/)
+      expect(children.spawn).not.toHaveBeenCalled()
+    })
+
+    it('400s when allowedTools is not an array of strings', async () => {
+      const res = await spawn({ ...VALID_SPAWN, allowedTools: 'Bash' })
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toMatch(/Invalid allowedTools/)
+      expect(children.spawn).not.toHaveBeenCalled()
+    })
+
+    it('400s when the repo path does not exist on disk', async () => {
+      const res = await spawn({ ...VALID_SPAWN, repo: '/tmp/definitely-not-a-real-repo-xyz' })
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toMatch(/directory does not exist/)
+      expect(children.spawn).not.toHaveBeenCalled()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Read routes
+  // -------------------------------------------------------------------------
+
+  describe('read routes', () => {
+    beforeEach(async () => { await mount(() => true) })
+
+    it('reports a stopped orchestrator when no session exists', async () => {
+      const res = await fetch(`${server.baseUrl}/api/orchestrator/status`)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toMatchObject({ sessionId: null, status: 'stopped' })
+    })
+
+    it('lists children (empty by default)', async () => {
+      const res = await fetch(`${server.baseUrl}/api/orchestrator/children`)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ children: [] })
+    })
+
+    it('400s on a reports request with neither ?repo nor ?since', async () => {
+      const res = await fetch(`${server.baseUrl}/api/orchestrator/reports`)
+      expect(res.status).toBe(400)
+      expect((await res.json()).error).toMatch(/Provide \?repo=/)
+    })
+  })
+})

--- a/src/components/TentativeBanner.test.tsx
+++ b/src/components/TentativeBanner.test.tsx
@@ -1,0 +1,94 @@
+/** Tests for TentativeBanner — verifies queued-message copy, pluralization, and Execute/Discard click handlers. */
+// @vitest-environment jsdom
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { TentativeBanner } from './TentativeBanner.js'
+
+/* ------------------------------------------------------------------ */
+/*  Minimal component renderer                                          */
+/* ------------------------------------------------------------------ */
+
+let activeRoot: ReturnType<typeof createRoot> | null = null
+let activeContainer: HTMLElement | null = null
+
+function render(ui: React.ReactElement): HTMLElement {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    activeRoot = createRoot(container)
+    activeRoot.render(ui)
+  })
+  activeContainer = container
+  return container
+}
+
+afterEach(() => {
+  if (activeRoot) act(() => activeRoot!.unmount())
+  activeContainer?.remove()
+  activeRoot = null
+  activeContainer = null
+})
+
+function findButton(container: HTMLElement, label: string): HTMLButtonElement {
+  const btn = [...container.querySelectorAll('button')].find(
+    (b) => b.textContent?.trim() === label,
+  )
+  if (!btn) throw new Error(`button "${label}" not found`)
+  return btn as HTMLButtonElement
+}
+
+function click(el: HTMLElement) {
+  act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe('TentativeBanner', () => {
+  it('renders the repo name and queued count', () => {
+    const container = render(
+      <TentativeBanner count={3} repoName="codekin" onExecute={() => {}} onDiscard={() => {}} />,
+    )
+    expect(container.textContent).toContain('codekin')
+    expect(container.textContent).toContain('3 messages queued')
+  })
+
+  it('uses the plural "messages" when count is not 1', () => {
+    const container = render(
+      <TentativeBanner count={2} repoName="repo" onExecute={() => {}} onDiscard={() => {}} />,
+    )
+    expect(container.textContent).toContain('2 messages queued')
+  })
+
+  it('uses the singular "message" when count is exactly 1', () => {
+    const container = render(
+      <TentativeBanner count={1} repoName="repo" onExecute={() => {}} onDiscard={() => {}} />,
+    )
+    expect(container.textContent).toContain('1 message queued')
+    expect(container.textContent).not.toContain('1 messages queued')
+  })
+
+  it('invokes onExecute when "Execute now" is clicked', () => {
+    const onExecute = vi.fn()
+    const container = render(
+      <TentativeBanner count={1} repoName="repo" onExecute={onExecute} onDiscard={() => {}} />,
+    )
+    click(findButton(container, 'Execute now'))
+    expect(onExecute).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onDiscard when "Discard" is clicked', () => {
+    const onDiscard = vi.fn()
+    const container = render(
+      <TentativeBanner count={1} repoName="repo" onExecute={() => {}} onDiscard={onDiscard} />,
+    )
+    click(findButton(container, 'Discard'))
+    expect(onDiscard).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/components/WorkflowBadges.test.tsx
+++ b/src/components/WorkflowBadges.test.tsx
@@ -1,0 +1,67 @@
+/** Tests for WorkflowBadges — verifies StatusBadge covers every status branch (incl. fallback) and CategoryBadge maps kind→category. */
+// @vitest-environment jsdom
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { StatusBadge, CategoryBadge } from './WorkflowBadges.js'
+
+let activeRoot: ReturnType<typeof createRoot> | null = null
+let activeContainer: HTMLElement | null = null
+
+function render(ui: React.ReactElement): HTMLElement {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    activeRoot = createRoot(container)
+    activeRoot.render(ui)
+  })
+  activeContainer = container
+  return container
+}
+
+afterEach(() => {
+  if (activeRoot) act(() => activeRoot!.unmount())
+  activeContainer?.remove()
+  activeRoot = null
+  activeContainer = null
+})
+
+describe('StatusBadge', () => {
+  it.each([
+    'succeeded',
+    'failed',
+    'running',
+    'queued',
+    'canceled',
+    'skipped',
+  ])('renders the "%s" status label', (status) => {
+    const container = render(<StatusBadge status={status} />)
+    expect(container.textContent).toContain(status)
+  })
+
+  it('falls back to rendering the raw status for an unknown value', () => {
+    const container = render(<StatusBadge status="mystery-state" />)
+    expect(container.textContent).toContain('mystery-state')
+  })
+})
+
+describe('CategoryBadge', () => {
+  it('renders the mapped category for a known kind', () => {
+    // coverage.daily → 'assessment'
+    const container = render(<CategoryBadge kind="coverage.daily" />)
+    expect(container.textContent?.trim()).toBe('assessment')
+  })
+
+  it('renders the event category for an event kind', () => {
+    // pr-review → 'event'
+    const container = render(<CategoryBadge kind="pr-review" />)
+    expect(container.textContent?.trim()).toBe('event')
+  })
+
+  it('falls back to "assessment" for an unknown kind', () => {
+    const container = render(<CategoryBadge kind="does-not-exist" />)
+    expect(container.textContent?.trim()).toBe('assessment')
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,34 @@ export default defineConfig({
   plugins: [react()],
   test: {
     environment: 'node',
-    include: ['src/**/*.test.ts', 'server/**/*.test.ts', '.claude/hooks/**/*.test.mjs'],
+    include: [
+      'src/**/*.test.ts',
+      'src/**/*.test.tsx',
+      'server/**/*.test.ts',
+      '.claude/hooks/**/*.test.mjs',
+    ],
     env: { NODE_ENV: 'test' },
+    coverage: {
+      provider: 'v8',
+      // Measure every source file, not just those a test happens to import.
+      // Without this, never-imported files (UI components, App.tsx, ws-server.ts)
+      // silently drop out of the denominator and inflate the headline number.
+      all: true,
+      include: [
+        'src/**/*.{ts,tsx}',
+        'server/**/*.ts',
+        '.claude/hooks/**/*.mjs',
+      ],
+      exclude: [
+        '**/*.test.*',
+        '**/*.d.ts',
+        'server/dist/**',
+        'src/types.ts',
+        'server/types.ts',
+        'server/stepflow-types.ts',
+        'server/webhook-types.ts',
+        'src/main.tsx',
+      ],
+    },
   },
 })


### PR DESCRIPTION
## Summary
Makes test coverage report honestly, then starts closing the largest real gaps it exposes.

**1. Honest coverage config** — `vitest.config.ts` now sets `coverage.all` so **every** source file counts toward the denominator, not just files a test imports. Previously the entire `src/components` UI layer, `App.tsx`, `ws-server.ts`, and 12 hooks silently dropped out, inflating the headline from the real ~54% lines up to a misleading 75%. Adds proper include/exclude so build artifacts (`server/dist`, `*.d.ts`), config JSON, and type-only modules don't pollute the numbers.

**2. First React component-render tests** — `TentativeBanner`, `WorkflowBadges`. The repo previously had *no* component render tests (only helper/hook tests); these establish a reusable `createRoot` + `act` pattern. Component coverage being near-zero is a real gap, not a deliberate scope decision.

**3. Full coverage of `OrchestratorMemory`** (0% → 100% lines) — the SQLite/FTS5 durable memory + trust store, the highest-risk untested server module. In-memory DB; covers CRUD, list filters, full-text search, expiry, trust-record progression, global-override fallback, and `computeTrustLevel` thresholds.

**4. Spawn rate limiter + validation in `orchestrator-session-router`** (~17% → ~38% lines, ~2% → ~27% branch) — exercises the per-IP spawn cap that gates real subprocess allocation, auth guards, and all spawn-request validation branches. No real child session is ever spawned.

### Coverage movement
| Metric | Before (inflated) | Honest baseline | After this PR |
|--------|-------------------|-----------------|---------------|
| Lines | 75.04% | ~54.1% | ~55.3% |
| Branches | 66.16% | ~42.7% | ~43.8% |

The headline *drop* vs. the old number is not a regression — it is the previously-hidden untested surface becoming visible. The gains are within the honest baseline.

## Test plan
- [x] `npm test` — 85 files / 2129 tests pass (51 new)
- [x] `npm run lint` — clean on changed files
- [x] `npm run build` — typecheck + bundle succeed

## Follow-ups (not in this PR)
- `src/components` (~1%): volume work, pattern now in place
- `server/orchestrator-monitor` / `orchestrator-learning` (0–3%)
- 12 zero-coverage hooks, `ws-server.ts`, `webhook-setup-routes.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)