### PR TITLE
fix: canonicalize WebSocket workingDir + add model-discovery tests

### DIFF
--- a/server/anthropic-models.test.ts
+++ b/server/anthropic-models.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for anthropic-models — verifies the two model-discovery strategies
+ * (Anthropic API + CLI probing), cache TTL behavior, probe de-duplication,
+ * and fallback when neither strategy has completed.
+ *
+ * The module keeps process-level state (cache + in-flight probe promise), so
+ * each test loads a fresh copy via vi.resetModules().
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock config so we don't depend on a real claude binary lookup.
+vi.mock('./config.js', () => ({ CLAUDE_BINARY: 'claude' }))
+
+// Mock child_process.execFile — the CLI probe path. Each test installs its own
+// behavior via setExecFileImpl().
+const mockExecFile = vi.hoisted(() => vi.fn())
+vi.mock('child_process', () => ({
+  execFile: (...args: any[]) => mockExecFile(...args),
+}))
+
+type ExecCallback = (err: Error | null, stdout: string) => void
+
+/**
+ * Install execFile behavior. `available` lists model IDs that "exist" — for
+ * those, the callback yields a JSON result whose modelUsage is keyed by the
+ * requested ID. Any other ID yields an error (probe failure / unavailable).
+ */
+function setExecFileImpl(available: Set<string>): void {
+  mockExecFile.mockImplementation((_bin: string, args: string[], _opts: any, cb: ExecCallback) => {
+    // args = ['-p', '--model', <id>, '--output-format', 'json', <prompt>]
+    const modelId = args[2]
+    queueMicrotask(() => {
+      if (available.has(modelId)) {
+        cb(null, JSON.stringify({ is_error: false, modelUsage: { [modelId]: { inputTokens: 1 } } }))
+      } else {
+        cb(new Error('model not available'), '')
+      }
+    })
+    return { unref: vi.fn() }
+  })
+}
+
+function mockFetch(impl: (url: string) => Response | Promise<Response>): void {
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL) =>
+    impl(typeof input === 'string' ? input : input.toString()),
+  ) as typeof fetch
+}
+
+function jsonResponse(body: unknown, ok = true): Response {
+  return { ok, json: async () => body } as Response
+}
+
+async function loadFreshModule(): Promise<typeof import('./anthropic-models.js')> {
+  vi.resetModules()
+  return await import('./anthropic-models.js')
+}
+
+describe('anthropic-models', () => {
+  const originalFetch = globalThis.fetch
+  const originalApiKey = process.env.ANTHROPIC_API_KEY
+  const originalCodeKey = process.env.CLAUDE_CODE_API_KEY
+
+  beforeEach(() => {
+    mockExecFile.mockReset()
+    delete process.env.ANTHROPIC_API_KEY
+    delete process.env.CLAUDE_CODE_API_KEY
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    vi.useRealTimers()
+    if (originalApiKey === undefined) delete process.env.ANTHROPIC_API_KEY
+    else process.env.ANTHROPIC_API_KEY = originalApiKey
+    if (originalCodeKey === undefined) delete process.env.CLAUDE_CODE_API_KEY
+    else process.env.CLAUDE_CODE_API_KEY = originalCodeKey
+  })
+
+  /* ---------------------------------------------------------------- */
+  /*  fetchAnthropicModels — Strategy 1 (API) + fallback              */
+  /* ---------------------------------------------------------------- */
+
+  describe('fetchAnthropicModels', () => {
+    it('returns the hardcoded fallback when no API key and no cache', async () => {
+      const mod = await loadFreshModule()
+      const models = await mod.fetchAnthropicModels()
+      expect(models).toEqual(mod.FALLBACK_MODELS)
+    })
+
+    it('maps, filters, and sorts the API catalog (newest created_at first)', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      mockFetch(() =>
+        jsonResponse({
+          data: [
+            { id: 'claude-sonnet-4-6', display_name: 'Sonnet 4.6', created_at: '2026-01-01' },
+            { id: 'claude-opus-4-8', display_name: 'Opus 4.8', created_at: '2026-05-01' },
+            { id: 'claude-embed-1', display_name: 'Embed', created_at: '2026-05-02' },
+            { id: 'gpt-4', display_name: 'Not Claude', created_at: '2026-05-03' },
+          ],
+        }),
+      )
+
+      const mod = await loadFreshModule()
+      const models = await mod.fetchAnthropicModels()
+
+      // embed + non-claude filtered out; sorted newest-first by created_at
+      expect(models).toEqual([
+        { id: 'claude-opus-4-8', label: 'Opus 4.8' },
+        { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+      ])
+    })
+
+    it('derives a label from the id when display_name is absent', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      mockFetch(() =>
+        jsonResponse({ data: [{ id: 'claude-haiku-4-5-20251001', created_at: '2026-01-01' }] }),
+      )
+
+      const mod = await loadFreshModule()
+      const models = await mod.fetchAnthropicModels()
+      expect(models).toEqual([{ id: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' }])
+    })
+
+    it('falls back when the API responds non-OK', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      mockFetch(() => jsonResponse({}, false))
+
+      const mod = await loadFreshModule()
+      const models = await mod.fetchAnthropicModels()
+      expect(models).toEqual(mod.FALLBACK_MODELS)
+    })
+
+    it('falls back when fetch throws', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      globalThis.fetch = vi.fn(async () => {
+        throw new Error('network down')
+      }) as typeof fetch
+
+      const mod = await loadFreshModule()
+      const models = await mod.fetchAnthropicModels()
+      expect(models).toEqual(mod.FALLBACK_MODELS)
+    })
+
+    it('serves cached models within the TTL without re-fetching', async () => {
+      vi.useFakeTimers()
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      const fetchSpy = vi.fn(() =>
+        jsonResponse({ data: [{ id: 'claude-opus-4-8', display_name: 'Opus 4.8', created_at: '2026-05-01' }] }),
+      )
+      globalThis.fetch = vi.fn(async () => fetchSpy()) as typeof fetch
+
+      const mod = await loadFreshModule()
+      await mod.fetchAnthropicModels()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+      // 30 min later — still within the 1h API TTL → cache hit, no new fetch
+      vi.advanceTimersByTime(30 * 60 * 1000)
+      await mod.fetchAnthropicModels()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-fetches once the API cache TTL expires', async () => {
+      vi.useFakeTimers()
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      const fetchSpy = vi.fn(() =>
+        jsonResponse({ data: [{ id: 'claude-opus-4-8', display_name: 'Opus 4.8', created_at: '2026-05-01' }] }),
+      )
+      globalThis.fetch = vi.fn(async () => fetchSpy()) as typeof fetch
+
+      const mod = await loadFreshModule()
+      await mod.fetchAnthropicModels()
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+      // Past the 1h TTL → cache expired → re-fetch
+      vi.advanceTimersByTime(61 * 60 * 1000)
+      await mod.fetchAnthropicModels()
+      expect(fetchSpy).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  /* ---------------------------------------------------------------- */
+  /*  triggerCliProbeIfNeeded — Strategy 2 (CLI probing)             */
+  /* ---------------------------------------------------------------- */
+
+  describe('triggerCliProbeIfNeeded', () => {
+    it('probes candidate models and caches the discovered IDs', async () => {
+      setExecFileImpl(new Set(['claude-opus-4-8', 'claude-sonnet-4-6']))
+
+      const mod = await loadFreshModule()
+      mod.triggerCliProbeIfNeeded()
+
+      await vi.waitFor(async () => {
+        const models = await mod.fetchAnthropicModels()
+        expect(models).toEqual([
+          { id: 'claude-opus-4-8', label: 'Opus 4.8' },
+          { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+        ])
+      })
+    })
+
+    it('de-duplicates model IDs returned by multiple probes', async () => {
+      // Two probed candidates resolve to the SAME underlying model id.
+      mockExecFile.mockImplementation((_bin: string, _args: string[], _opts: any, cb: ExecCallback) => {
+        queueMicrotask(() =>
+          cb(null, JSON.stringify({ is_error: false, modelUsage: { 'claude-opus-4-8': { inputTokens: 1 } } })),
+        )
+        return { unref: vi.fn() }
+      })
+
+      const mod = await loadFreshModule()
+      mod.triggerCliProbeIfNeeded()
+
+      await vi.waitFor(async () => {
+        const models = await mod.fetchAnthropicModels()
+        expect(models).toEqual([{ id: 'claude-opus-4-8', label: 'Opus 4.8' }])
+      })
+    })
+
+    it('does not start a second probe while one is in flight (de-dup)', async () => {
+      setExecFileImpl(new Set(['claude-opus-4-8']))
+
+      const mod = await loadFreshModule()
+      mod.triggerCliProbeIfNeeded()
+      const callsAfterFirst = mockExecFile.mock.calls.length
+      // Second synchronous call should be suppressed by probeInFlight guard.
+      mod.triggerCliProbeIfNeeded()
+      expect(mockExecFile.mock.calls.length).toBe(callsAfterFirst)
+
+      await vi.waitFor(() => expect(mockExecFile).toHaveBeenCalled())
+    })
+
+    it('skips probing entirely when an API key is present', async () => {
+      process.env.ANTHROPIC_API_KEY = 'sk-test'
+      setExecFileImpl(new Set(['claude-opus-4-8']))
+
+      const mod = await loadFreshModule()
+      mod.triggerCliProbeIfNeeded()
+
+      expect(mockExecFile).not.toHaveBeenCalled()
+    })
+
+    it('caches CLI results for 24h — a later trigger does not re-probe', async () => {
+      vi.useFakeTimers()
+      setExecFileImpl(new Set(['claude-opus-4-8']))
+
+      const mod = await loadFreshModule()
+      mod.triggerCliProbeIfNeeded()
+      await vi.waitFor(() => expect(mockExecFile).toHaveBeenCalled())
+      const callsAfterFirstProbe = mockExecFile.mock.calls.length
+
+      // 1h later — still inside the 24h CLI TTL → no new probe.
+      vi.advanceTimersByTime(60 * 60 * 1000)
+      mod.triggerCliProbeIfNeeded()
+      expect(mockExecFile.mock.calls.length).toBe(callsAfterFirstProbe)
+    })
+  })
+})

--- a/server/ws-message-handler.test.ts
+++ b/server/ws-message-handler.test.ts
@@ -4,10 +4,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 // Mock config so REPOS_ROOT covers test paths
 vi.mock('./config.js', () => ({ REPOS_ROOT: '/projects' }))
 
-// Mock fs.realpathSync to return paths as-is in tests (no real filesystem)
+// Mock fs.realpathSync — defaults to identity (no real filesystem); individual
+// tests can override the implementation to simulate symlink canonicalization.
+const realpathSyncMock = vi.fn((p: string) => p)
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>()
-  return { ...actual, realpathSync: (p: string) => p }
+  return { ...actual, realpathSync: (p: string) => realpathSyncMock(p) }
 })
 
 import { handleWsMessage, type WsHandlerContext } from './ws-message-handler.js'
@@ -89,6 +91,9 @@ describe('handleWsMessage', () => {
     ctx = createContext()
     // Wire up ws key so clientSessions.get(ws) works
     ctx.clientSessions.set(ctx.ws, 'sess-1')
+    // Reset realpath to identity by default
+    realpathSyncMock.mockReset()
+    realpathSyncMock.mockImplementation((p: string) => p)
   })
 
   /* ---- ping ---- */
@@ -137,6 +142,23 @@ describe('handleWsMessage', () => {
       expect(ctx.sessions.startClaude).toHaveBeenCalledWith('new-1')
     })
 
+    it('passes the canonical (realpath-resolved) dir to create(), not the raw path', () => {
+      // Simulate a symlinked working dir that resolves to a different canonical path
+      realpathSyncMock.mockImplementation((p: string) =>
+        p === '/projects/link' ? '/projects/app' : p,
+      )
+      const session = mockSession({ id: 'canon-1', workingDir: '/projects/app' })
+      ;(ctx.sessions.create as ReturnType<typeof vi.fn>).mockReturnValue(session)
+
+      handleWsMessage({
+        type: 'create_session',
+        name: 'Canon',
+        workingDir: '/projects/link',
+      } as WsClientMessage, ctx)
+
+      expect(ctx.sessions.create).toHaveBeenCalledWith('Canon', '/projects/app', expect.any(Object))
+    })
+
     it('rejects invalid permissionMode', () => {
       handleWsMessage({
         type: 'create_session',
@@ -179,6 +201,27 @@ describe('handleWsMessage', () => {
         sessionId: 'wt-1',
       })
       expect(ctx.sessions.startClaude).toHaveBeenCalledWith('wt-1')
+    })
+
+    it('passes the canonical (realpath-resolved) dir to createWorktree(), not the raw path', async () => {
+      realpathSyncMock.mockImplementation((p: string) =>
+        p === '/projects/link' ? '/projects/app' : p,
+      )
+      const session = mockSession({ id: 'wt-canon', name: 'WT Canon', workingDir: '/projects/app' })
+      ;(ctx.sessions.create as ReturnType<typeof vi.fn>).mockReturnValue(session)
+      ;(ctx.sessions.createWorktree as ReturnType<typeof vi.fn>).mockResolvedValue('/tmp/worktree')
+
+      handleWsMessage({
+        type: 'create_session',
+        name: 'WT Canon',
+        workingDir: '/projects/link',
+        useWorktree: true,
+      } as WsClientMessage, ctx)
+
+      await vi.waitFor(() => expect(ctx.sent.length).toBeGreaterThan(0))
+
+      expect(ctx.sessions.create).toHaveBeenCalledWith('WT Canon', '/projects/app', expect.any(Object))
+      expect(ctx.sessions.createWorktree).toHaveBeenCalledWith('wt-canon', '/projects/app')
     })
 
     it('sends error when worktree creation fails, then falls back', async () => {

--- a/server/ws-message-handler.ts
+++ b/server/ws-message-handler.ts
@@ -59,7 +59,9 @@ export function handleWsMessage(msg: WsClientMessage, ctx: WsHandlerContext): vo
       // restarts the process and drops the user's first message.
       const provider = msg.provider ?? 'claude'
       const model = msg.model ?? (provider === 'claude' ? getDefaultClaudeModel() : undefined)
-      const session = sessions.create(msg.name, msg.workingDir, { model, permissionMode: msg.permissionMode, allowedTools: msg.allowedTools, provider: msg.provider })
+      // Use the security-checked canonical path (not the raw msg.workingDir) so
+      // grouping/archive behavior stays consistent with the resolved directory.
+      const session = sessions.create(msg.name, resolvedDir, { model, permissionMode: msg.permissionMode, allowedTools: msg.allowedTools, provider: msg.provider })
       session.clients.add(ws)
       clientSessions.set(ws, session.id)
 
@@ -68,7 +70,7 @@ export function handleWsMessage(msg: WsClientMessage, ctx: WsHandlerContext): vo
 
       if (msg.useWorktree) {
         // Create worktree asynchronously, then start Claude in it
-        void sessions.createWorktree(session.id, msg.workingDir).then((wtPath) => {
+        void sessions.createWorktree(session.id, resolvedDir).then((wtPath) => {
           if (wtPath) {
             send({
               type: 'session_created',

--- a/src/hooks/useClaudeModelSync.test.ts
+++ b/src/hooks/useClaudeModelSync.test.ts
@@ -1,0 +1,114 @@
+/** Tests for useClaudeModelSync — verifies dynamic Claude model fetching:
+ *  initial fallback state, replacement with server results, auto-selection when
+ *  the current model disappears, and silent fallback on empty/error responses. */
+// @vitest-environment jsdom
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { createElement, act } from 'react'
+import { createRoot } from 'react-dom/client'
+
+// Mock the API layer — the hook only depends on fetchClaudeModels.
+const mockFetchClaudeModels = vi.hoisted(() => vi.fn())
+vi.mock('../lib/ccApi', () => ({ fetchClaudeModels: mockFetchClaudeModels }))
+
+import { useClaudeModelSync } from './useClaudeModelSync.js'
+import { CLAUDE_MODELS, type ModelOption } from '../types'
+
+interface Props {
+  token: string
+  currentModel: string | null
+  setModel: (model: string) => void
+}
+
+async function renderHook(props: Props): Promise<{
+  result: { current: { claudeModels: ModelOption[] } }
+  unmount: () => void
+}> {
+  const result = { current: { claudeModels: [] as ModelOption[] } }
+  const container = document.createElement('div')
+  const root = createRoot(container)
+
+  function TestComponent() {
+    result.current = useClaudeModelSync(props)
+    return null
+  }
+
+  // Mount + flush the fetch promise and resulting state updates.
+  await act(async () => {
+    root.render(createElement(TestComponent))
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+
+  return { result, unmount: () => act(() => root.unmount()) }
+}
+
+describe('useClaudeModelSync', () => {
+  beforeEach(() => {
+    mockFetchClaudeModels.mockReset()
+  })
+
+  it('does not fetch when there is no token', async () => {
+    const { result } = await renderHook({ token: '', currentModel: null, setModel: vi.fn() })
+    expect(mockFetchClaudeModels).not.toHaveBeenCalled()
+    expect(result.current.claudeModels).toEqual(CLAUDE_MODELS)
+  })
+
+  it('replaces the fallback list with fetched models', async () => {
+    const fetched = [
+      { id: 'claude-opus-5-0', label: 'Opus 5.0' },
+      { id: 'claude-sonnet-4-7', label: 'Sonnet 4.7' },
+    ]
+    mockFetchClaudeModels.mockResolvedValue(fetched)
+
+    const { result } = await renderHook({ token: 't', currentModel: 'claude-opus-5-0', setModel: vi.fn() })
+
+    expect(mockFetchClaudeModels).toHaveBeenCalledWith('t')
+    expect(result.current.claudeModels).toEqual(fetched)
+  })
+
+  it('auto-selects the first fetched model when the current one is gone', async () => {
+    mockFetchClaudeModels.mockResolvedValue([
+      { id: 'claude-opus-5-0', label: 'Opus 5.0' },
+      { id: 'claude-sonnet-4-7', label: 'Sonnet 4.7' },
+    ])
+    const setModel = vi.fn()
+
+    await renderHook({ token: 't', currentModel: 'claude-opus-4-6', setModel })
+
+    expect(setModel).toHaveBeenCalledWith('claude-opus-5-0')
+  })
+
+  it('keeps the current model when it is still present in the fetched list', async () => {
+    mockFetchClaudeModels.mockResolvedValue([
+      { id: 'claude-opus-5-0', label: 'Opus 5.0' },
+      { id: 'claude-sonnet-4-7', label: 'Sonnet 4.7' },
+    ])
+    const setModel = vi.fn()
+
+    await renderHook({ token: 't', currentModel: 'claude-sonnet-4-7', setModel })
+
+    expect(setModel).not.toHaveBeenCalled()
+  })
+
+  it('keeps the fallback list when the server returns no models', async () => {
+    mockFetchClaudeModels.mockResolvedValue([])
+    const setModel = vi.fn()
+
+    const { result } = await renderHook({ token: 't', currentModel: 'claude-opus-4-6', setModel })
+
+    expect(result.current.claudeModels).toEqual(CLAUDE_MODELS)
+    expect(setModel).not.toHaveBeenCalled()
+  })
+
+  it('keeps the fallback list when the fetch rejects', async () => {
+    mockFetchClaudeModels.mockRejectedValue(new Error('network'))
+    const setModel = vi.fn()
+
+    const { result } = await renderHook({ token: 't', currentModel: 'claude-opus-4-6', setModel })
+
+    expect(result.current.claudeModels).toEqual(CLAUDE_MODELS)
+    expect(setModel).not.toHaveBeenCalled()
+  })
+})

--- a/src/hooks/useProviderValidation.test.ts
+++ b/src/hooks/useProviderValidation.test.ts
@@ -1,0 +1,112 @@
+/** Tests for useProviderValidation — verifies that the active Claude model is
+ *  reconciled against the available model list, auto-selecting the first when
+ *  the current selection is unknown, and that non-claude providers are skipped. */
+// @vitest-environment jsdom
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+import { describe, it, expect, vi } from 'vitest'
+import { createElement, act } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import { useProviderValidation } from './useProviderValidation.js'
+import type { CodingProvider, ModelOption } from '../types'
+
+interface Props {
+  activeSessionProvider: CodingProvider
+  currentModel: string | null
+  setModel: (model: string) => void
+  claudeModels: ModelOption[]
+}
+
+function renderHook(initial: Props): {
+  rerender: (next: Props) => void
+  unmount: () => void
+} {
+  const container = document.createElement('div')
+  const root = createRoot(container)
+
+  function TestComponent(props: Props) {
+    useProviderValidation(props)
+    return null
+  }
+
+  act(() => {
+    root.render(createElement(TestComponent, initial))
+  })
+
+  return {
+    rerender: (next: Props) => act(() => root.render(createElement(TestComponent, next))),
+    unmount: () => act(() => root.unmount()),
+  }
+}
+
+const MODELS: ModelOption[] = [
+  { id: 'claude-opus-4-8', label: 'Opus 4.8' },
+  { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+]
+
+describe('useProviderValidation', () => {
+  it('auto-selects the first model when currentModel is unknown', () => {
+    const setModel = vi.fn()
+    renderHook({
+      activeSessionProvider: 'claude',
+      currentModel: 'claude-gone-1-0',
+      setModel,
+      claudeModels: MODELS,
+    })
+    expect(setModel).toHaveBeenCalledWith('claude-opus-4-8')
+  })
+
+  it('does not reassign when currentModel is already valid', () => {
+    const setModel = vi.fn()
+    renderHook({
+      activeSessionProvider: 'claude',
+      currentModel: 'claude-sonnet-4-6',
+      setModel,
+      claudeModels: MODELS,
+    })
+    expect(setModel).not.toHaveBeenCalled()
+  })
+
+  it('does nothing for non-claude providers', () => {
+    const setModel = vi.fn()
+    renderHook({
+      activeSessionProvider: 'opencode' as CodingProvider,
+      currentModel: 'something-else',
+      setModel,
+      claudeModels: MODELS,
+    })
+    expect(setModel).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when the model list is empty (discovery not yet loaded)', () => {
+    const setModel = vi.fn()
+    renderHook({
+      activeSessionProvider: 'claude',
+      currentModel: 'claude-gone-1-0',
+      setModel,
+      claudeModels: [],
+    })
+    expect(setModel).not.toHaveBeenCalled()
+  })
+
+  it('reconciles after the model list changes on rerender', () => {
+    const setModel = vi.fn()
+    const { rerender } = renderHook({
+      activeSessionProvider: 'claude',
+      currentModel: 'claude-opus-4-8',
+      setModel,
+      claudeModels: MODELS,
+    })
+    expect(setModel).not.toHaveBeenCalled()
+
+    // New discovery result no longer contains the current model → reconcile.
+    rerender({
+      activeSessionProvider: 'claude',
+      currentModel: 'claude-opus-4-8',
+      setModel,
+      claudeModels: [{ id: 'claude-opus-5-0', label: 'Opus 5.0' }],
+    })
+    expect(setModel).toHaveBeenCalledWith('claude-opus-5-0')
+  })
+})


### PR DESCRIPTION
## Summary
Addresses two items from a recent code-review report (verified against the actual code):

- **#2 Canonical workingDir** — `create_session` validated the realpath but stored the raw `msg.workingDir`. Now passes `resolvedDir` into both `sessions.create()` and `createWorktree()`, keeping grouping/archive behavior consistent with the canonical path. The `session_created` responses already echo `session.workingDir`, so the client gets the canonical path automatically.
- **#5 Model-discovery tests** — the dynamic Claude model discovery/sync flow (added in #479/#480) had no direct test coverage. Adds 23 tests.

Two other report items were dropped after verification: a claimed `sendInput()` startup race (the guard is fully synchronous — no input loss possible) and a claimed `LIKE %/basename` archive-matching bug (the code uses exact match, the issue doesn't exist). A Stepflow SSRF DNS-resolution hardening item is being scoped separately.

## Changes
- `server/ws-message-handler.ts` — use `resolvedDir` for `create()` / `createWorktree()`
- `server/ws-message-handler.test.ts` — 2 tests asserting the canonical (realpath-resolved) dir is used, for both worktree and non-worktree paths
- `server/anthropic-models.test.ts` (new, 12) — API map/filter/sort, fallback, 1h/24h cache TTLs, CLI probe + in-flight de-dup, API-key skip
- `src/hooks/useClaudeModelSync.test.ts` (new, 6) — list replacement, auto-select, empty/error fallback
- `src/hooks/useProviderValidation.test.ts` (new, 5) — model reconciliation against the available list

## Test plan
- [x] `npm test` — 2096 passing (84 files)
- [x] `tsc -b` clean
- [x] lint clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)