### PR TITLE
fix: harden workflow query builder against SQL injection

### DIFF
--- a/server/workflow-engine.test.ts
+++ b/server/workflow-engine.test.ts
@@ -30,7 +30,7 @@ vi.mock('fs', async (importOriginal) => {
   }
 })
 
-import { WorkflowEngine, WorkflowSkipped, SessionGoneError, initWorkflowEngine, getWorkflowEngine, shutdownWorkflowEngine, cronMatchesDate } from './workflow-engine.js'
+import { WorkflowEngine, WorkflowSkipped, SessionGoneError, initWorkflowEngine, getWorkflowEngine, shutdownWorkflowEngine, cronMatchesDate, buildListQuery } from './workflow-engine.js'
 import type { StepHandler } from './workflow-engine.js'
 
 describe('WorkflowEngine', () => {
@@ -447,6 +447,42 @@ describe('WorkflowEngine', () => {
       engine.listRuns({ kind: 'test', status: 'failed', limit: 10, offset: 5 })
       // Verify the SQL was called (we can check prepare was called)
       expect(mockAll).toHaveBeenCalled()
+    })
+  })
+
+  describe('buildListQuery', () => {
+    it('builds a parameterized query for valid inputs', () => {
+      const { sql, params } = buildListQuery('workflow_runs', {
+        filters: [{ column: 'kind', value: 'test' }, { column: 'status', value: 'failed' }],
+        orderBy: 'created_at DESC',
+        limit: 10,
+        offset: 5,
+      })
+      expect(sql).toBe('SELECT * FROM workflow_runs WHERE 1=1 AND kind = ? AND status = ? ORDER BY created_at DESC LIMIT ? OFFSET ?')
+      expect(params).toEqual(['test', 'failed', 10, 5])
+    })
+
+    it('rejects an injection attempt in the table name', () => {
+      expect(() => buildListQuery('workflow_runs; DROP TABLE workflow_runs', { filters: [] }))
+        .toThrow(/invalid table name/)
+    })
+
+    it('rejects an injection attempt in a filter column', () => {
+      expect(() => buildListQuery('workflow_runs', {
+        filters: [{ column: 'kind = 1 OR 1=1 --', value: 'x' }],
+      })).toThrow(/invalid filter column/)
+    })
+
+    it('rejects an injection attempt in the orderBy clause', () => {
+      expect(() => buildListQuery('workflow_runs', {
+        filters: [],
+        orderBy: 'created_at; DROP TABLE workflow_runs',
+      })).toThrow(/invalid orderBy clause/)
+    })
+
+    it('rejects an orderBy without an explicit direction', () => {
+      expect(() => buildListQuery('workflow_runs', { filters: [], orderBy: 'created_at' }))
+        .toThrow(/invalid orderBy clause/)
     })
   })
 

--- a/server/workflow-engine.ts
+++ b/server/workflow-engine.ts
@@ -282,17 +282,45 @@ interface ListQueryOpts {
   offset?: number
 }
 
-/** Build a parameterized SELECT query from typed filter objects. */
-function buildListQuery(table: string, opts: ListQueryOpts): { sql: string; params: unknown[] } {
+/**
+ * A bare SQL identifier: a table or column name with no quoting, spaces, or
+ * other metacharacters. Filter values are always parameterized, but table and
+ * column names cannot be — so they are validated against this pattern to ensure
+ * a future caller passing user-controlled input cannot inject SQL.
+ */
+const SQL_IDENTIFIER = /^[a-z_][a-z0-9_]*$/i
+
+/** An ORDER BY clause: a single identifier followed by an explicit direction. */
+const SQL_ORDER_BY = /^[a-z_][a-z0-9_]* (ASC|DESC)$/i
+
+/**
+ * Build a parameterized SELECT query from typed filter objects.
+ *
+ * Exported for testing. Filter values are parameterized; table/column/orderBy
+ * are validated as bare SQL identifiers since they cannot be parameterized.
+ */
+export function buildListQuery(table: string, opts: ListQueryOpts): { sql: string; params: unknown[] } {
+  if (!SQL_IDENTIFIER.test(table)) {
+    throw new Error(`buildListQuery: invalid table name '${table}'`)
+  }
+
   const params: unknown[] = []
   let sql = `SELECT * FROM ${table} WHERE 1=1`
 
   for (const f of opts.filters) {
+    if (!SQL_IDENTIFIER.test(f.column)) {
+      throw new Error(`buildListQuery: invalid filter column '${f.column}'`)
+    }
     sql += ` AND ${f.column} = ?`
     params.push(f.value)
   }
 
-  if (opts.orderBy) sql += ` ORDER BY ${opts.orderBy}`
+  if (opts.orderBy) {
+    if (!SQL_ORDER_BY.test(opts.orderBy)) {
+      throw new Error(`buildListQuery: invalid orderBy clause '${opts.orderBy}'`)
+    }
+    sql += ` ORDER BY ${opts.orderBy}`
+  }
   if (opts.limit) { sql += ` LIMIT ?`; params.push(opts.limit) }
   if (opts.offset) { sql += ` OFFSET ?`; params.push(opts.offset) }
 


### PR DESCRIPTION
## Summary
- Validates the table name, filter column names, and `ORDER BY` clause in `buildListQuery` (`server/workflow-engine.ts`) as bare SQL identifiers, throwing on anything else. Filter values remain parameterized as before.
- This is a **defensive / latent-risk** fix: every current caller passes hardcoded values, so it is not exploitable today. The generic signature means a future caller wiring user input into a column or sort parameter would otherwise create a direct SQL injection with no compiler warning.
- Exports the helper and adds unit tests covering valid query construction and rejected injection attempts (malicious table, column, and `ORDER BY` inputs).

## Context
Surfaced by the 2026-06-04 automated security audit (finding **M1**). Two other audit items were dropped after verification: the GitHub-webhook-secret fail-fast (L4) is already implemented, and the `TRUST_PROXY` hardening (L3) turned out to be more involved than a config tweak — it touches the manual `X-Forwarded-For` parsing on the WebSocket path and changes documented semantics, so it's deferred for separate discussion.

## Test plan
- [x] `npx vitest run server/workflow-engine.test.ts` — 53 passed (5 new)
- [x] `npm run build` — typecheck + production build clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only, none in changed files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)