### PR TITLE
docs: record unreleased changes in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Dynamic Claude model discovery — probe candidate model IDs at runtime instead of relying on static aliases, adding Opus 4.8 support (#479, #480)
+
+### Changed
+- Make coverage configuration honest (`coverage.all`) and start covering React components (#487)
+
+### Fixed
+- Canonicalize WebSocket `workingDir` and add model-discovery tests (#488)
+- Group webhook/stepflow sessions under canonical owner-namespaced repo (#481)
+- Surface and resume archived sessions across repo clone paths (#482)
+- Start new sessions on the latest model and surface reconnect notices (#483)
+- Make session auto-naming resilient to rate limits and chatty replies (#484)
+
+### Docs
+- Fix accuracy drift surfaced by docs audit (#489)
+
 ## [0.6.5] - 2026-05-14
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds an `[Unreleased]` section to `CHANGELOG.md` covering the 11 commits that landed on 2026-06-03 (dynamic model discovery, WebSocket `workingDir` canonicalization, session-grouping fixes, coverage overhaul, docs audit) — these had not been recorded.

## Context
Surfaced by a repo-health audit. The audit also recommended adding `noImplicitReturns` to `server/tsconfig.json` for config parity, but enabling it flags ~40 Express route handlers (the standard send-response-then-fall-through pattern — not bugs). That turned out to be a real refactor rather than the no-op it was pitched as, so it was dropped from this PR. Worth tracking separately if desired.

## Test plan
- [x] `npm run build` passes (tsc + vite)
- [x] Diff is CHANGELOG-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)