### PR TITLE
feat: add Claude Fable 5 model support

### DIFF
--- a/server/anthropic-models.ts
+++ b/server/anthropic-models.ts
@@ -24,6 +24,7 @@ export interface ClaudeModelInfo {
  *  Per https://platform.claude.com/docs/en/about-claude/models/overview */
 export const FALLBACK_MODELS: ClaudeModelInfo[] = [
   { id: 'claude-opus-4-8', label: 'Opus 4.8' },
+  { id: 'claude-fable-5', label: 'Fable 5' },
   { id: 'claude-opus-4-7', label: 'Opus 4.7' },
   { id: 'claude-opus-4-6', label: 'Opus 4.6' },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
@@ -38,6 +39,9 @@ export const FALLBACK_MODELS: ClaudeModelInfo[] = [
  * probes cost ~$0.04 each. Probing in parallel keeps total wall time under 5s.
  */
 const CANDIDATE_MODEL_IDS: string[] = [
+  // Fable family (5th-generation flagship; GA 2026-06-09). Dateless pinned ID.
+  'claude-fable-5',
+  'claude-fable-6',
   // Opus family (currently 4.6, 4.7, 4.8 are live; probe ahead for new releases)
   'claude-opus-4-6',
   'claude-opus-4-7',
@@ -75,13 +79,14 @@ let probeInFlight: Promise<void> | null = null
  * Build a human-friendly label from a model ID.
  * e.g. "claude-opus-4-8" → "Opus 4.8"
  *      "claude-haiku-4-5-20251001" → "Haiku 4.5"
+ *      "claude-fable-5" → "Fable 5"  (single-version, dateless IDs)
  */
 function labelFromId(id: string): string {
   const rest = id.replace(/^claude-/, '')
-  const m = rest.match(/^(\w+?)-(\d+)-(\d+)/)
+  const m = rest.match(/^(\w+?)-(\d+)(?:-(\d+))?/)
   if (m) {
     const family = m[1].charAt(0).toUpperCase() + m[1].slice(1)
-    return `${family} ${m[2]}.${m[3]}`
+    return m[3] ? `${family} ${m[2]}.${m[3]}` : `${family} ${m[2]}`
   }
   return id
 }

--- a/src/components/ChatView.test.ts
+++ b/src/components/ChatView.test.ts
@@ -15,6 +15,10 @@ describe('formatModelName', () => {
     expect(formatModelName('claude-haiku-3-5')).toBe('Haiku 3.5')
   })
 
+  it('parses single-version dateless id claude-fable-5 → Fable 5', () => {
+    expect(formatModelName('claude-fable-5')).toBe('Fable 5')
+  })
+
   it('returns raw string for non-matching input', () => {
     expect(formatModelName('gpt-4o')).toBe('gpt-4o')
   })

--- a/src/lib/chatFormatters.ts
+++ b/src/lib/chatFormatters.ts
@@ -1,9 +1,9 @@
 /** Format a Claude model ID into a human-readable label. */
 export function formatModelName(modelId: string): string {
-  const m = modelId.match(/^claude-(\w+)-(\d+)-(\d+)/)
+  const m = modelId.match(/^claude-(\w+)-(\d+)(?:-(\d+))?/)
   if (m) {
     const name = m[1].charAt(0).toUpperCase() + m[1].slice(1)
-    return `${name} ${m[2]}.${m[3]}`
+    return m[3] ? `${name} ${m[2]}.${m[3]}` : `${name} ${m[2]}`
   }
   return modelId
 }

--- a/src/lib/workflowHelpers.ts
+++ b/src/lib/workflowHelpers.ts
@@ -40,6 +40,7 @@ export function isEventDriven(kind: string): boolean {
 /** Model options for the workflow config UI. Empty value means server default (Opus). */
 export const MODEL_OPTIONS = [
   { value: '', label: 'Default (Opus)' },
+  { value: 'claude-fable-5', label: 'Fable 5' },
   { value: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
   { value: 'claude-haiku-4-5-20251001', label: 'Haiku 4.5' },
 ]

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export interface ModelOption { id: string; label: string }
 /** Static models for Claude Code CLI. Used as fallback before dynamic discovery completes. */
 export const CLAUDE_MODELS: ModelOption[] = [
   { id: 'claude-opus-4-8', label: 'Opus 4.8' },
+  { id: 'claude-fable-5', label: 'Fable 5' },
   { id: 'claude-opus-4-7', label: 'Opus 4.7' },
   { id: 'claude-opus-4-6', label: 'Opus 4.6' },
   { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },


### PR DESCRIPTION
## Summary
- Adds **Claude Fable 5** (`claude-fable-5`) to Codekin's model pickers — Anthropic's most capable widely-released model (GA 2026-06-09; 1M context, 128k output, adaptive thinking always on). Confirmed available by probing the installed CLI.
- Surfaces it in both discovery paths (server `FALLBACK_MODELS` + `CANDIDATE_MODEL_IDS`) and the frontend (`CLAUDE_MODELS`, workflow `MODEL_OPTIONS`).
- Fixes `labelFromId` and `formatModelName`, which assumed a two-number `family-N-N` slug — Fable 5's dateless single-version ID now renders as **"Fable 5"** instead of the raw `claude-fable-5`.

## Decision
**Opus 4.8 remains the auto-selected default** (`[0]` of the model lists). Fable 5 is offered as the flagship option but not the default, because it costs 2× per token ($10/$50 vs $5/$25 MTok) and the official docs still recommend Opus 4.8 as the starting point. Easy to promote to default if desired.

Note: `claude-mythos-5` was deliberately excluded — it is invitation-only (Project Glasswing), not GA.

## Test plan
- [x] `npm run build` — typecheck + Vite build pass
- [x] `npm test` — 2154 passed (88 files), incl. new `formatModelName('claude-fable-5') → 'Fable 5'` regression test
- [x] `npm run lint` — 0 errors
- [ ] Verify Fable 5 appears in the model picker in the running UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)