### PR TITLE
feat: use OpenCode's native agents, permissions, commands, and system context

### DIFF
--- a/.codekin/reports/architecture/2026-06-11_opencode-integration-audit.md
+++ b/.codekin/reports/architecture/2026-06-11_opencode-integration-audit.md
@@ -86,6 +86,11 @@ The three reported symptoms map to concrete causes:
 - `src/components/InputBar.tsx`, `src/App.tsx` — provider-conditional UI
 - `~/.config/opencode/opencode.jsonc` — system prompt override (outside repo)
 
+## Decision log
+
+- **2026-06-11 — `@opencode-ai/sdk` adoption (roadmap item 4): deferred.** The hand-rolled HTTP/SSE client has since been hardened (turn watchdog, resync via message history, permission-reply retries) and is covered by unit tests that exercise the exact wire shapes of the installed OpenCode version. The SDK tracks the latest upstream protocol and pulls in its own transport; swapping it in now risks regressing the just-fixed turn-lifecycle behavior for no immediate functional gain. Revisit when upgrading the OpenCode server version, where the SDK's typed protocol would pay for the migration.
+- **2026-06-11 — Roadmap items 1–3, 5, 6 implemented**: prompt-override removal, turn-lifecycle hardening, permission-mode mapping (`permission` ruleset on session create/PATCH), plan mode via the `plan` agent, Codekin context via the additive `system` prompt field, OpenCode commands surfaced in the slash-command autocomplete and routed to `POST /session/:id/command`, permission metadata in approval prompts, step-finish flushing, and provider inference fixes.
+
 ## Upstream references
 
 - OpenCode server/SDK docs: opencode.ai/docs/server, /docs/sdk, /docs/permissions, /docs/agents, /docs/rules

--- a/.codekin/reports/architecture/2026-06-11_opencode-integration-audit.md
+++ b/.codekin/reports/architecture/2026-06-11_opencode-integration-audit.md
@@ -1,0 +1,92 @@
+# OpenCode Integration Audit
+
+**Date:** 2026-06-11
+**Scope:** How Codekin integrates OpenCode vs Claude Code, why OpenCode sessions feel verbose / loop / stall, and high-level improvements to take full advantage of the platform.
+
+---
+
+## Executive summary
+
+Codekin's OpenCode integration is structurally sound — it correctly uses `opencode serve` + HTTP + SSE rather than the fragile `opencode run` mode — but it is **semantically hollow**. The transport works; almost everything layered on top of the transport for Claude (system-prompt injection, agent/mode selection, permission configuration, plan mode, turn-completion guarantees, skills, model switching) is missing or stubbed for OpenCode. In addition, a global user config (`~/.config/opencode/opencode.jsonc`) **replaces OpenCode's tuned build-agent system prompt** with a generic one, which by itself plausibly explains much of the verbosity and looping.
+
+The three reported symptoms map to concrete causes:
+
+| Symptom | Primary cause |
+|---|---|
+| Verbose, runs in circles | Tuned system prompt replaced by generic override in `~/.config/opencode/opencode.jsonc`; no Codekin context injected; no agent (`build`/`plan`) selected per turn |
+| Stops mid-way | Turn-completion latch can never fire if SSE drops before `session.idle`; no in-flight turn timeout; permission `ask` states can deadlock; zombie sessions after reconnect exhaustion |
+| Generally weaker than Claude sessions | Feature gaps: no AGENTS.md/skills surface, no plan mode, no permission-mode mapping, no mid-session model picker, lossy event translation |
+
+---
+
+## 1. Root cause outside the repo: the system prompt override
+
+`~/.config/opencode/opencode.jsonc` sets `agent.build.prompt` to a long generic prompt. Per OpenCode semantics, this **replaces** (does not append to) the tuned, provider-specific system prompt OpenCode ships per model — including its conciseness norms, todo discipline, and anti-looping guidance. Codekin does not write this file, but every Codekin OpenCode session inherits it.
+
+**Recommendation (highest impact, zero code):** remove or drastically trim the `agent.build.prompt` override. If Codekin-specific guidance is needed, prefer an `AGENTS.md`/`instructions` entry (additive) over `agent.*.prompt` (replacing).
+
+## 2. "Stops mid-way": turn lifecycle is not robust
+
+`server/opencode-process.ts`:
+
+- **Turn-completion latch with no safety net** (`turnComplete`, lines 262, 658–737, 853): the turn only ends when one of `message.completed` / `session.status` / `session.idle` arrives over SSE. If the SSE stream drops mid-turn and the idle event is missed, the latch never fires — the session hangs with no `result`, indefinitely. There is no in-flight turn timeout (Claude path has a 60s startup timeout; OpenCode has none anywhere).
+- **Zombie sessions after reconnect exhaustion** (lines 369–453): after 20 failed SSE reconnects the code emits `error` but the process stays `alive` and never emits `exit` — the frontend shows a running session that will never respond.
+- **Reconnect does not recover turn state**: on reconnect, `turnComplete`, delta buffers, and reasoning state are not reconciled with the server (the server API exposes message history that could be used to resync).
+- **Permission deadlocks**: OpenCode defaults several permissions to `ask` (`external_directory`, `doom_loop`, `.env` read denied). Codekin surfaces `permission.asked` as a control request, but (a) permission replies that fail over HTTP are swallowed (lines 784–789) — the user believes they approved while OpenCode still blocks; (b) Codekin never configures OpenCode's `permission` object from the session's `permissionMode`, despite the field claiming so (line 241), so `bypassPermissions` sessions still hit `ask` states server-side until the event round-trips.
+
+**Recommendations:**
+- Add a per-turn watchdog: if no SSE event for a session arrives for N seconds while a turn is open, query `GET /session/:id/message` (or session status) to resync, and force-complete or surface an error.
+- After reconnect exhaustion, emit `exit` so the session transitions to a terminal state in the UI.
+- On permission-reply HTTP failure, retry and surface the failure as a session error instead of `console.error`.
+- Map Codekin `permissionMode` to OpenCode's `permission` config at session creation (e.g. `bypassPermissions` → all-allow), instead of only reactively auto-approving `permission.asked` events.
+
+## 3. Feature parity gaps vs the Claude path
+
+| Capability | Claude path | OpenCode path | OpenCode supports it? |
+|---|---|---|---|
+| System prompt context | `--append-system-prompt` with Codekin environment guidance (`claude-process.ts:208–215`) | none | Yes — `instructions` config, AGENTS.md, or custom agent definitions |
+| Plan mode | `EnterPlanMode`/`ExitPlanMode` detection → `planning_mode` events | none, despite `capabilities.planMode: true` (line 114) | Yes — first-class `plan` agent; select via `agent` field on prompt |
+| Agent selection | n/a (permission modes) | prompt body sends only `parts` + `model` (lines 909–926); never selects `build`/`plan`/custom agents | Yes — `agent` param on `/session/:id/prompt` |
+| Permission modes | `--permission-mode`, granular control, `updatedInput` | global once/always/reject only; mode not pushed into config | Yes — per-tool `permission` object with pattern rules |
+| Skills / slash commands | `.claude/skills` menu in InputBar | hidden | Partially — OpenCode has its own commands API (`/command` endpoints), unused |
+| Mid-session model picker | InputBar dropdown | only at session creation (`App.tsx:222, 274–276`) | Yes — model is per-request already (lines 912–916); this is purely a UI gap |
+| Todos | `todo_update` events → TodoPanel | partial (todowrite mapped) but step boundaries (`step-start`/`step-finish`) discarded (line 647) | Yes |
+| Thinking display | thinking blocks → activity label | fragile text/reasoning delta disambiguation (lines 509–522) | Yes — `--thinking` / reasoning parts |
+| Tool input summaries in permission UI | `summarizeToolInput` | permission type string only — user sees e.g. "external_directory" with no detail | Yes — `permission.asked` carries pattern/metadata |
+| Context files | CLAUDE.md auto-loaded by CLI | implicit only (OpenCode falls back to CLAUDE.md unless `OPENCODE_DISABLE_CLAUDE_CODE=1`) — never verified or surfaced | Yes |
+
+## 4. Translation-layer quality issues
+
+- **Lossy event handling**: unhandled SSE event types are logged and dropped (`opencode-process.ts:762–767`). No inventory exists of which OpenCode bus events matter; new event types added upstream degrade silently.
+- **User-echo heuristic**: initial deltas are buffered and compared against `lastUserInput` to suppress echo (lines 526–537, 853–860). If SSE drops before the buffer flushes, text is lost; flags are not reset on reconnect.
+- **Hand-rolled HTTP/SSE client**: the official `@opencode-ai/sdk` (`createOpencodeClient`) provides typed sessions, events, and permission replies. Migrating would eliminate most of the bespoke parsing and track upstream protocol changes.
+- **Brittle provider inference**: `EditWorkflowModal.tsx:36–38` infers provider from `!model.startsWith('claude-')`.
+
+## 5. UX gaps (frontend)
+
+- No permission-mode selector, no plan-mode entry point, no skills menu, and no mid-session model switcher for OpenCode sessions (`InputBar.tsx:503–517`, `App.tsx:222`), even where the backend could support them today.
+- Features silently degrade: if OpenCode emits no `thinking`/`todo_update`/`planning_mode`, the UI shows empty state with no indication the capability is absent.
+- Session resume rebuilds from `outputBuffer` uniformly (`useChatSocket.ts:327–366`) but no verification that the OpenCode path populates equivalent history events.
+
+---
+
+## Prioritized roadmap
+
+1. **Fix the prompt override** (config change, no code): restore OpenCode's native system prompt; move any custom guidance to AGENTS.md/`instructions`. Likely fixes most verbosity/looping.
+2. **Turn-lifecycle hardening** (server): in-flight turn watchdog + resync via message history; emit `exit` on reconnect exhaustion; retry + surface permission-reply failures. Fixes "stops mid-way".
+3. **Map permission modes** to OpenCode's `permission` config at session creation; pass `agent: 'plan' | 'build'` on prompts to get real plan mode; surface permission metadata (patterns) in the approval UI.
+4. **Adopt `@opencode-ai/sdk`** to replace the hand-rolled SSE/HTTP client and reduce translation-layer drift.
+5. **Frontend parity**: mid-session model picker (backend already supports it), agent selector, OpenCode commands menu, and explicit "not supported by this provider" affordances instead of silent empty states.
+6. **Inject Codekin context** for OpenCode sessions (web-terminal environment, report conventions) via project `AGENTS.md` or per-session `instructions`, mirroring `--append-system-prompt`.
+
+## Key files
+
+- `server/opencode-process.ts` — spawn, SSE, turn latch, permissions (988 lines)
+- `server/claude-process.ts` — reference implementation of the richer path (779 lines)
+- `src/components/InputBar.tsx`, `src/App.tsx` — provider-conditional UI
+- `~/.config/opencode/opencode.jsonc` — system prompt override (outside repo)
+
+## Upstream references
+
+- OpenCode server/SDK docs: opencode.ai/docs/server, /docs/sdk, /docs/permissions, /docs/agents, /docs/rules
+- Known headless-hang issues: anomalyco/opencode#3503, #11899, #14473, #16367, #17516

--- a/server/opencode-process.test.ts
+++ b/server/opencode-process.test.ts
@@ -535,6 +535,144 @@ describe('OpenCodeProcess', () => {
   })
 
   // ---------------------------------------------------------------------------
+  // Turn lifecycle hardening
+  // ---------------------------------------------------------------------------
+
+  describe('turn lifecycle', () => {
+    it('emits result only once even when multiple idle events arrive', () => {
+      const resultHandler = vi.fn()
+      ocp.on('result', resultHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'session.idle',
+        properties: { sessionID: 'oc-session-1' },
+      })
+      callHandleSSE(ocp, {
+        type: 'message.completed',
+        properties: { sessionID: 'oc-session-1' },
+      })
+      callHandleSSE(ocp, {
+        type: 'session.status',
+        properties: { sessionID: 'oc-session-1', status: { type: 'idle' } },
+      })
+      expect(resultHandler).toHaveBeenCalledTimes(1)
+    })
+
+    it('clears the turn watchdog when the turn completes', () => {
+      setSessionId(ocp, 'oc-session-1')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).startTurnWatchdog()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((ocp as any).turnWatchdog).not.toBeNull()
+
+      callHandleSSE(ocp, {
+        type: 'session.idle',
+        properties: { sessionID: 'oc-session-1' },
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((ocp as any).turnWatchdog).toBeNull()
+    })
+
+    it('recovers a missed completion event via message poll', async () => {
+      const resultHandler = vi.fn()
+      ocp.on('result', resultHandler)
+      setSessionId(ocp, 'oc-session-1')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).alive = true
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).turnComplete = false
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { info: { role: 'user', time: { created: 1 } } },
+          { info: { role: 'assistant', time: { created: 2, completed: 3 } } },
+        ],
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (ocp as any).checkTurnLiveness(true)
+      expect(resultHandler).toHaveBeenCalledWith('', false)
+    })
+
+    it('does not force-complete when the assistant message is still running', async () => {
+      const resultHandler = vi.fn()
+      ocp.on('result', resultHandler)
+      setSessionId(ocp, 'oc-session-1')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).alive = true
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { info: { role: 'assistant', time: { created: 2 } } },
+        ],
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (ocp as any).checkTurnLiveness(true)
+      expect(resultHandler).not.toHaveBeenCalled()
+    })
+
+    it('handles flat message objects (no info wrapper) in poll response', async () => {
+      const resultHandler = vi.fn()
+      ocp.on('result', resultHandler)
+      setSessionId(ocp, 'oc-session-1')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).alive = true
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          { role: 'assistant', time: { created: 2, completed: 3 } },
+        ],
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (ocp as any).checkTurnLiveness(true)
+      expect(resultHandler).toHaveBeenCalledWith('', false)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Permission reply retries
+  // ---------------------------------------------------------------------------
+
+  describe('permission reply retries', () => {
+    it('emits error when all permission reply attempts fail', async () => {
+      const errorHandler = vi.fn()
+      ocp.on('error', errorHandler)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).permissionRetryDelayMs = 0
+      mockFetch.mockRejectedValue(new Error('connection refused'))
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (ocp as any).replyToPermission('perm-1', 'once')
+
+      expect(mockFetch).toHaveBeenCalledTimes(3)
+      expect(errorHandler).toHaveBeenCalledTimes(1)
+      expect(errorHandler.mock.calls[0][0]).toContain('permission response')
+    })
+
+    it('does not emit error when a retry succeeds', async () => {
+      const errorHandler = vi.fn()
+      ocp.on('error', errorHandler)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).permissionRetryDelayMs = 0
+      mockFetch
+        .mockRejectedValueOnce(new Error('connection refused'))
+        .mockResolvedValueOnce({ ok: true })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (ocp as any).replyToPermission('perm-2', 'once')
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+      expect(errorHandler).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // Tool input summarization
   // ---------------------------------------------------------------------------
 

--- a/server/opencode-process.test.ts
+++ b/server/opencode-process.test.ts
@@ -26,7 +26,7 @@ vi.mock('child_process', async (importOriginal) => {
   }
 })
 
-import { OpenCodeProcess, stopOpenCodeServer } from './opencode-process.js'
+import { OpenCodeProcess, stopOpenCodeServer, permissionRulesetFor, OPENCODE_SYSTEM_CONTEXT } from './opencode-process.js'
 import { OPENCODE_CAPABILITIES } from './coding-process.js'
 
 describe('OpenCodeProcess', () => {
@@ -632,6 +632,161 @@ describe('OpenCodeProcess', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (ocp as any).checkTurnLiveness(true)
       expect(resultHandler).toHaveBeenCalledWith('', false)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Permission mode → OpenCode permission ruleset
+  // ---------------------------------------------------------------------------
+
+  describe('permissionRulesetFor', () => {
+    it('maps bypassPermissions to an all-allow ruleset', () => {
+      expect(permissionRulesetFor('bypassPermissions')).toEqual([
+        { permission: '*', pattern: '*', action: 'allow' },
+      ])
+    })
+
+    it('maps dangerouslySkipPermissions to an all-allow ruleset', () => {
+      expect(permissionRulesetFor('dangerouslySkipPermissions')).toEqual([
+        { permission: '*', pattern: '*', action: 'allow' },
+      ])
+    })
+
+    it('maps acceptEdits to an edit-allow ruleset', () => {
+      expect(permissionRulesetFor('acceptEdits')).toEqual([
+        { permission: 'edit', pattern: '*', action: 'allow' },
+      ])
+    })
+
+    it('returns undefined for default, plan, and unset modes', () => {
+      expect(permissionRulesetFor('default')).toBeUndefined()
+      expect(permissionRulesetFor('plan')).toBeUndefined()
+      expect(permissionRulesetFor(undefined)).toBeUndefined()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // sendMessage request body (agent, system, model, command routing)
+  // ---------------------------------------------------------------------------
+
+  describe('sendMessage request body', () => {
+    /** Prepare a connected process and capture the next outgoing request. */
+    const connect = (proc: OpenCodeProcess) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(proc as any).alive = true
+      setSessionId(proc, 'oc-session-1')
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) })
+    }
+
+    const lastRequest = () => {
+      const [url, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1] as [string, { body: string }]
+      return { url, body: JSON.parse(init.body) as Record<string, unknown> }
+    }
+
+    it('selects the build agent and appends Codekin system context by default', () => {
+      connect(ocp)
+      ocp.sendMessage('hello')
+      const { url, body } = lastRequest()
+      expect(url).toContain('/session/oc-session-1/prompt_async')
+      expect(body.agent).toBe('build')
+      expect(body.system).toBe(OPENCODE_SYSTEM_CONTEXT)
+      expect(body.model).toEqual({ providerID: 'anthropic', modelID: 'claude-sonnet-4' })
+    })
+
+    it('selects the plan agent in plan mode', () => {
+      const planProc = new OpenCodeProcess('/tmp/test-repo', {
+        sessionId: 'plan-session',
+        model: 'anthropic/claude-sonnet-4',
+        permissionMode: 'plan',
+      })
+      connect(planProc)
+      planProc.sendMessage('propose a refactor')
+      const { body } = lastRequest()
+      expect(body.agent).toBe('plan')
+      planProc.stop()
+    })
+
+    it('splits OpenRouter-style model IDs at the first slash only', () => {
+      const orProc = new OpenCodeProcess('/tmp/test-repo', {
+        sessionId: 'or-session',
+        model: 'openrouter/meta-llama/llama-3.1-8b',
+      })
+      connect(orProc)
+      orProc.sendMessage('hi')
+      const { body } = lastRequest()
+      expect(body.model).toEqual({ providerID: 'openrouter', modelID: 'meta-llama/llama-3.1-8b' })
+      orProc.stop()
+    })
+
+    it('routes known slash commands to the command endpoint', () => {
+      connect(ocp)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).commands = new Map([['review', { name: 'review', source: 'command' }]])
+      ocp.sendMessage('/review src/index.ts')
+      const { url, body } = lastRequest()
+      expect(url).toContain('/session/oc-session-1/command')
+      expect(body.command).toBe('review')
+      expect(body.arguments).toBe('src/index.ts')
+      expect(body.agent).toBe('build')
+      expect(body.model).toBe('anthropic/claude-sonnet-4')
+    })
+
+    it('routes a known slash command without arguments', () => {
+      connect(ocp)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).commands = new Map([['init', { name: 'init' }]])
+      ocp.sendMessage('/init')
+      const { url, body } = lastRequest()
+      expect(url).toContain('/command')
+      expect(body.command).toBe('init')
+      expect(body.arguments).toBeUndefined()
+    })
+
+    it('sends unknown slash commands as a regular prompt', () => {
+      connect(ocp)
+      ocp.sendMessage('/not-a-command do things')
+      const { url, body } = lastRequest()
+      expect(url).toContain('/prompt_async')
+      expect((body.parts as Array<{ text: string }>)[0].text).toBe('/not-a-command do things')
+    })
+
+    it('does not route commands when attachments are present', () => {
+      connect(ocp)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).commands = new Map([['review', { name: 'review' }]])
+      // Attached file does not exist — attachment is skipped, but the message
+      // had an attachment prefix, so it must go through the prompt path.
+      ocp.sendMessage('[Attached files: /nonexistent/file.png]\n/review this')
+      const { url } = lastRequest()
+      expect(url).toContain('/prompt_async')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // step-finish flushing
+  // ---------------------------------------------------------------------------
+
+  describe('step-finish', () => {
+    it('flushes buffered text deltas on step-finish', () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).lastUserInput = 'a long user message that exceeds the delta'
+
+      // Short delta — buffered awaiting the echo check
+      callHandleSSE(ocp, {
+        type: 'message.part.delta',
+        properties: { sessionID: 'oc-session-1', field: 'text', delta: 'Done.' },
+      })
+      expect(textHandler).not.toHaveBeenCalled()
+
+      // Step boundary — buffer must flush
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: { sessionID: 'oc-session-1', part: { type: 'step-finish' } },
+      })
+      expect(textHandler).toHaveBeenCalledWith('Done.')
     })
   })
 

--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -246,6 +246,11 @@ export interface OpenCodeProcessOptions {
 // OpenCodeProcess
 // ---------------------------------------------------------------------------
 
+/** How often the turn watchdog checks for a stalled turn. */
+const TURN_WATCHDOG_INTERVAL_MS = 30_000
+/** How long without any session SSE event before we poll the server to resync. */
+const TURN_STALL_THRESHOLD_MS = 60_000
+
 export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implements CodingProcess {
   readonly provider: CodingProvider = 'opencode'
   readonly capabilities: ProviderCapabilities = OPENCODE_CAPABILITIES
@@ -261,6 +266,16 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   private tasks = new Map<string, TaskItem>()
   private turnComplete = false
   private taskSeq = 0
+  /**
+   * Watchdog that detects turns stalled by a missed completion event.
+   * The turn-completion latch (turnComplete) is only released by SSE events
+   * (session.idle / message.completed / session.status). If the SSE stream
+   * drops and the completion event is lost, the turn would hang forever —
+   * the watchdog polls the server's message history to recover.
+   */
+  private turnWatchdog: ReturnType<typeof setInterval> | null = null
+  /** Timestamp of the last SSE event explicitly scoped to this session. */
+  private lastSessionEventTime = 0
   /** Whether we've received streaming delta events this turn (to avoid double-emitting text). */
   private receivedDeltas = false
   /** Whether we've already emitted text via message.part.updated (to avoid re-emitting from message.updated). */
@@ -388,6 +403,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
             reconnectAttempts++
             if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
               this.emit('error', `SSE reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts (last status: ${res.status})`)
+              this.stop()
               return
             }
             console.warn(`[opencode-sse] Non-2xx ${res.status}, reconnecting in ${reconnectDelay / 1000}s (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`)
@@ -400,6 +416,12 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         // Reset backoff on successful connection
         reconnectDelay = 1000
         reconnectAttempts = 0
+
+        // If a turn was in flight across the reconnect, the completion event
+        // may have been lost while disconnected — resync immediately.
+        if (!this.turnComplete && this.turnWatchdog) {
+          void this.checkTurnLiveness(true)
+        }
 
         const reader = res.body.getReader()
         const decoder = new TextDecoder()
@@ -434,6 +456,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
           reconnectAttempts++
           if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
             this.emit('error', `SSE reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts`)
+            this.stop()
             return
           }
           console.warn(`[opencode-sse] Stream closed cleanly, reconnecting in ${reconnectDelay / 1000}s (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`)
@@ -446,6 +469,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
           reconnectAttempts++
           if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
             this.emit('error', `SSE reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts`)
+            this.stop()
             return
           }
           console.warn(`[opencode-sse] Connection lost, reconnecting in ${reconnectDelay / 1000}s (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`, err)
@@ -488,9 +512,28 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     }
   }
 
+  /**
+   * Mark the current turn as complete: release the latch, flush any buffered
+   * text, stop the stall watchdog, and emit the result event. Idempotent.
+   */
+  private completeTurn(): void {
+    if (this.turnComplete) return
+    this.turnComplete = true
+    this.clearTurnWatchdog()
+    this.flushDeltaBuffer()
+    this.emit('result', '', false)
+  }
+
   /** Map an OpenCode SSE event to CodingProcess events. */
   private handleSSEEvent(event: OpenCodeSSEEvent): void {
     const { type, properties } = event
+
+    // Track liveness of this session's event flow for the turn watchdog.
+    // Only count events explicitly scoped to our session — server-level
+    // events (heartbeats etc.) say nothing about our turn's progress.
+    if (properties.sessionID === this.opencodeSessionId) {
+      this.lastSessionEventTime = Date.now()
+    }
 
     switch (type) {
       // Delta events carry the actual streaming text content
@@ -655,10 +698,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         const status = properties.status
         const statusType = typeof status === 'string' ? status : (status as { type?: string } | undefined)?.type
         if (statusType === 'idle') {
-          if (this.turnComplete) break
-          this.turnComplete = true
-          this.flushDeltaBuffer()
-          this.emit('result', '', false)
+          this.completeTurn()
         }
         break
       }
@@ -704,10 +744,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       // message.completed signals that the model has finished its response
       case 'message.completed': {
         if (!this.isOwnSession(properties)) break
-        if (this.turnComplete) break
-        this.turnComplete = true
-        this.flushDeltaBuffer()
-        this.emit('result', '', false)
+        this.completeTurn()
         break
       }
 
@@ -718,10 +755,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         const sessionStatus = session?.status
         const sType = typeof sessionStatus === 'string' ? sessionStatus : (sessionStatus as { type?: string } | undefined)?.type
         if (sType === 'idle') {
-          if (this.turnComplete) break
-          this.turnComplete = true
-          this.flushDeltaBuffer()
-          this.emit('result', '', false)
+          this.completeTurn()
         }
         break
       }
@@ -729,10 +763,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       // OpenCode >=1.4 sends session.idle as a standalone event (not nested in session.status)
       case 'session.idle': {
         if (!this.isOwnSession(properties)) break
-        if (this.turnComplete) break
-        this.turnComplete = true
-        this.flushDeltaBuffer()
-        this.emit('result', '', false)
+        this.completeTurn()
         break
       }
 
@@ -768,25 +799,99 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     }
   }
 
-  /** Reply to an OpenCode permission request via HTTP. */
-  private async replyToPermission(requestId: string, type: 'once' | 'always' | 'reject'): Promise<void> {
+  /** Start (or restart) the stalled-turn watchdog for an in-flight turn. */
+  private startTurnWatchdog(): void {
+    this.clearTurnWatchdog()
+    this.lastSessionEventTime = Date.now()
+    this.turnWatchdog = setInterval(() => {
+      void this.checkTurnLiveness()
+    }, TURN_WATCHDOG_INTERVAL_MS)
+  }
+
+  private clearTurnWatchdog(): void {
+    if (this.turnWatchdog) {
+      clearInterval(this.turnWatchdog)
+      this.turnWatchdog = null
+    }
+  }
+
+  /**
+   * Detect a turn stalled by a missed SSE completion event and recover.
+   * If no session-scoped event has arrived recently, poll the server's
+   * message history: when the last assistant message is marked completed,
+   * the turn finished server-side and we only missed the event — force
+   * completion so the session doesn't hang forever.
+   *
+   * A long-running tool with no event flow is NOT force-completed: the poll
+   * only completes the turn when the server itself says the message is done.
+   */
+  private async checkTurnLiveness(force = false): Promise<void> {
+    if (!this.alive || this.turnComplete) {
+      this.clearTurnWatchdog()
+      return
+    }
+    if (!force && Date.now() - this.lastSessionEventTime < TURN_STALL_THRESHOLD_MS) return
+    if (!this.opencodeSessionId) return
+
     try {
       const baseUrl = `http://localhost:${serverState.port}`
-      const res = await fetch(`${baseUrl}/permission/${requestId}/reply`, {
-        method: 'POST',
+      const res = await fetch(`${baseUrl}/session/${this.opencodeSessionId}/message`, {
         headers: {
           ...authHeaders(),
-          'Content-Type': 'application/json',
           'x-opencode-directory': this.workingDir,
         },
-        body: JSON.stringify({ type }),
+        signal: AbortSignal.timeout(10_000),
       })
-      if (!res.ok) {
-        console.error(`[opencode] Permission reply failed: HTTP ${res.status} for ${requestId}`)
+      if (!res.ok) return
+      const messages = await res.json() as Array<Record<string, unknown>>
+      if (!Array.isArray(messages) || messages.length === 0) return
+      // Entries may be flat message objects or { info, parts } wrappers
+      // depending on OpenCode version.
+      const last = messages[messages.length - 1]
+      const info = (last.info ?? last) as { role?: string; time?: { completed?: number } }
+      if (info.role === 'assistant' && info.time?.completed) {
+        console.warn(`[opencode] Missed turn-completion event for session ${this.opencodeSessionId} — recovered via message poll`)
+        this.completeTurn()
       }
     } catch (err) {
-      console.error(`[opencode] Failed to reply to permission ${requestId}:`, err)
+      console.warn(`[opencode] Turn liveness poll failed for ${this.opencodeSessionId}:`, err)
     }
+  }
+
+  /**
+   * Reply to an OpenCode permission request via HTTP, with retries.
+   * A dropped reply leaves OpenCode blocked on the permission forever, so
+   * failures are retried and ultimately surfaced as a session error instead
+   * of being silently swallowed.
+   */
+  /** Base backoff delay between permission reply retries (overridable in tests). */
+  private permissionRetryDelayMs = 1000
+
+  private async replyToPermission(requestId: string, type: 'once' | 'always' | 'reject'): Promise<void> {
+    const MAX_ATTEMPTS = 3
+    const baseUrl = `http://localhost:${serverState.port}`
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        const res = await fetch(`${baseUrl}/permission/${requestId}/reply`, {
+          method: 'POST',
+          headers: {
+            ...authHeaders(),
+            'Content-Type': 'application/json',
+            'x-opencode-directory': this.workingDir,
+          },
+          body: JSON.stringify({ type }),
+          signal: AbortSignal.timeout(10_000),
+        })
+        if (res.ok) return
+        console.error(`[opencode] Permission reply failed: HTTP ${res.status} for ${requestId} (attempt ${attempt}/${MAX_ATTEMPTS})`)
+      } catch (err) {
+        console.error(`[opencode] Failed to reply to permission ${requestId} (attempt ${attempt}/${MAX_ATTEMPTS}):`, err)
+      }
+      if (attempt < MAX_ATTEMPTS) {
+        await new Promise(r => setTimeout(r, this.permissionRetryDelayMs * attempt))
+      }
+    }
+    this.emit('error', `Failed to deliver permission response (${type}) — OpenCode may still be waiting for approval`)
   }
 
   /**
@@ -858,6 +963,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     this.reasoningBuffer = ''
     this.emittedReasoningSummary = false
     this.inReasoningPhase = false
+    this.startTurnWatchdog()
 
     const baseUrl = `http://localhost:${serverState.port}`
     // Parse [Attached files: ...] prefix and convert image paths to proper parts.
@@ -952,6 +1058,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   stop(): void {
     if (!this.alive) return
     this.alive = false
+    this.clearTurnWatchdog()
     if (this.startupTimer) {
       clearTimeout(this.startupTimer)
       this.startupTimer = null

--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -58,6 +58,63 @@ interface OpenCodeSSEEvent {
 }
 
 // ---------------------------------------------------------------------------
+// Codekin context + permission mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * Codekin environment context appended to OpenCode's agent system prompt via
+ * the `system` field on each prompt request. OpenCode APPENDS this to its
+ * tuned per-model prompt (verified against OpenCode 1.15) — unlike
+ * `agent.*.prompt` config which would REPLACE it. Mirrors the
+ * `--append-system-prompt` text used for the Claude path (claude-process.ts).
+ */
+export const OPENCODE_SYSTEM_CONTEXT = [
+  'You are running inside a web-based terminal (Codekin).',
+  'Tool permissions are managed by the system through an approval UI.',
+  'Do not tell the user to click approve or grant permission. Just proceed with your work.',
+  'If a tool call fails, read the error message carefully. Common causes: wrong file path, missing dependency, syntax error, or network issue.',
+].join(' ')
+
+/** One rule in OpenCode's permission ruleset (last match wins, wildcards on both fields). */
+interface OpenCodePermissionRule {
+  permission: string
+  pattern: string
+  action: 'allow' | 'deny' | 'ask'
+}
+
+/**
+ * Map Codekin's PermissionMode to an OpenCode permission ruleset, applied at
+ * session creation (and via PATCH on resume). Without this, bypass-mode
+ * sessions still hit server-side `ask` states (external_directory, doom_loop)
+ * that must round-trip through the UI even though the user opted out.
+ * Returns undefined for modes where OpenCode's defaults are appropriate.
+ */
+export function permissionRulesetFor(mode?: PermissionMode): OpenCodePermissionRule[] | undefined {
+  switch (mode) {
+    case 'bypassPermissions':
+    case 'dangerouslySkipPermissions':
+      return [{ permission: '*', pattern: '*', action: 'allow' }]
+    case 'acceptEdits':
+      return [{ permission: 'edit', pattern: '*', action: 'allow' }]
+    default:
+      // 'default' and 'plan' use OpenCode's defaults; plan-mode safety comes
+      // from selecting the read-only `plan` agent on each prompt.
+      return undefined
+  }
+}
+
+/** An OpenCode command (slash command / skill / MCP prompt) from GET /command. */
+export interface OpenCodeCommandInfo {
+  name: string
+  description?: string
+  agent?: string
+  model?: string
+  source?: 'command' | 'mcp' | 'skill'
+  template?: string
+  hints?: string[]
+}
+
+// ---------------------------------------------------------------------------
 // OpenCode server manager (singleton — one server for all sessions)
 // ---------------------------------------------------------------------------
 
@@ -214,6 +271,28 @@ export async function fetchOpenCodeModels(workingDir: string): Promise<{
   }
 }
 
+/**
+ * Fetch the list of commands (slash commands, skills, MCP prompts) from the
+ * running OpenCode server. Returns an empty array if the server is not running.
+ */
+export async function fetchOpenCodeCommands(workingDir: string): Promise<OpenCodeCommandInfo[]> {
+  try {
+    const baseUrl = await ensureOpenCodeServer(workingDir)
+    const res = await fetch(`${baseUrl}/command`, {
+      headers: {
+        ...authHeaders(),
+        'x-opencode-directory': workingDir,
+      },
+      signal: AbortSignal.timeout(15000),
+    })
+    if (!res.ok) return []
+    const data = await res.json() as OpenCodeCommandInfo[]
+    return Array.isArray(data) ? data : []
+  } catch {
+    return []
+  }
+}
+
 /** Stop the shared OpenCode server. */
 export function stopOpenCodeServer(): void {
   if (serverState.process) {
@@ -263,6 +342,8 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   private abortController: AbortController | null = null
   private startupTimer: ReturnType<typeof setTimeout> | null = null
   private permissionMode?: PermissionMode
+  /** OpenCode commands available on the server, keyed by name (for /name routing). */
+  private commands = new Map<string, OpenCodeCommandInfo>()
   private tasks = new Map<string, TaskItem>()
   private turnComplete = false
   private taskSeq = 0
@@ -335,8 +416,30 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     // Create or resume a session — must happen BEFORE SSE subscription
     // so that this.opencodeSessionId is set and the session ID filter
     // guards in handleSSEEvent() are active (prevents cross-session leakage).
+    const permission = permissionRulesetFor(this.permissionMode)
     if (this.opencodeSessionId) {
-      // Resume existing session — just reconnect to SSE
+      // Resume existing session — reconnect to SSE, but push the current
+      // permission ruleset since the mode may have changed since creation
+      // (mode changes restart the process with resume).
+      if (permission) {
+        try {
+          const patchRes = await fetch(`${baseUrl}/session/${this.opencodeSessionId}`, {
+            method: 'PATCH',
+            headers: {
+              ...authHeaders(),
+              'Content-Type': 'application/json',
+              'x-opencode-directory': this.workingDir,
+            },
+            body: JSON.stringify({ permission }),
+            signal: AbortSignal.timeout(10_000),
+          })
+          if (!patchRes.ok) {
+            console.warn(`[opencode] Failed to update session permissions: HTTP ${patchRes.status}`)
+          }
+        } catch (err) {
+          console.warn('[opencode] Failed to update session permissions:', err)
+        }
+      }
     } else {
       const createRes = await fetch(`${baseUrl}/session`, {
         method: 'POST',
@@ -347,6 +450,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         },
         body: JSON.stringify({
           title: `Codekin session ${this.sessionId.slice(0, 8)}`,
+          ...(permission ? { permission } : {}),
         }),
       })
 
@@ -357,6 +461,11 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       const data = await createRes.json() as { id: string }
       this.opencodeSessionId = data.id
     }
+
+    // Load available commands (slash commands / skills / MCP prompts) so
+    // sendMessage can route `/name args` input to the command endpoint.
+    // Non-fatal — command routing simply stays disabled on failure.
+    void this.loadCommands(baseUrl)
 
     // Subscribe to SSE events AFTER opencodeSessionId is set so session
     // filtering is active from the first event received.
@@ -375,6 +484,32 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     if (this.model) {
       const modelName = this.model.includes('/') ? this.model.slice(this.model.indexOf('/') + 1) : this.model
       this.emit('system_init', modelName)
+    }
+
+    // Surface plan mode in the UI — OpenCode plan mode is implemented by
+    // selecting the read-only `plan` agent on every prompt this session.
+    if (this.permissionMode === 'plan') {
+      this.emit('planning_mode', true)
+    }
+  }
+
+  /** Fetch the command list from the server (used for slash-command routing). */
+  private async loadCommands(baseUrl: string): Promise<void> {
+    try {
+      const res = await fetch(`${baseUrl}/command`, {
+        headers: {
+          ...authHeaders(),
+          'x-opencode-directory': this.workingDir,
+        },
+        signal: AbortSignal.timeout(10_000),
+      })
+      if (!res.ok) return
+      const data = await res.json() as OpenCodeCommandInfo[]
+      if (Array.isArray(data)) {
+        this.commands = new Map(data.map(c => [c.name, c]))
+      }
+    } catch (err) {
+      console.warn('[opencode] Failed to load command list:', err)
     }
   }
 
@@ -687,7 +822,15 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
             break
           }
 
-          // step-start / step-finish are agentic iteration boundaries — no mapping needed
+          case 'step-finish': {
+            // Agentic iteration boundary — any buffered text below the echo
+            // threshold belongs to the finished step; flush it now instead of
+            // holding it until turn end.
+            this.flushDeltaBuffer()
+            break
+          }
+
+          // step-start is an agentic iteration boundary — no mapping needed
         }
         break
       }
@@ -1008,6 +1151,37 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       }
     }
     this.lastUserInput = textContent.trim()
+
+    // Route known slash commands (`/name args`) to OpenCode's command
+    // endpoint so its commands/skills/MCP prompts work from Codekin.
+    // Only when there are no attached files — commands take text args.
+    const cmdMatch = !attachMatch ? textContent.trim().match(/^\/([a-zA-Z0-9_:-]+)(?:\s+([\s\S]*))?$/) : null
+    const command = cmdMatch ? this.commands.get(cmdMatch[1]) : undefined
+    if (cmdMatch && command) {
+      const cmdBody: Record<string, unknown> = {
+        command: command.name,
+        ...(cmdMatch[2] ? { arguments: cmdMatch[2] } : {}),
+        ...(this.model ? { model: this.model } : {}),
+        agent: this.permissionMode === 'plan' ? 'plan' : 'build',
+      }
+      void fetch(`${baseUrl}/session/${this.opencodeSessionId}/command`, {
+        method: 'POST',
+        headers: {
+          ...authHeaders(),
+          'Content-Type': 'application/json',
+          'x-opencode-directory': this.workingDir,
+        },
+        body: JSON.stringify(cmdBody),
+      }).then((res) => {
+        if (!res.ok) {
+          this.emit('error', `Failed to run command /${command.name}: HTTP ${res.status}`)
+        }
+      }).catch((err) => {
+        this.emit('error', `Failed to run command /${command.name}: ${err instanceof Error ? err.message : String(err)}`)
+      })
+      return
+    }
+
     if (textContent.trim()) {
       parts.push({ type: 'text', text: textContent })
     }
@@ -1021,6 +1195,12 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       const modelID = this.model.slice(slashIdx + 1)
       body.model = { providerID, modelID }
     }
+    // Select the agent per turn: plan mode uses OpenCode's read-only `plan`
+    // agent (real plan mode); everything else uses the default `build` agent.
+    body.agent = this.permissionMode === 'plan' ? 'plan' : 'build'
+    // Append Codekin environment context to the agent's system prompt
+    // (OpenCode appends `system` — it does not replace the tuned prompt).
+    body.system = OPENCODE_SYSTEM_CONTEXT
     // Use prompt_async for fire-and-forget (events come via SSE)
     void fetch(`${baseUrl}/session/${this.opencodeSessionId}/prompt_async`, {
       method: 'POST',

--- a/server/prompt-router.test.ts
+++ b/server/prompt-router.test.ts
@@ -422,6 +422,33 @@ describe('PromptRouter', () => {
     it('formats unknown tools', () => {
       expect(router.summarizeToolPermission('WebFetch', {})).toBe('Allow WebFetch?')
     })
+
+    it('formats OpenCode external_directory with filepath and patterns', () => {
+      const result = router.summarizeToolPermission('external_directory', {
+        permission: 'external_directory',
+        filepath: '/etc/hosts',
+        patterns: ['/etc/*'],
+      })
+      expect(result).toContain('outside the project directory')
+      expect(result).toContain('/etc/hosts')
+      expect(result).toContain('/etc/*')
+    })
+
+    it('formats OpenCode external_directory without metadata', () => {
+      const result = router.summarizeToolPermission('external_directory', { permission: 'external_directory' })
+      expect(result).toContain('outside the project directory')
+    })
+
+    it('formats OpenCode doom_loop', () => {
+      const result = router.summarizeToolPermission('doom_loop', { permission: 'doom_loop' })
+      expect(result).toContain('repeating itself')
+    })
+
+    it('includes patterns for unknown OpenCode permission types', () => {
+      const result = router.summarizeToolPermission('webfetch', { permission: 'webfetch', patterns: ['https://example.com/*'] })
+      expect(result).toContain('Allow webfetch?')
+      expect(result).toContain('https://example.com/*')
+    })
   })
 
   // -------------------------------------------------------------------------

--- a/server/prompt-router.ts
+++ b/server/prompt-router.ts
@@ -674,8 +674,24 @@ export class PromptRouter {
         const filePath = String(toolInput.file_path || '')
         return `Allow Read? \`${filePath}\``
       }
-      default:
-        return `Allow ${toolName}?`
+      // OpenCode permission types — toolInput carries {permission, ...metadata, patterns}
+      case 'external_directory': {
+        const target = String(toolInput.filepath || toolInput.parentDir || '')
+        const patterns = Array.isArray(toolInput.patterns) && toolInput.patterns.length
+          ? ` (${(toolInput.patterns as unknown[]).map(String).join(', ')})`
+          : ''
+        return target
+          ? `Allow access outside the project directory? \`${target}\`${patterns}`
+          : `Allow access outside the project directory?${patterns}`
+      }
+      case 'doom_loop':
+        return 'The agent appears to be repeating itself (possible loop). Allow it to continue?'
+      default: {
+        const patterns = Array.isArray(toolInput.patterns) && toolInput.patterns.length
+          ? ` \`${(toolInput.patterns as unknown[]).map(String).join(', ')}\``
+          : ''
+        return `Allow ${toolName}?${patterns}`
+      }
     }
   }
 }

--- a/server/session-routes.ts
+++ b/server/session-routes.ts
@@ -22,7 +22,7 @@ import { fetchAnthropicModels } from './anthropic-models.js'
 import { VALID_PROVIDERS, VALID_PERMISSION_MODES } from './types.js'
 import type { CodingProvider } from './coding-process.js'
 import type { PermissionMode } from './types.js'
-import { fetchOpenCodeModels } from './opencode-process.js'
+import { fetchOpenCodeModels, fetchOpenCodeCommands } from './opencode-process.js'
 
 // ---------------------------------------------------------------------------
 // Request body interfaces for route handlers
@@ -173,6 +173,28 @@ export function createSessionRouter(
 
     const result = await fetchOpenCodeModels(resolvedDir)
     res.json(result)
+  })
+
+  router.get('/api/opencode/commands', async (req, res) => {
+    const token = extractToken(req)
+    if (!verifyToken(token)) return res.status(401).json({ error: 'Unauthorized' })
+    const rawDir = (req.query.workingDir as string) || osHomedir()
+
+    // Bounds-check: workingDir must be under home or REPOS_ROOT (same as /api/opencode/models)
+    const home = osHomedir()
+    const allowedRoots = [home, REPOS_ROOT]
+    let resolvedDir: string
+    try {
+      resolvedDir = fsRealpathSync(pathResolve(rawDir))
+    } catch {
+      return res.status(400).json({ error: 'workingDir could not be resolved (path does not exist or is inaccessible)' })
+    }
+    if (!allowedRoots.some(root => resolvedDir === root || resolvedDir.startsWith(root + '/'))) {
+      return res.status(403).json({ error: 'workingDir is outside allowed directories' })
+    }
+
+    const commands = await fetchOpenCodeCommands(resolvedDir)
+    res.json({ commands })
   })
 
   router.post('/api/sessions/create', (req: Request<Record<string, string>, unknown, CreateSessionBody>, res) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,8 +27,9 @@ import { useSendMessage } from './hooks/useSendMessage'
 import { useErrorNotification } from './hooks/useErrorNotification'
 import { useGlobalKeyBindings } from './hooks/useGlobalKeyBindings'
 import { useOpenCodeModelSync } from './hooks/useOpenCodeModelSync'
+import { useOpenCodeCommands } from './hooks/useOpenCodeCommands'
 import { useProviderValidation } from './hooks/useProviderValidation'
-import { buildSlashCommandList } from './lib/slashCommands'
+import { buildSlashCommandList, buildOpenCodeSlashCommandList } from './lib/slashCommands'
 import { deriveActivityLabel } from './lib/deriveActivityLabel'
 import { getQueueMessages, getAgentName } from './lib/ccApi'
 import { Settings } from './components/Settings'
@@ -267,6 +268,18 @@ export default function App() {
 
   // Unified slash command list for autocomplete (skills + bundled + built-in)
   const allCommands = useMemo(() => buildSlashCommandList(allSkills), [allSkills])
+
+  // OpenCode sessions get the server's own commands instead of Claude skills
+  const openCodeCommands = useOpenCodeCommands({
+    token: settings.token,
+    activeSessionProvider,
+    activeOpenCodeWd,
+    openCodeDisabled,
+  })
+  const sessionCommands = useMemo(
+    () => activeSessionProvider === 'opencode' ? buildOpenCodeSlashCommandList(openCodeCommands) : allCommands,
+    [activeSessionProvider, openCodeCommands, allCommands],
+  )
 
   // Wrap setModel to also persist OpenCode model selection to localStorage
   const handleModelChange = useCallback((model: string) => {
@@ -646,7 +659,7 @@ export default function App() {
             onAddFiles={addFiles}
             onRemoveFile={removeFile}
             skillGroups={skillGroups}
-            slashCommands={allCommands}
+            slashCommands={sessionCommands}
             sessionInputs={sessionInputs}
             onSessionInputChange={handleSessionInputChange}
             currentModel={currentModel}
@@ -683,12 +696,13 @@ export default function App() {
             onAddFiles={addFiles}
             onRemoveFile={removeFile}
             skillGroups={skillGroups}
-            slashCommands={allCommands}
+            slashCommands={sessionCommands}
             sessionInputs={sessionInputs}
             onSessionInputChange={handleSessionInputChange}
             currentModel={currentModel}
             onModelChange={handleModelChange}
             availableModels={availableModels}
+            sessionProvider={activeSessionProvider}
             hasUserMessages={messages.some(m => m.type === 'user')}
             useWorktree={useWorktree}
             onWorktreeChange={setUseWorktree}

--- a/src/components/EditWorkflowModal.tsx
+++ b/src/components/EditWorkflowModal.tsx
@@ -33,9 +33,11 @@ interface Props {
 
 export function EditWorkflowModal({ token, repo, onClose, onSave }: Props) {
   const parsed = parseCron(repo.cronExpression)
-  // Infer provider from model when provider field is missing (legacy configs)
+  // Infer provider from model when provider field is missing (legacy configs).
+  // OpenCode models are "providerID/modelID" (contain a slash); Claude models
+  // never do (full IDs like "claude-sonnet-4-6" or aliases like "opus").
   const inferredProvider: CodingProvider =
-    repo.provider ?? (repo.model && !repo.model.startsWith('claude-') ? 'opencode' : 'claude')
+    repo.provider ?? (repo.model?.includes('/') ? 'opencode' : 'claude')
 
   const [form, setForm] = useState({
     kind: repo.kind ?? 'coverage.daily',

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -69,8 +69,8 @@ function SendButton({ onClick, disabled, hasContent, size = 16, rounded = 'round
 }
 
 /** Desktop permission mode dropdown with full descriptions. */
-function PermissionModeDropdown({ currentMode, isOpen, menuRef, onToggle, onSelect }: {
-  currentMode: PermissionMode; isOpen: boolean
+function PermissionModeDropdown({ currentMode, modes, isOpen, menuRef, onToggle, onSelect }: {
+  currentMode: PermissionMode; modes: typeof PERMISSION_MODES; isOpen: boolean
   menuRef: React.RefObject<HTMLDivElement | null>
   onToggle: () => void; onSelect: (mode: PermissionMode) => void
 }) {
@@ -95,7 +95,7 @@ function PermissionModeDropdown({ currentMode, isOpen, menuRef, onToggle, onSele
       </button>
       {isOpen && (
         <div className="absolute bottom-full mb-1 left-0 z-50 min-w-[260px] rounded-lg border border-neutral-6 bg-neutral-8 shadow-lg py-1">
-          {PERMISSION_MODES.map(m => {
+          {modes.map(m => {
             const ModeIcon = PERMISSION_MODE_ICONS[m.icon]
             const isActive = m.id === currentMode
             return (
@@ -308,6 +308,8 @@ interface InputBarProps {
   onModelChange?: (model: string) => void
   /** Available models for the current provider. */
   availableModels?: ModelOption[]
+  /** Coding provider of the active session — filters provider-specific permission modes. */
+  sessionProvider?: 'claude' | 'opencode'
   /** Override the default placeholder text in the textarea. */
   placeholder?: string
   /** When true, disables drag-to-resize and uses auto-height instead. */
@@ -330,8 +332,13 @@ interface InputBarProps {
   variant?: InputBarVariant
 }
 
-export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function InputBar({ onSendInput, isWaiting, disabled, onEscape, pendingFiles, onAddFiles, onRemoveFile, skillGroups, slashCommands, initialValue = '', onValueChange, currentModel, onModelChange, availableModels = [], placeholder, isMobile = false, showWorktreeToggle = false, useWorktree = false, onWorktreeChange, currentPermissionMode, onPermissionModeChange, onMoveToWorktree, worktreePath, variant = 'default' }, ref) {
+export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function InputBar({ onSendInput, isWaiting, disabled, onEscape, pendingFiles, onAddFiles, onRemoveFile, skillGroups, slashCommands, initialValue = '', onValueChange, currentModel, onModelChange, availableModels = [], sessionProvider, placeholder, isMobile = false, showWorktreeToggle = false, useWorktree = false, onWorktreeChange, currentPermissionMode, onPermissionModeChange, onMoveToWorktree, worktreePath, variant = 'default' }, ref) {
   const isOrchestrator = variant === 'orchestrator'
+  // OpenCode has no equivalent of Claude's --dangerously-skip-permissions flag;
+  // bypassPermissions (all-allow ruleset) already covers that use case.
+  const visibleModes = sessionProvider === 'opencode'
+    ? PERMISSION_MODES.filter(m => m.id !== 'dangerouslySkipPermissions')
+    : PERMISSION_MODES
   const [value, setValue] = useState(initialValue)
   const [skillMenuOpen, setSkillMenuOpen] = useState(false)
   const [modelMenuOpen, setModelMenuOpen] = useState(false)
@@ -581,6 +588,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
               {currentPermissionMode && onPermissionModeChange && (
                 <PermissionModeDropdown
                   currentMode={currentPermissionMode}
+                  modes={visibleModes}
                   isOpen={permMenuOpen}
                   menuRef={permMenuRef}
                   onToggle={() => { closeAllPopups('perm'); setPermMenuOpen(!permMenuOpen) }}
@@ -692,7 +700,7 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
                     {currentPermissionMode && onPermissionModeChange && (
                       <>
                         <div className="px-3 py-1.5 text-[12px] text-neutral-5 uppercase tracking-wider">Permissions</div>
-                        {PERMISSION_MODES.map(m => {
+                        {visibleModes.map(m => {
                           const ModeIcon = PERMISSION_MODE_ICONS[m.icon]
                           const isActive = m.id === currentPermissionMode
                           return (

--- a/src/components/SessionContent.tsx
+++ b/src/components/SessionContent.tsx
@@ -49,6 +49,8 @@ export interface SessionContentProps {
   currentModel: string | null
   onModelChange: (model: string) => void
   availableModels?: import('../types').ModelOption[]
+  /** Coding provider of the active session — drives provider-specific UI (permission modes). */
+  sessionProvider?: import('../types').CodingProvider
   hasUserMessages: boolean
   useWorktree: boolean
   onWorktreeChange: (v: boolean) => void
@@ -93,6 +95,7 @@ export function SessionContent({
   currentModel,
   onModelChange,
   availableModels,
+  sessionProvider,
   hasUserMessages,
   useWorktree,
   onWorktreeChange,
@@ -206,6 +209,7 @@ export function SessionContent({
         currentModel={currentModel}
         onModelChange={onModelChange}
         availableModels={availableModels}
+        sessionProvider={sessionProvider}
         isMobile={isMobile}
         showWorktreeToggle={!hasUserMessages}
         useWorktree={useWorktree}

--- a/src/components/SlashAutocomplete.tsx
+++ b/src/components/SlashAutocomplete.tsx
@@ -20,12 +20,14 @@ const CATEGORY_BADGE: Record<SlashCommandCategory, { label: string; className: s
   skill: { label: 'skill', className: 'bg-accent-9/30 text-accent-5' },
   bundled: { label: 'built-in', className: 'bg-primary-9/30 text-primary-5' },
   builtin: { label: 'command', className: 'bg-neutral-8 text-neutral-4' },
+  opencode: { label: 'opencode', className: 'bg-primary-9/30 text-primary-5' },
 }
 
 const CATEGORY_ICON_CLASS: Record<SlashCommandCategory, string> = {
   skill: 'text-accent-6',
   bundled: 'text-primary-5',
   builtin: 'text-neutral-5',
+  opencode: 'text-primary-5',
 }
 
 export function SlashAutocomplete({ commands, filter, onSelect, onClose }: Props) {

--- a/src/hooks/useOpenCodeCommands.ts
+++ b/src/hooks/useOpenCodeCommands.ts
@@ -1,0 +1,40 @@
+import { useState, useEffect } from 'react'
+import { fetchOpenCodeCommands } from '../lib/ccApi'
+import type { OpenCodeCommand } from '../lib/slashCommands'
+import type { CodingProvider } from '../types'
+
+interface UseOpenCodeCommandsOptions {
+  token: string
+  activeSessionProvider: CodingProvider
+  activeOpenCodeWd: string | undefined
+  openCodeDisabled: boolean
+}
+
+/**
+ * Fetches the OpenCode command list (slash commands / skills / MCP prompts)
+ * for the active OpenCode session's working directory, so the slash-command
+ * autocomplete can offer them. Commands are routed server-side.
+ */
+export function useOpenCodeCommands({
+  token,
+  activeSessionProvider,
+  activeOpenCodeWd,
+  openCodeDisabled,
+}: UseOpenCodeCommandsOptions): OpenCodeCommand[] {
+  const [commands, setCommands] = useState<OpenCodeCommand[]>([])
+  const [fetchedDir, setFetchedDir] = useState<string | undefined>(undefined)
+
+  useEffect(() => {
+    if (activeSessionProvider !== 'opencode' || !token || openCodeDisabled) return
+    if (commands.length > 0 && activeOpenCodeWd === fetchedDir) return
+    let cancelled = false
+    fetchOpenCodeCommands(token, activeOpenCodeWd).then(result => {
+      if (cancelled) return
+      setCommands(result)
+      setFetchedDir(activeOpenCodeWd)
+    }).catch(() => { /* commands menu simply stays empty */ })
+    return () => { cancelled = true }
+  }, [activeSessionProvider, token, openCodeDisabled, activeOpenCodeWd, fetchedDir, commands.length])
+
+  return commands
+}

--- a/src/lib/ccApi.ts
+++ b/src/lib/ccApi.ts
@@ -482,6 +482,20 @@ export async function fetchOpenCodeModels(
   }>(res)
 }
 
+/** Fetch the OpenCode command list (slash commands / skills / MCP prompts). */
+export async function fetchOpenCodeCommands(
+  token: string,
+  workingDir?: string,
+): Promise<Array<{ name: string; description?: string; source?: 'command' | 'mcp' | 'skill' }>> {
+  const params = workingDir ? `?workingDir=${encodeURIComponent(workingDir)}` : ''
+  const res = await fetch(`${BASE}/api/opencode/commands${params}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) return []
+  const data = await jsonBody<{ commands?: Array<{ name: string; description?: string; source?: 'command' | 'mcp' | 'skill' }> }>(res)
+  return data.commands ?? []
+}
+
 /** Fetch available Claude models from the Anthropic API (via server proxy). */
 export async function fetchClaudeModels(
   token: string,

--- a/src/lib/slashCommands.test.ts
+++ b/src/lib/slashCommands.test.ts
@@ -4,6 +4,7 @@ import {
   BUNDLED_SKILLS,
   resolveBuiltinAlias,
   buildSlashCommandList,
+  buildOpenCodeSlashCommandList,
 } from './slashCommands'
 import type { Skill } from '../types'
 
@@ -134,5 +135,56 @@ describe('buildSlashCommandList', () => {
 
     expect(deployEntries).toHaveLength(1)
     expect(deployEntries[0].name).toBe('Deploy A')
+  })
+})
+
+describe('buildOpenCodeSlashCommandList', () => {
+  it('returns only built-ins when no opencode commands provided', () => {
+    const result = buildOpenCodeSlashCommandList([])
+    expect(result).toHaveLength(BUILTIN_COMMANDS.length)
+    expect(result.every((c) => c.category === 'builtin')).toBe(true)
+  })
+
+  it('maps opencode commands with the opencode category', () => {
+    const result = buildOpenCodeSlashCommandList([
+      { name: 'review', description: 'Review code', source: 'command' },
+    ])
+    const entry = result.find((c) => c.command === '/review')
+    expect(entry).toBeDefined()
+    expect(entry!.category).toBe('opencode')
+    expect(entry!.description).toBe('Review code')
+  })
+
+  it('derives a description from the source when missing', () => {
+    const result = buildOpenCodeSlashCommandList([
+      { name: 'myskill', source: 'skill' },
+      { name: 'myprompt', source: 'mcp' },
+      { name: 'mycmd' },
+    ])
+    expect(result.find((c) => c.command === '/myskill')!.description).toBe('OpenCode skill')
+    expect(result.find((c) => c.command === '/myprompt')!.description).toBe('MCP prompt')
+    expect(result.find((c) => c.command === '/mycmd')!.description).toBe('OpenCode command')
+  })
+
+  it('opencode commands take priority over built-ins with the same name', () => {
+    const result = buildOpenCodeSlashCommandList([{ name: 'help', description: 'OpenCode help' }])
+    const helpEntries = result.filter((c) => c.command === '/help')
+    expect(helpEntries).toHaveLength(1)
+    expect(helpEntries[0].category).toBe('opencode')
+  })
+
+  it('deduplicates opencode commands with the same name', () => {
+    const result = buildOpenCodeSlashCommandList([
+      { name: 'review', description: 'First' },
+      { name: 'review', description: 'Second' },
+    ])
+    const entries = result.filter((c) => c.command === '/review')
+    expect(entries).toHaveLength(1)
+    expect(entries[0].description).toBe('First')
+  })
+
+  it('does not include Claude bundled skills', () => {
+    const result = buildOpenCodeSlashCommandList([])
+    expect(result.find((c) => c.command === '/commit')).toBeUndefined()
   })
 })

--- a/src/lib/slashCommands.ts
+++ b/src/lib/slashCommands.ts
@@ -16,7 +16,7 @@
 
 import type { Skill } from '../types'
 
-export type SlashCommandCategory = 'skill' | 'bundled' | 'builtin'
+export type SlashCommandCategory = 'skill' | 'bundled' | 'builtin' | 'opencode'
 
 export interface SlashCommand {
   command: string
@@ -79,6 +79,41 @@ export const BUNDLED_SKILLS: SlashCommand[] = [
  * If a filesystem skill has the same command as a bundled skill, the
  * filesystem version wins (it has real content to expand).
  */
+/** An OpenCode command as returned by GET /api/opencode/commands. */
+export interface OpenCodeCommand {
+  name: string
+  description?: string
+  source?: 'command' | 'mcp' | 'skill'
+}
+
+/**
+ * Build the slash command list for an OpenCode session: the server's own
+ * commands (routed server-side to POST /session/:id/command) plus Codekin's
+ * built-in commands (handled locally — /clear, /model, etc.).
+ */
+export function buildOpenCodeSlashCommandList(commands: OpenCodeCommand[]): SlashCommand[] {
+  const seen = new Set<string>()
+  const result: SlashCommand[] = []
+  for (const cmd of commands) {
+    const command = `/${cmd.name}`
+    if (seen.has(command)) continue
+    seen.add(command)
+    result.push({
+      command,
+      name: cmd.name,
+      description: cmd.description || (cmd.source === 'skill' ? 'OpenCode skill' : cmd.source === 'mcp' ? 'MCP prompt' : 'OpenCode command'),
+      category: 'opencode',
+    })
+  }
+  for (const cmd of BUILTIN_COMMANDS) {
+    if (seen.has(cmd.command)) continue
+    seen.add(cmd.command)
+    for (const alias of cmd.aliases ?? []) seen.add(alias)
+    result.push(cmd)
+  }
+  return result
+}
+
 export function buildSlashCommandList(allSkills: Skill[]): SlashCommand[] {
   const seen = new Set<string>()
   const result: SlashCommand[] = []


### PR DESCRIPTION
## Summary
- Implements the remaining roadmap items from the OpenCode integration audit (#493 follow-up): real plan mode via OpenCode's `plan` agent, permission-mode → permission-ruleset mapping (session create + PATCH on resume), Codekin environment context via the additive `system` prompt field, and OpenCode commands (commands/skills/MCP prompts) routed server-side and surfaced in the slash-command autocomplete.
- Improves the permission approval UI for OpenCode (`external_directory`/`doom_loop` now show paths and patterns), flushes buffered text at `step-finish` boundaries, fixes EditWorkflowModal provider inference (slash-based model IDs), and hides `dangerouslySkipPermissions` for OpenCode sessions.
- Records the `@opencode-ai/sdk` adoption decision (deferred, with rationale) in the audit report.

## Test plan
- [x] `npm test` — 2188 tests pass (new tests: permission ruleset mapping, prompt body agent/system/model, slash-command routing incl. attachment/unknown-command fallthrough, step-finish flush, OpenCode permission summaries, buildOpenCodeSlashCommandList)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` (frontend) and `server` tsc — clean
- [ ] Manual: OpenCode session in plan mode proposes without editing; bypass session no longer hits external_directory asks; `/commands` appear in autocomplete

🤖 Generated with [Claude Code](https://claude.com/claude-code)