### PR TITLE
OpenCode runtime improvements: abort, compact, usage, recovery, subagents

### DIFF
--- a/server/claude-process.test.ts
+++ b/server/claude-process.test.ts
@@ -1403,3 +1403,65 @@ describe('stop — force kill timeout', () => {
     expect(killMock).toHaveBeenCalledWith('SIGTERM')
   })
 })
+
+describe('usage events (via handleLine result)', () => {
+  let cp: CP
+  const usageEvents: unknown[] = []
+
+  beforeEach(() => {
+    cp = makeCP()
+    usageEvents.length = 0
+    cp.on('usage', (u: unknown) => usageEvents.push(u))
+  })
+
+  it('emits cumulative usage from a result event', () => {
+    cp.handleLine(JSON.stringify({
+      type: 'result',
+      result: 'done',
+      total_cost_usd: 0.05,
+      usage: {
+        input_tokens: 100,
+        output_tokens: 40,
+        cache_read_input_tokens: 30,
+        cache_creation_input_tokens: 20,
+      },
+    }))
+
+    expect(usageEvents).toEqual([{ inputTokens: 150, outputTokens: 40, costUsd: 0.05 }])
+  })
+
+  it('accumulates token totals across turns and keeps the latest cost', () => {
+    cp.handleLine(JSON.stringify({
+      type: 'result',
+      result: 'first',
+      total_cost_usd: 0.02,
+      usage: { input_tokens: 100, output_tokens: 50 },
+    }))
+    cp.handleLine(JSON.stringify({
+      type: 'result',
+      result: 'second',
+      total_cost_usd: 0.07,
+      usage: { input_tokens: 60, output_tokens: 30 },
+    }))
+
+    expect(usageEvents).toEqual([
+      { inputTokens: 100, outputTokens: 50, costUsd: 0.02 },
+      { inputTokens: 160, outputTokens: 80, costUsd: 0.07 },
+    ])
+  })
+
+  it('emits usage with cost only when usage block is absent', () => {
+    cp.handleLine(JSON.stringify({
+      type: 'result',
+      result: 'done',
+      total_cost_usd: 0.01,
+    }))
+
+    expect(usageEvents).toEqual([{ inputTokens: 0, outputTokens: 0, costUsd: 0.01 }])
+  })
+
+  it('does not emit usage when neither usage nor cost is present', () => {
+    cp.handleLine(JSON.stringify({ type: 'result', result: 'done' }))
+    expect(usageEvents).toEqual([])
+  })
+})

--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -16,7 +16,7 @@ import { createInterface, type Interface } from 'readline'
 import { existsSync } from 'fs'
 import { EventEmitter } from 'events'
 import { randomUUID } from 'crypto'
-import type { ClaudeEvent, ClaudeSystemInit, ClaudeControlRequest, ClaudeResultEvent, ClaudeStreamEvent, TaskItem, PromptQuestion, PermissionMode } from './types.js'
+import type { ClaudeEvent, ClaudeSystemInit, ClaudeControlRequest, ClaudeResultEvent, ClaudeStreamEvent, TaskItem, PromptQuestion, PermissionMode, SessionUsage } from './types.js'
 import { SCREENSHOTS_DIR, CLAUDE_BINARY } from './config.js'
 import { summarizeToolInput } from './tool-labels.js'
 import { redactSecrets } from './crypto-utils.js'
@@ -71,6 +71,7 @@ export interface ClaudeProcessEvents {
   todo_update: [tasks: TaskItem[]]
   image: [base64: string, mediaType: string]
   result: [text: string, isError: boolean]
+  usage: [usage: SessionUsage]
   rate_limit: [event: Record<string, unknown>]
   error: [message: string]
   exit: [code: number | null, signal: string | null]
@@ -101,6 +102,10 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
    * skip retries when this flag is true.
    */
   private _sessionConflict = false
+
+  /** Cumulative token counts across all result events in this process's lifetime. */
+  private cumulativeInputTokens = 0
+  private cumulativeOutputTokens = 0
 
   /**
    * Set to true when spawn() itself fails (ENOENT, EACCES, etc.).
@@ -356,6 +361,20 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
 
       case 'result': {
         const resultEvent = event as ClaudeResultEvent
+        // Surface cumulative token/cost usage. The CLI's result event carries
+        // per-turn usage plus a cumulative total_cost_usd for the session.
+        const u = resultEvent.usage
+        if (u) {
+          this.cumulativeInputTokens += (u.input_tokens ?? 0) + (u.cache_read_input_tokens ?? 0) + (u.cache_creation_input_tokens ?? 0)
+          this.cumulativeOutputTokens += u.output_tokens ?? 0
+        }
+        if (u || typeof resultEvent.total_cost_usd === 'number') {
+          this.emit('usage', {
+            inputTokens: this.cumulativeInputTokens,
+            outputTokens: this.cumulativeOutputTokens,
+            ...(typeof resultEvent.total_cost_usd === 'number' ? { costUsd: resultEvent.total_cost_usd } : {}),
+          })
+        }
         this.emit('result', resultEvent.result || '', resultEvent.is_error || false)
         break
       }
@@ -571,8 +590,12 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
     }
   }
 
-  /** Send a control_response back to the CLI to allow or deny a pending request. */
-  sendControlResponse(requestId: string, behavior: 'allow' | 'deny', updatedInput?: Record<string, unknown>, message?: string): void {
+  /**
+   * Send a control_response back to the CLI to allow or deny a pending request.
+   * 'allow_always' is treated as 'allow' — the CLI protocol has no persistent
+   * grant; persistence is handled by Codekin's ApprovalManager.
+   */
+  sendControlResponse(requestId: string, behavior: 'allow' | 'deny' | 'allow_always', updatedInput?: Record<string, unknown>, message?: string): void {
     // The CLI expects a nested format: { type, response: { subtype, request_id, response: { behavior, ... } } }
     // Inner response schema:
     //   allow: { behavior: "allow", updatedInput: Record<string, unknown> }  (updatedInput required)

--- a/server/coding-process.ts
+++ b/server/coding-process.ts
@@ -68,10 +68,10 @@ export interface CodingProcess extends EventEmitter<ClaudeProcessEvents> {
 
   /**
    * Respond to a permission/control request.
-   * Claude: writes control_response JSON to stdin.
-   * OpenCode: POSTs to /permission/:requestId/reply.
+   * Claude: writes control_response JSON to stdin ('allow_always' = 'allow').
+   * OpenCode: POSTs to /permission/:requestId/reply (once/always/reject).
    */
-  sendControlResponse(requestId: string, behavior: 'allow' | 'deny', updatedInput?: Record<string, unknown>, message?: string): void
+  sendControlResponse(requestId: string, behavior: 'allow' | 'deny' | 'allow_always', updatedInput?: Record<string, unknown>, message?: string): void
 
   /** Whether the process is currently running and accepting input. */
   isAlive(): boolean

--- a/server/opencode-process.test.ts
+++ b/server/opencode-process.test.ts
@@ -532,6 +532,13 @@ describe('OpenCodeProcess', () => {
       ocp.sendControlResponse('req-2', 'deny')
       expect(replyFn).toHaveBeenCalledWith('req-2', 'reject')
     })
+
+    it('sendControlResponse maps allow_always to always', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const replyFn = vi.spyOn(ocp as any, 'replyToPermission').mockResolvedValue(undefined)
+      ocp.sendControlResponse('req-3', 'allow_always')
+      expect(replyFn).toHaveBeenCalledWith('req-3', 'always')
+    })
   })
 
   // ---------------------------------------------------------------------------
@@ -912,6 +919,442 @@ describe('OpenCodeProcess', () => {
       })
 
       expect(todoHandler).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Abort on stop (in-flight turn interrupt)
+  // ---------------------------------------------------------------------------
+
+  describe('abort on stop', () => {
+    const connect = (proc: OpenCodeProcess) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(proc as any).alive = true
+      setSessionId(proc, 'oc-session-1')
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) })
+    }
+
+    it('aborts an in-flight turn when stopped', () => {
+      connect(ocp)
+      ocp.sendMessage('do something long')
+      mockFetch.mockClear()
+
+      ocp.stop()
+
+      const abortCall = mockFetch.mock.calls.find(
+        ([url]) => typeof url === 'string' && url.includes('/session/oc-session-1/abort'),
+      )
+      expect(abortCall).toBeDefined()
+      expect((abortCall![1] as { method: string }).method).toBe('POST')
+    })
+
+    it('does not abort when no turn is in flight', () => {
+      connect(ocp)
+      mockFetch.mockClear()
+
+      ocp.stop()
+
+      const abortCall = mockFetch.mock.calls.find(
+        ([url]) => typeof url === 'string' && url.includes('/abort'),
+      )
+      expect(abortCall).toBeUndefined()
+    })
+
+    it('does not abort after the turn has completed', () => {
+      connect(ocp)
+      ocp.sendMessage('quick task')
+      callHandleSSE(ocp, {
+        type: 'session.idle',
+        properties: { sessionID: 'oc-session-1' },
+      })
+      mockFetch.mockClear()
+
+      ocp.stop()
+
+      const abortCall = mockFetch.mock.calls.find(
+        ([url]) => typeof url === 'string' && url.includes('/abort'),
+      )
+      expect(abortCall).toBeUndefined()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // /compact → native summarize endpoint
+  // ---------------------------------------------------------------------------
+
+  describe('compact command', () => {
+    const connect = (proc: OpenCodeProcess) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(proc as any).alive = true
+      setSessionId(proc, 'oc-session-1')
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) })
+    }
+
+    const lastRequest = () => {
+      const [url, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1] as [string, { method: string; body: string }]
+      return { url, method: init.method, body: JSON.parse(init.body) as Record<string, unknown> }
+    }
+
+    it('routes /compact to the summarize endpoint with the session model', () => {
+      connect(ocp)
+      ocp.sendMessage('/compact')
+      const { url, method, body } = lastRequest()
+      expect(url).toContain('/session/oc-session-1/summarize')
+      expect(method).toBe('POST')
+      expect(body).toEqual({ providerID: 'anthropic', modelID: 'claude-sonnet-4' })
+    })
+
+    it('routes /summarize to the summarize endpoint', () => {
+      connect(ocp)
+      ocp.sendMessage('/summarize')
+      const { url } = lastRequest()
+      expect(url).toContain('/session/oc-session-1/summarize')
+    })
+
+    it('sends an empty body when no model is set', () => {
+      const noModelProc = new OpenCodeProcess('/tmp/test-repo', { sessionId: 'no-model' })
+      connect(noModelProc)
+      noModelProc.sendMessage('/compact')
+      const { body } = lastRequest()
+      expect(body).toEqual({})
+      noModelProc.stop()
+    })
+
+    it('emits error when the summarize request fails', async () => {
+      connect(ocp)
+      const errorHandler = vi.fn()
+      ocp.on('error', errorHandler)
+      mockFetch.mockResolvedValue({ ok: false, status: 500 })
+
+      ocp.sendMessage('/compact')
+      await vi.waitFor(() => {
+        expect(errorHandler).toHaveBeenCalledWith('Failed to compact conversation: HTTP 500')
+      })
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Token/cost usage tracking
+  // ---------------------------------------------------------------------------
+
+  describe('usage tracking', () => {
+    it('emits cumulative usage from assistant message.updated tokens', () => {
+      const usageHandler = vi.fn()
+      ocp.on('usage', usageHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          info: {
+            id: 'm1',
+            role: 'assistant',
+            cost: 0.01,
+            tokens: { input: 100, output: 50, reasoning: 10, cache: { read: 20, write: 5 } },
+          },
+        },
+      })
+
+      expect(usageHandler).toHaveBeenCalledTimes(1)
+      expect(usageHandler).toHaveBeenCalledWith({ inputTokens: 125, outputTokens: 60, costUsd: 0.01 })
+    })
+
+    it('suppresses duplicate usage emissions for unchanged totals', () => {
+      const usageHandler = vi.fn()
+      ocp.on('usage', usageHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      const event = {
+        type: 'message.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          info: { id: 'm1', role: 'assistant', cost: 0.01, tokens: { input: 100, output: 50 } },
+        },
+      }
+      callHandleSSE(ocp, event)
+      callHandleSSE(ocp, event)
+
+      expect(usageHandler).toHaveBeenCalledTimes(1)
+    })
+
+    it('accumulates usage across messages and replaces same-message updates', () => {
+      const usageHandler = vi.fn()
+      ocp.on('usage', usageHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          info: { id: 'm1', role: 'assistant', cost: 0.01, tokens: { input: 100, output: 50 } },
+        },
+      })
+      // Same message grows (message.updated fires repeatedly) — replaces, not adds
+      callHandleSSE(ocp, {
+        type: 'message.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          info: { id: 'm1', role: 'assistant', cost: 0.02, tokens: { input: 150, output: 80 } },
+        },
+      })
+      // A second message accumulates on top
+      callHandleSSE(ocp, {
+        type: 'message.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          info: { id: 'm2', role: 'assistant', cost: 0.01, tokens: { input: 50, output: 20 } },
+        },
+      })
+
+      expect(usageHandler).toHaveBeenCalledTimes(3)
+      expect(usageHandler).toHaveBeenNthCalledWith(2, { inputTokens: 150, outputTokens: 80, costUsd: 0.02 })
+      expect(usageHandler).toHaveBeenNthCalledWith(3, { inputTokens: 200, outputTokens: 100, costUsd: 0.03 })
+    })
+
+    it('does not emit usage when tokens are absent or zero', () => {
+      const usageHandler = vi.fn()
+      ocp.on('usage', usageHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          info: { id: 'm1', role: 'assistant' },
+        },
+      })
+      callHandleSSE(ocp, {
+        type: 'message.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          info: { id: 'm2', role: 'assistant', tokens: { input: 0, output: 0 } },
+        },
+      })
+
+      expect(usageHandler).not.toHaveBeenCalled()
+    })
+
+    it('ignores usage on non-assistant messages', () => {
+      const usageHandler = vi.fn()
+      ocp.on('usage', usageHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'message.updated',
+        properties: {
+          sessionID: 'oc-session-1',
+          info: { id: 'u1', role: 'user', tokens: { input: 100, output: 0 } },
+        },
+      })
+
+      expect(usageHandler).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Missed-text recovery via message poll
+  // ---------------------------------------------------------------------------
+
+  describe('missed-text recovery', () => {
+    it('recovers assistant text when SSE events were lost', async () => {
+      const textHandler = vi.fn()
+      const resultHandler = vi.fn()
+      ocp.on('text', textHandler)
+      ocp.on('result', resultHandler)
+      setSessionId(ocp, 'oc-session-1')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).alive = true
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            info: { role: 'assistant', time: { created: 2, completed: 3 } },
+            parts: [
+              { type: 'step-start' },
+              { type: 'text', text: 'Recovered answer' },
+            ],
+          },
+        ],
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (ocp as any).checkTurnLiveness(true)
+
+      expect(textHandler).toHaveBeenCalledWith('Recovered answer')
+      expect(resultHandler).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not re-emit text when deltas were already received', async () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).alive = true
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).receivedDeltas = true
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            info: { role: 'assistant', time: { completed: 3 } },
+            parts: [{ type: 'text', text: 'Already streamed' }],
+          },
+        ],
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (ocp as any).checkTurnLiveness(true)
+
+      expect(textHandler).not.toHaveBeenCalled()
+    })
+
+    it('strips user echo prefix from recovered text', async () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).alive = true
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).lastUserInput = 'what is 2+2?'
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => [
+          {
+            info: { role: 'assistant', time: { completed: 3 } },
+            parts: [{ type: 'text', text: 'what is 2+2?The answer is 4.' }],
+          },
+        ],
+      })
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (ocp as any).checkTurnLiveness(true)
+
+      expect(textHandler).toHaveBeenCalledWith('The answer is 4.')
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Subagent (child session) activity
+  // ---------------------------------------------------------------------------
+
+  describe('subagent activity', () => {
+    it('surfaces a new child session as Task tool activity', () => {
+      const toolActiveHandler = vi.fn()
+      ocp.on('tool_active', toolActiveHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'session.created',
+        properties: {
+          info: { id: 'child-1', parentID: 'oc-session-1', title: 'Investigate bug' },
+        },
+      })
+
+      expect(toolActiveHandler).toHaveBeenCalledWith('Task', 'Investigate bug')
+    })
+
+    it('registers a child session only once', () => {
+      const toolActiveHandler = vi.fn()
+      ocp.on('tool_active', toolActiveHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      const event = {
+        type: 'session.updated',
+        properties: { info: { id: 'child-1', parentID: 'oc-session-1', title: 'Subtask' } },
+      }
+      callHandleSSE(ocp, event)
+      callHandleSSE(ocp, event)
+
+      expect(toolActiveHandler).toHaveBeenCalledTimes(1)
+    })
+
+    it('ignores child sessions of other parents', () => {
+      const toolActiveHandler = vi.fn()
+      ocp.on('tool_active', toolActiveHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'session.created',
+        properties: {
+          info: { id: 'child-x', parentID: 'some-other-session', title: 'Not ours' },
+        },
+      })
+
+      expect(toolActiveHandler).not.toHaveBeenCalled()
+    })
+
+    it('surfaces child session tool activity', () => {
+      const toolActiveHandler = vi.fn()
+      const toolDoneHandler = vi.fn()
+      ocp.on('tool_active', toolActiveHandler)
+      ocp.on('tool_done', toolDoneHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 'oc-session-1', title: 'Research' } },
+      })
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'child-1',
+          part: { type: 'tool', tool: 'grep', state: { status: 'running', input: { pattern: 'foo' } } },
+        },
+      })
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'child-1',
+          part: { type: 'tool', tool: 'grep', state: { status: 'completed', output: 'match found' } },
+        },
+      })
+
+      expect(toolActiveHandler).toHaveBeenCalledWith('grep', 'foo')
+      expect(toolDoneHandler).toHaveBeenCalledWith('grep', 'match found')
+    })
+
+    it('does not surface child session text parts', () => {
+      const textHandler = vi.fn()
+      ocp.on('text', textHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 'oc-session-1' } },
+      })
+      callHandleSSE(ocp, {
+        type: 'message.part.updated',
+        properties: {
+          sessionID: 'child-1',
+          part: { type: 'text', text: 'internal subagent text' },
+        },
+      })
+
+      expect(textHandler).not.toHaveBeenCalled()
+    })
+
+    it('does not complete the parent turn when a child session goes idle', () => {
+      const resultHandler = vi.fn()
+      ocp.on('result', resultHandler)
+      setSessionId(ocp, 'oc-session-1')
+
+      callHandleSSE(ocp, {
+        type: 'session.created',
+        properties: { info: { id: 'child-1', parentID: 'oc-session-1' } },
+      })
+      // session.updated for the child reporting idle — must NOT complete our turn
+      callHandleSSE(ocp, {
+        type: 'session.updated',
+        properties: {
+          info: { id: 'child-1', parentID: 'oc-session-1', status: { type: 'idle' } },
+        },
+      })
+
+      expect(resultHandler).not.toHaveBeenCalled()
     })
   })
 })

--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -346,6 +346,14 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   private commands = new Map<string, OpenCodeCommandInfo>()
   private tasks = new Map<string, TaskItem>()
   private turnComplete = false
+  /** True while a prompt/command turn is running server-side (set on send, cleared on completion). */
+  private turnInFlight = false
+  /** OpenCode child sessions spawned by this session's subagents (task tool). */
+  private childSessionIds = new Set<string>()
+  /** Latest token/cost usage per assistant message ID (message.updated fires repeatedly). */
+  private usageByMessage = new Map<string, { input: number; output: number; cost: number }>()
+  /** Last emitted usage totals, serialized — suppresses duplicate usage events. */
+  private lastEmittedUsage = ''
   private taskSeq = 0
   /**
    * Watchdog that detects turns stalled by a missed completion event.
@@ -654,6 +662,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   private completeTurn(): void {
     if (this.turnComplete) return
     this.turnComplete = true
+    this.turnInFlight = false
     this.clearTurnWatchdog()
     this.flushDeltaBuffer()
     this.emit('result', '', false)
@@ -664,9 +673,11 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     const { type, properties } = event
 
     // Track liveness of this session's event flow for the turn watchdog.
-    // Only count events explicitly scoped to our session — server-level
-    // events (heartbeats etc.) say nothing about our turn's progress.
-    if (properties.sessionID === this.opencodeSessionId) {
+    // Only count events explicitly scoped to our session (or a subagent child
+    // session) — server-level events (heartbeats etc.) say nothing about our
+    // turn's progress.
+    const evtSessionID = properties.sessionID as string | undefined
+    if (evtSessionID && (evtSessionID === this.opencodeSessionId || this.childSessionIds.has(evtSessionID))) {
       this.lastSessionEventTime = Date.now()
     }
 
@@ -738,8 +749,15 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         const part = properties.part as OpenCodeMessagePart | undefined
         if (!part) break
 
-        // Only process events for our session
-        if (!this.isOwnSession(properties)) break
+        // Only process events for our session. Subagent child sessions get
+        // their tool activity surfaced (text/reasoning is internal to the
+        // subagent and would pollute the main transcript).
+        if (!this.isOwnSession(properties)) {
+          if (evtSessionID && this.childSessionIds.has(evtSessionID) && part.type === 'tool') {
+            this.handleChildToolPart(part)
+          }
+          break
+        }
 
         if (process.env.CODEKIN_DEBUG_SSE) {
           console.log(`[opencode-sse] part.updated type=${part.type} len=${part.text?.length ?? 0} text=${part.text?.slice(0, 80)} receivedDeltas=${this.receivedDeltas} emittedPartText=${this.emittedPartText}`)
@@ -891,10 +909,23 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
         break
       }
 
-      // session.updated may carry idle status in some OpenCode versions
+      // session.updated may carry idle status in some OpenCode versions.
+      // session.created/session.updated also announce subagent child sessions
+      // (parentID = our session) which we track to surface their tool activity.
+      case 'session.created':
       case 'session.updated': {
+        const session = (properties.info ?? properties.session) as Record<string, unknown> | undefined
+        const sessId = session?.id as string | undefined
+        const parentID = session?.parentID as string | undefined
+        if (sessId && parentID && parentID === this.opencodeSessionId && !this.childSessionIds.has(sessId)) {
+          this.childSessionIds.add(sessId)
+          const title = typeof session?.title === 'string' && session.title ? session.title : 'subagent'
+          this.emit('tool_active', 'Task', title)
+        }
         if (!this.isOwnSession(properties)) break
-        const session = properties.session as Record<string, unknown> | undefined
+        // Guard: a session object for a different session (e.g. a child) must
+        // not complete our turn even if it reports idle.
+        if (sessId && sessId !== this.opencodeSessionId) break
         const sessionStatus = session?.status
         const sType = typeof sessionStatus === 'string' ? sessionStatus : (sessionStatus as { type?: string } | undefined)?.type
         if (sType === 'idle') {
@@ -915,10 +946,15 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       case 'message.updated': {
         if (!this.isOwnSession(properties)) break
         const info = properties.info as {
+          id?: string
           role?: string
           parts?: OpenCodeMessagePart[]
+          cost?: number
+          tokens?: { input?: number; output?: number; reasoning?: number; cache?: { read?: number; write?: number } }
         } | undefined
-        if (!info || info.role !== 'assistant' || !info.parts) break
+        if (!info || info.role !== 'assistant') break
+        this.trackUsage(info)
+        if (!info.parts) break
         if (process.env.CODEKIN_DEBUG_SSE) {
           console.log(`[opencode-sse] message.updated parts=${info.parts.length} types=${info.parts.map(p => p.type).join(',')}`)
           for (const p of info.parts) {
@@ -939,6 +975,48 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
           }
         }
         break
+    }
+  }
+
+  /**
+   * Accumulate token/cost usage from assistant message.updated info and emit
+   * cumulative session totals. message.updated fires repeatedly per message,
+   * so usage is keyed by message ID (latest wins) and duplicate totals are
+   * suppressed.
+   */
+  private trackUsage(info: { id?: string; cost?: number; tokens?: { input?: number; output?: number; reasoning?: number; cache?: { read?: number; write?: number } } }): void {
+    const t = info.tokens
+    if (!t || !info.id) return
+    const input = (t.input ?? 0) + (t.cache?.read ?? 0) + (t.cache?.write ?? 0)
+    const output = (t.output ?? 0) + (t.reasoning ?? 0)
+    if (input === 0 && output === 0) return
+    this.usageByMessage.set(info.id, { input, output, cost: info.cost ?? 0 })
+    let inputTokens = 0
+    let outputTokens = 0
+    let costUsd = 0
+    for (const u of this.usageByMessage.values()) {
+      inputTokens += u.input
+      outputTokens += u.output
+      costUsd += u.cost
+    }
+    const key = `${inputTokens}/${outputTokens}/${costUsd}`
+    if (key === this.lastEmittedUsage) return
+    this.lastEmittedUsage = key
+    this.emit('usage', { inputTokens, outputTokens, costUsd })
+  }
+
+  /** Surface a subagent (child session) tool part as tool activity in the main session. */
+  private handleChildToolPart(part: OpenCodeMessagePart): void {
+    const toolName = part.tool || 'unknown'
+    const status = part.state?.status
+    if (status === 'running') {
+      const inputStr = part.state?.input ? summarizeToolInput(toolName, part.state.input) : undefined
+      this.emit('tool_active', toolName, inputStr)
+    } else if (status === 'completed') {
+      const output = part.state?.output
+      this.emit('tool_done', toolName, output ? output.slice(0, 200) : undefined)
+    } else if (status === 'error') {
+      this.emit('tool_done', toolName, `Error: ${part.state?.error || 'unknown'}`)
     }
   }
 
@@ -994,10 +1072,36 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       const info = (last.info ?? last) as { role?: string; time?: { completed?: number } }
       if (info.role === 'assistant' && info.time?.completed) {
         console.warn(`[opencode] Missed turn-completion event for session ${this.opencodeSessionId} — recovered via message poll`)
+        this.recoverMissedText(last)
         this.completeTurn()
       }
     } catch (err) {
       console.warn(`[opencode] Turn liveness poll failed for ${this.opencodeSessionId}:`, err)
+    }
+  }
+
+  /**
+   * When a turn completed server-side but its SSE events were lost (stream
+   * drop), the assistant's response text was never emitted. Recover it from
+   * the polled message-history entry so the user isn't left with a silent turn.
+   */
+  private recoverMissedText(entry: Record<string, unknown>): void {
+    if (this.receivedDeltas || this.emittedPartText || this.deltaBuffer) return
+    const parts = (entry.parts ?? (entry.info as Record<string, unknown> | undefined)?.parts) as OpenCodeMessagePart[] | undefined
+    if (!Array.isArray(parts)) return
+    const text = parts
+      .filter((p) => p.type === 'text' && p.text)
+      .map((p) => p.text)
+      .join('\n')
+    if (!text) return
+    let out = text
+    if (this.lastUserInput && out.startsWith(this.lastUserInput)) {
+      out = out.slice(this.lastUserInput.length)
+    }
+    if (out) {
+      this.emittedPartText = true
+      console.warn(`[opencode] Recovered ${out.length} chars of missed assistant text for session ${this.opencodeSessionId}`)
+      this.emit('text', out)
     }
   }
 
@@ -1099,6 +1203,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     }
 
     this.turnComplete = false // reset completion latch for new turn
+    this.turnInFlight = true
     this.receivedDeltas = false
     this.emittedPartText = false
     this.deltaBuffer = ''
@@ -1151,6 +1256,35 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       }
     }
     this.lastUserInput = textContent.trim()
+
+    // /compact and /summarize map to OpenCode's native summarize endpoint,
+    // which condenses the conversation server-side. The summarization runs as
+    // a turn — SSE events stream in and the idle event completes the latch.
+    const trimmedText = textContent.trim()
+    if (!attachMatch && (trimmedText === '/compact' || trimmedText === '/summarize')) {
+      const summarizeBody: Record<string, unknown> = {}
+      if (this.model && this.model.includes('/')) {
+        const slashIdx = this.model.indexOf('/')
+        summarizeBody.providerID = this.model.slice(0, slashIdx)
+        summarizeBody.modelID = this.model.slice(slashIdx + 1)
+      }
+      void fetch(`${baseUrl}/session/${this.opencodeSessionId}/summarize`, {
+        method: 'POST',
+        headers: {
+          ...authHeaders(),
+          'Content-Type': 'application/json',
+          'x-opencode-directory': this.workingDir,
+        },
+        body: JSON.stringify(summarizeBody),
+      }).then((res) => {
+        if (!res.ok) {
+          this.emit('error', `Failed to compact conversation: HTTP ${res.status}`)
+        }
+      }).catch((err) => {
+        this.emit('error', `Failed to compact conversation: ${err instanceof Error ? err.message : String(err)}`)
+      })
+      return
+    }
 
     // Route known slash commands (`/name args`) to OpenCode's command
     // endpoint so its commands/skills/MCP prompts work from Codekin.
@@ -1227,17 +1361,36 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
 
   /**
    * Respond to a permission/control request.
-   * Maps Codekin's allow/deny to OpenCode's once/always/reject.
+   * Maps Codekin's allow/deny/allow_always to OpenCode's once/reject/always.
+   * 'always' makes OpenCode remember the grant server-side, so the same
+   * permission won't round-trip through the approval UI again this session.
    */
-  sendControlResponse(requestId: string, behavior: 'allow' | 'deny'): void {
-    const type = behavior === 'deny' ? 'reject' : 'once'
+  sendControlResponse(requestId: string, behavior: 'allow' | 'deny' | 'allow_always'): void {
+    const type = behavior === 'deny' ? 'reject' : behavior === 'allow_always' ? 'always' : 'once'
     void this.replyToPermission(requestId, type)
   }
 
-  /** Stop the OpenCode session and disconnect the SSE stream. */
+  /**
+   * Stop the OpenCode session and disconnect the SSE stream. If a turn is
+   * still running server-side, abort it — otherwise OpenCode keeps generating
+   * (and editing files) with nobody attached.
+   */
   stop(): void {
     if (!this.alive) return
     this.alive = false
+    if (this.turnInFlight && this.opencodeSessionId) {
+      this.turnInFlight = false
+      void fetch(`http://localhost:${serverState.port}/session/${this.opencodeSessionId}/abort`, {
+        method: 'POST',
+        headers: {
+          ...authHeaders(),
+          'x-opencode-directory': this.workingDir,
+        },
+        signal: AbortSignal.timeout(5000),
+      }).catch((err) => {
+        console.warn(`[opencode] Failed to abort in-flight turn for ${this.opencodeSessionId}:`, err)
+      })
+    }
     this.clearTurnWatchdog()
     if (this.startupTimer) {
       clearTimeout(this.startupTimer)

--- a/server/prompt-router.test.ts
+++ b/server/prompt-router.test.ts
@@ -373,6 +373,18 @@ describe('PromptRouter', () => {
       expect(deps.approvalManager.saveAlwaysAllow).toHaveBeenCalledWith('/repos/test', 'Bash', { command: 'npm test' })
     })
 
+    it('forwards always_allow to the provider as allow_always', () => {
+      session.pendingControlRequests.set('cr-4', {
+        requestId: 'cr-4',
+        toolName: 'Bash',
+        toolInput: { command: 'npm test' },
+      })
+
+      router.sendPromptResponse('sess-1', 'always_allow', 'cr-4')
+
+      expect(session.claudeProcess!.sendControlResponse).toHaveBeenCalledWith('cr-4', 'allow_always')
+    })
+
     it('infers sole pending prompt when no requestId given', () => {
       session.pendingControlRequests.set('cr-only', {
         requestId: 'cr-only',

--- a/server/prompt-router.ts
+++ b/server/prompt-router.ts
@@ -593,7 +593,10 @@ export class PromptRouter {
       this.deps.approvalManager.savePatternApproval(session.groupDir ?? session.workingDir, pending.toolName, pending.toolInput)
     }
 
-    const behavior = isDeny ? 'deny' : 'allow'
+    // 'allow_always' lets providers persist the grant natively (OpenCode maps
+    // it to its 'always' reply; Claude treats it as a plain allow — Codekin's
+    // ApprovalManager handles persistence there).
+    const behavior = isDeny ? 'deny' : isAlwaysAllow ? 'allow_always' : 'allow'
     if (!session.claudeProcess?.isAlive()) return
     session.claudeProcess.sendControlResponse(pending.requestId, behavior)
   }

--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -239,6 +239,7 @@ export class SessionLifecycle {
       // ExitPlanMode stream event intentionally ignored — hook handles it.
     })
     cp.on('todo_update', (tasks) => { this.deps.broadcastAndHistory(session, { type: 'todo_update', tasks }) })
+    cp.on('usage', (usage) => { this.deps.broadcastAndHistory(session, { type: 'usage', ...usage }) })
     cp.on('prompt', (...args) => this.deps.promptRouter.onPromptEvent(session, ...args))
     cp.on('control_request', (requestId, toolName, toolInput) => this.deps.promptRouter.onControlRequestEvent(cp, session, sessionId, requestId, toolName, toolInput))
     cp.on('result', (result, isError) => {

--- a/server/session-manager.test.ts
+++ b/server/session-manager.test.ts
@@ -745,7 +745,7 @@ describe('SessionManager', () => {
 
       sm.sendPromptResponse(s.id, 'always_allow', 'req-1')
 
-      expect(cp.sendControlResponse).toHaveBeenCalledWith('req-1', 'allow')
+      expect(cp.sendControlResponse).toHaveBeenCalledWith('req-1', 'allow_always')
       // Pattern-first: 'npm test' is patternable, stored as pattern
       expect(sm.approvalManager.getApprovals(s.workingDir).patterns).toContain('npm test *')
     })
@@ -763,7 +763,7 @@ describe('SessionManager', () => {
 
       sm.sendPromptResponse(s.id, 'always_allow', 'req-1')
 
-      expect(cp.sendControlResponse).toHaveBeenCalledWith('req-1', 'allow')
+      expect(cp.sendControlResponse).toHaveBeenCalledWith('req-1', 'allow_always')
       expect(sm.approvalManager.getApprovals(s.workingDir).tools).toContain('Write')
     })
 
@@ -1481,7 +1481,7 @@ describe('SessionManager', () => {
 
       // Pattern-first: 'git status' is patternable, stored as pattern
       expect(sm.approvalManager.getApprovals(s.workingDir).patterns).toContain('git status *')
-      expect(cp.sendControlResponse).toHaveBeenCalledWith('req-1', 'allow')
+      expect(cp.sendControlResponse).toHaveBeenCalledWith('req-1', 'allow_always')
     })
 
   })

--- a/server/types.ts
+++ b/server/types.ts
@@ -225,6 +225,20 @@ export interface ClaudeResultEvent {
   session_id: string
   duration_ms: number
   total_cost_usd: number
+  /** Per-turn token usage (present in recent CLI versions). */
+  usage?: {
+    input_tokens?: number
+    output_tokens?: number
+    cache_read_input_tokens?: number
+    cache_creation_input_tokens?: number
+  }
+}
+
+/** Cumulative session token/cost usage emitted by coding processes. */
+export interface SessionUsage {
+  inputTokens: number
+  outputTokens: number
+  costUsd?: number
 }
 
 /**
@@ -292,6 +306,7 @@ export type WsServerMessage =
   | { type: 'system_message'; subtype: 'init' | 'exit' | 'error' | 'restart' | 'notification'; text: string; model?: string }
   | { type: 'user_echo'; text: string }
   | { type: 'result' }
+  | { type: 'usage'; inputTokens: number; outputTokens: number; costUsd?: number }
   | { type: 'planning_mode'; active: boolean }
   | { type: 'todo_update'; tasks: TaskItem[] }
   | { type: 'session_name_update'; sessionId: string; name: string }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -127,6 +127,7 @@ export default function App() {
     connState,
     messages,
     tasks,
+    usage,
     planningMode,
     isProcessing,
     thinkingSummary,
@@ -300,7 +301,14 @@ export default function App() {
         if (activeWorkingDir) handleNewSessionForRepo()
         break
       case '/compact':
-        sendInput('Please compact the conversation context to save tokens while preserving important context.')
+        // OpenCode has a native summarize endpoint — the server maps the
+        // literal /compact to POST /session/:id/summarize. Claude (stream-json)
+        // has no such command, so ask the model to compact in-band.
+        if (activeSessionProvider === 'opencode') {
+          sendInput('/compact')
+        } else {
+          sendInput('Please compact the conversation context to save tokens while preserving important context.')
+        }
         break
       case '/model':
         if (args) {
@@ -316,7 +324,7 @@ export default function App() {
         sendInput(`[Codekin] Command ${command} is not available in the web UI.`)
         break
     }
-  }, [leaveSession, clearMessages, activeWorkingDir, handleNewSessionForRepo, sendInput, currentModel, handleModelChange])
+  }, [leaveSession, clearMessages, activeWorkingDir, handleNewSessionForRepo, sendInput, currentModel, handleModelChange, activeSessionProvider])
 
   // Message sending: file uploads, skill expansion, tentative queue
   const {
@@ -703,6 +711,7 @@ export default function App() {
             onModelChange={handleModelChange}
             availableModels={availableModels}
             sessionProvider={activeSessionProvider}
+            usage={usage}
             hasUserMessages={messages.some(m => m.type === 'user')}
             useWorktree={useWorktree}
             onWorktreeChange={setUseWorktree}

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -14,6 +14,7 @@ import { SkillMenu, type SkillGroup } from './SkillMenu'
 import { SlashAutocomplete } from './SlashAutocomplete'
 import { DropZone } from './DropZone'
 import type { SlashCommand } from '../lib/slashCommands'
+import { formatUsageLabel } from '../lib/formatUsage'
 import { PERMISSION_MODES, type PermissionMode, type ModelOption } from '../types'
 
 const PERMISSION_MODE_ICONS: Record<string, typeof IconShieldCheck> = {
@@ -310,6 +311,8 @@ interface InputBarProps {
   availableModels?: ModelOption[]
   /** Coding provider of the active session — filters provider-specific permission modes. */
   sessionProvider?: 'claude' | 'opencode'
+  /** Cumulative token/cost usage for the session — shown as a small toolbar indicator. */
+  usage?: import('../types').SessionUsage | null
   /** Override the default placeholder text in the textarea. */
   placeholder?: string
   /** When true, disables drag-to-resize and uses auto-height instead. */
@@ -332,7 +335,7 @@ interface InputBarProps {
   variant?: InputBarVariant
 }
 
-export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function InputBar({ onSendInput, isWaiting, disabled, onEscape, pendingFiles, onAddFiles, onRemoveFile, skillGroups, slashCommands, initialValue = '', onValueChange, currentModel, onModelChange, availableModels = [], sessionProvider, placeholder, isMobile = false, showWorktreeToggle = false, useWorktree = false, onWorktreeChange, currentPermissionMode, onPermissionModeChange, onMoveToWorktree, worktreePath, variant = 'default' }, ref) {
+export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function InputBar({ onSendInput, isWaiting, disabled, onEscape, pendingFiles, onAddFiles, onRemoveFile, skillGroups, slashCommands, initialValue = '', onValueChange, currentModel, onModelChange, availableModels = [], sessionProvider, usage, placeholder, isMobile = false, showWorktreeToggle = false, useWorktree = false, onWorktreeChange, currentPermissionMode, onPermissionModeChange, onMoveToWorktree, worktreePath, variant = 'default' }, ref) {
   const isOrchestrator = variant === 'orchestrator'
   // OpenCode has no equivalent of Claude's --dangerously-skip-permissions flag;
   // bypassPermissions (all-allow ruleset) already covers that use case.
@@ -629,6 +632,14 @@ export const InputBar = forwardRef<InputBarHandle, InputBarProps>(function Input
               ) : null}
             </div>
             <div className="flex items-center gap-1">
+              {usage && (usage.inputTokens > 0 || usage.outputTokens > 0) && (
+                <span
+                  className="hidden md:inline px-2 py-1 text-[11px] text-neutral-5 whitespace-nowrap"
+                  title={`Session usage — input: ${usage.inputTokens.toLocaleString()} tokens, output: ${usage.outputTokens.toLocaleString()} tokens${usage.costUsd ? `, cost: $${usage.costUsd.toFixed(4)}` : ''}`}
+                >
+                  {formatUsageLabel(usage)}
+                </span>
+              )}
               {currentModel && onModelChange && (
                 <ModelDropdown
                   currentModel={currentModel}

--- a/src/components/SessionContent.tsx
+++ b/src/components/SessionContent.tsx
@@ -51,6 +51,8 @@ export interface SessionContentProps {
   availableModels?: import('../types').ModelOption[]
   /** Coding provider of the active session — drives provider-specific UI (permission modes). */
   sessionProvider?: import('../types').CodingProvider
+  /** Cumulative token/cost usage for the active session (shown in the input bar). */
+  usage?: import('../types').SessionUsage | null
   hasUserMessages: boolean
   useWorktree: boolean
   onWorktreeChange: (v: boolean) => void
@@ -96,6 +98,7 @@ export function SessionContent({
   onModelChange,
   availableModels,
   sessionProvider,
+  usage,
   hasUserMessages,
   useWorktree,
   onWorktreeChange,
@@ -210,6 +213,7 @@ export function SessionContent({
         onModelChange={onModelChange}
         availableModels={availableModels}
         sessionProvider={sessionProvider}
+        usage={usage}
         isMobile={isMobile}
         showWorktreeToggle={!hasUserMessages}
         useWorktree={useWorktree}

--- a/src/hooks/useChatSocket.ts
+++ b/src/hooks/useChatSocket.ts
@@ -12,7 +12,7 @@
  */
 
 import { useRef, useCallback, useEffect, useState } from 'react'
-import type { WsClientMessage, WsServerMessage, ChatMessage, TaskItem, PermissionMode } from '../types'
+import type { WsClientMessage, WsServerMessage, ChatMessage, TaskItem, PermissionMode, SessionUsage } from '../types'
 import { usePromptState } from './usePromptState'
 import { useWsConnection } from './useWsConnection'
 
@@ -180,6 +180,7 @@ export function useChatSocket({
     (localStorage.getItem('claude-permission-mode') as PermissionMode) || 'acceptEdits'
   )
   const [thinkingSummary, setThinkingSummary] = useState<string | null>(null)
+  const [usage, setUsage] = useState<SessionUsage | null>(null)
   const promptState = usePromptState()
   const currentSessionId = useRef<string | null>(null)
   /** True after the socket drops (e.g. server restart) until the session rejoins. */
@@ -295,6 +296,10 @@ export function useChatSocket({
         setTasks(msg.tasks)
         break
 
+      case 'usage':
+        setUsage({ inputTokens: msg.inputTokens, outputTokens: msg.outputTokens, costUsd: msg.costUsd })
+        break
+
       // Prompt handling: permission requests and questions from Claude's control protocol.
       // See server/types.ts:ClaudeControlRequest — prompt responses require a control_response
       // wrapper sent via the 'prompt_response' WsClientMessage type, not a regular 'input' message.
@@ -319,6 +324,7 @@ export function useChatSocket({
         setRenderSessionId(msg.sessionId)
         setMessages([])
         setTasks([])
+        setUsage(null)
         setIsProcessing(false)
         setThinkingSummary(null)
         callbacksRef.current.onSessionCreated?.(msg.sessionId)
@@ -341,6 +347,7 @@ export function useChatSocket({
         let rebuilt: ChatMessage[] = []
         let restoredPlanMode = false
         let restoredTasks: TaskItem[] = []
+        let restoredUsage: SessionUsage | null = null
         if (msg.outputBuffer?.length) {
           rebuilt = rebuildFromHistory(msg.outputBuffer)
           for (const bufferedMsg of msg.outputBuffer) {
@@ -349,6 +356,9 @@ export function useChatSocket({
             }
             if (bufferedMsg.type === 'todo_update') {
               restoredTasks = bufferedMsg.tasks
+            }
+            if (bufferedMsg.type === 'usage') {
+              restoredUsage = { inputTokens: bufferedMsg.inputTokens, outputTokens: bufferedMsg.outputTokens, costUsd: bufferedMsg.costUsd }
             }
           }
         }
@@ -361,6 +371,7 @@ export function useChatSocket({
         }
         setPlanningMode(restoredPlanMode)
         setTasks(restoredTasks)
+        setUsage(restoredUsage)
         setMessages(trimMessages(rebuilt))
         callbacksRef.current.onSessionJoined?.(msg.sessionId)
         break
@@ -515,6 +526,7 @@ export function useChatSocket({
     connState,
     messages,
     tasks,
+    usage,
     planningMode,
     isProcessing,
     thinkingSummary,

--- a/src/lib/formatUsage.test.ts
+++ b/src/lib/formatUsage.test.ts
@@ -1,0 +1,38 @@
+/** Tests for formatUsage — verifies compact token-count and usage-label formatting. */
+import { describe, it, expect } from 'vitest'
+import { formatTokenCount, formatUsageLabel } from './formatUsage'
+
+describe('formatTokenCount', () => {
+  it('returns small counts as-is', () => {
+    expect(formatTokenCount(0)).toBe('0')
+    expect(formatTokenCount(950)).toBe('950')
+  })
+
+  it('formats thousands with a k suffix', () => {
+    expect(formatTokenCount(1_000)).toBe('1.0k')
+    expect(formatTokenCount(12_340)).toBe('12.3k')
+  })
+
+  it('formats millions with an M suffix', () => {
+    expect(formatTokenCount(2_100_000)).toBe('2.1M')
+  })
+})
+
+describe('formatUsageLabel', () => {
+  it('sums input and output tokens', () => {
+    expect(formatUsageLabel({ inputTokens: 800, outputTokens: 200 })).toBe('1.0k tok')
+  })
+
+  it('appends cost with 3 decimals below $1', () => {
+    expect(formatUsageLabel({ inputTokens: 100, outputTokens: 50, costUsd: 0.0421 })).toBe('150 tok · $0.042')
+  })
+
+  it('appends cost with 2 decimals at $1 and above', () => {
+    expect(formatUsageLabel({ inputTokens: 100, outputTokens: 50, costUsd: 1.5 })).toBe('150 tok · $1.50')
+  })
+
+  it('omits cost when zero or absent', () => {
+    expect(formatUsageLabel({ inputTokens: 100, outputTokens: 50, costUsd: 0 })).toBe('150 tok')
+    expect(formatUsageLabel({ inputTokens: 100, outputTokens: 50 })).toBe('150 tok')
+  })
+})

--- a/src/lib/formatUsage.ts
+++ b/src/lib/formatUsage.ts
@@ -1,0 +1,19 @@
+/** Pure formatters for the session token/cost usage indicator in the input bar. */
+
+/** Format a token count compactly: 950 → "950", 12_340 → "12.3k", 2_100_000 → "2.1M". */
+export function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
+}
+
+/** Build the toolbar usage label, e.g. "12.3k tok · $0.042". */
+export function formatUsageLabel(usage: { inputTokens: number; outputTokens: number; costUsd?: number }): string {
+  const total = usage.inputTokens + usage.outputTokens
+  const tok = `${formatTokenCount(total)} tok`
+  if (usage.costUsd && usage.costUsd > 0) {
+    const cost = usage.costUsd < 1 ? usage.costUsd.toFixed(3) : usage.costUsd.toFixed(2)
+    return `${tok} · $${cost}`
+  }
+  return tok
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -142,6 +142,13 @@ export interface TaskItem {
   activeForm?: string
 }
 
+/** Cumulative session token/cost usage reported by the coding process. */
+export interface SessionUsage {
+  inputTokens: number
+  outputTokens: number
+  costUsd?: number
+}
+
 /**
  * Messages sent from the WebSocket server to the browser client.
  *
@@ -184,6 +191,7 @@ export type WsServerMessage =
   | { type: 'system_message'; subtype: 'init' | 'exit' | 'error' | 'restart' | 'notification' | 'info'; text: string; model?: string }
   | { type: 'user_echo'; text: string }
   | { type: 'result' }
+  | { type: 'usage'; inputTokens: number; outputTokens: number; costUsd?: number }
   | { type: 'planning_mode'; active: boolean }
   | { type: 'todo_update'; tasks: TaskItem[] }
   | { type: 'session_name_update'; sessionId: string; name: string }


### PR DESCRIPTION
## Summary

Implements the six remaining OpenCode integration improvements:

1. **Turn interrupt on stop** — `stop()` now fires `POST /session/:id/abort` when a turn is in flight (tracked via a new `turnInFlight` latch), so OpenCode stops generating/editing when the user hits Stop or closes the session.
2. **`/compact` → native summarize** — `/compact` and `/summarize` route to `POST /session/:id/summarize` with the session's provider/model; the Claude path keeps its existing prompt-based compaction.
3. **Native "Always Allow"** — the provider interface gains an `allow_always` behavior; OpenCode maps it to its native `always` permission reply, Claude treats it as allow (persistence stays in ApprovalManager).
4. **Token/cost usage end to end** — both providers emit cumulative `usage` events (Claude from result-event usage/`total_cost_usd`; OpenCode from assistant `message.updated` tokens/cost, keyed per message with dedup). Broadcast via history so rejoin restores it. Shown as a compact indicator in the input bar (`12.3k tok · $0.042`).
5. **Missed-text recovery** — when the turn watchdog recovers a missed completion via message poll, the assistant's lost response text is now recovered from the polled parts (with user-echo stripping) instead of leaving a silent turn.
6. **Subagent activity** — child sessions (`parentID` = our session) are tracked from `session.created/updated`; their tool parts surface as tool activity, their text stays out of the transcript, and their events feed turn liveness. Also fixes a latent bug where a child session reporting idle could complete the parent turn.

## Test plan

- [x] `npm test` — 2222 tests pass (new suites: abort-on-stop, compact routing, usage tracking/dedup/accumulation, missed-text recovery, subagent surfacing, allow_always mapping for both providers, usage formatters)
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — typecheck + build pass
- [ ] Manual: stop an in-flight OpenCode turn and confirm generation halts server-side
- [ ] Manual: run `/compact` in an OpenCode session
- [ ] Manual: verify usage indicator appears and survives rejoin

🤖 Generated with [Claude Code](https://claude.com/claude-code)