### PR TITLE
feat: add OpenAI Codex CLI as a third coding-agent provider

### DIFF
--- a/server/codex-process.test.ts
+++ b/server/codex-process.test.ts
@@ -1,0 +1,705 @@
+/**
+ * Tests for CodexProcess — verifies the JSON-RPC handshake, app-server
+ * notification → ClaudeProcessEvents mapping, approval round-trips, and
+ * provider interface compliance. The `codex app-server` child is mocked with
+ * an EventEmitter + PassThrough stdout so NDJSON lines can be fed in.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { PassThrough } from 'stream'
+
+interface MockProc extends EventEmitter {
+  stdin: { write: ReturnType<typeof vi.fn>; writable: boolean; end: ReturnType<typeof vi.fn> }
+  stdout: PassThrough
+  stderr: PassThrough
+  kill: ReturnType<typeof vi.fn>
+  killed: boolean
+  exitCode: number | null
+}
+
+const spawnState = vi.hoisted(() => ({
+  procs: [] as unknown[],
+  failNext: null as string | null,
+}))
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  const { EventEmitter } = await import('events')
+  const { PassThrough } = await import('stream')
+  return {
+    ...actual,
+    spawn: vi.fn(() => {
+      const proc = Object.assign(new EventEmitter(), {
+        stdin: { write: vi.fn(), writable: true, end: vi.fn() },
+        stdout: new PassThrough(),
+        stderr: new PassThrough(),
+        kill: vi.fn(),
+        killed: false,
+        exitCode: null,
+      })
+      spawnState.procs.push(proc)
+      if (spawnState.failNext) {
+        const code = spawnState.failNext
+        spawnState.failNext = null
+        setImmediate(() => {
+          const err = new Error(`spawn codex ${code}`) as NodeJS.ErrnoException
+          err.code = code
+          proc.emit('error', err)
+        })
+      }
+      return proc
+    }),
+  }
+})
+
+import { CodexProcess, fetchCodexModels, clearCodexModelCache } from './codex-process.js'
+import { CODEX_CAPABILITIES } from './coding-process.js'
+
+const tick = async () => {
+  await new Promise<void>(r => setImmediate(r))
+  await new Promise<void>(r => setImmediate(r))
+}
+
+const lastProc = (): MockProc => spawnState.procs[spawnState.procs.length - 1] as MockProc
+
+/** All JSON messages written to the child's stdin so far. */
+const writes = (proc: MockProc): Array<Record<string, unknown>> =>
+  proc.stdin.write.mock.calls.map((c: unknown[]) => JSON.parse(c[0] as string) as Record<string, unknown>)
+
+/** Feed one NDJSON line to the child's stdout. */
+const feed = async (proc: MockProc, msg: Record<string, unknown>) => {
+  proc.stdout.write(JSON.stringify(msg) + '\n')
+  await tick()
+}
+
+/** Run the full initialize → thread/start handshake. */
+const handshake = async (cxp: CodexProcess, threadId = 'thread-1') => {
+  cxp.start()
+  const proc = lastProc()
+  await tick()
+  const init = writes(proc).find(w => w.method === 'initialize')!
+  await feed(proc, { id: init.id, result: {} })
+  const ts = writes(proc).find(w => w.method === 'thread/start' || w.method === 'thread/resume')!
+  await feed(proc, { id: ts.id, result: { thread: { id: threadId } } })
+  return proc
+}
+
+describe('CodexProcess', () => {
+  let cxp: CodexProcess
+  let errors: string[]
+
+  beforeEach(() => {
+    spawnState.procs = []
+    spawnState.failNext = null
+    clearCodexModelCache()
+    vi.clearAllMocks()
+    cxp = new CodexProcess('/tmp', { sessionId: 'test-session-id', model: 'gpt-5.5' })
+    errors = []
+    cxp.on('error', (msg) => errors.push(msg))
+  })
+
+  afterEach(async () => {
+    cxp.stop()
+    // Settle the close handler so kill/startup timers are cleared
+    for (const p of spawnState.procs) (p as MockProc).emit('close', 0, null)
+    await tick()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Interface compliance
+  // ---------------------------------------------------------------------------
+
+  describe('provider interface', () => {
+    it('reports provider as codex', () => {
+      expect(cxp.provider).toBe('codex')
+    })
+
+    it('has codex capabilities', () => {
+      expect(cxp.capabilities).toBe(CODEX_CAPABILITIES)
+      expect(cxp.capabilities.multiProvider).toBe(false)
+      expect(cxp.capabilities.planMode).toBe(false)
+    })
+
+    it('starts as not alive and not ready', () => {
+      expect(cxp.isAlive()).toBe(false)
+      expect(cxp.isReady()).toBe(false)
+    })
+
+    it('returns codekin session ID when no thread exists', () => {
+      expect(cxp.getSessionId()).toBe('test-session-id')
+    })
+
+    it('returns the codex thread ID when available (for resume)', () => {
+      const cxp2 = new CodexProcess('/tmp', { sessionId: 'ck-id', codexThreadId: 'thread-abc' })
+      expect(cxp2.getSessionId()).toBe('thread-abc')
+      cxp2.stop()
+    })
+
+    it('generates a session ID if not provided', () => {
+      const cxp2 = new CodexProcess('/tmp')
+      expect(cxp2.getSessionId()).toHaveLength(36)
+      cxp2.stop()
+    })
+
+    it('sendRaw is a no-op', () => {
+      cxp.sendRaw('anything')
+    })
+
+    it('waitForExit resolves immediately when not started', async () => {
+      await expect(cxp.waitForExit()).resolves.toBeUndefined()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Startup & handshake
+  // ---------------------------------------------------------------------------
+
+  describe('startup handshake', () => {
+    it('errors immediately when working directory does not exist', () => {
+      const cxp2 = new CodexProcess('/nonexistent/dir/xyz')
+      const errs: string[] = []
+      const exits: Array<number | null> = []
+      cxp2.on('error', (m) => errs.push(m))
+      cxp2.on('exit', (code) => exits.push(code))
+      cxp2.start()
+      expect(errs[0]).toContain('Working directory does not exist')
+      expect(exits).toEqual([1])
+    })
+
+    it('sends initialize with codekin clientInfo', async () => {
+      cxp.start()
+      await tick()
+      const init = writes(lastProc()).find(w => w.method === 'initialize')!
+      expect(init.params).toMatchObject({ clientInfo: { name: 'codekin' } })
+    })
+
+    it('sends initialized notification then thread/start with cwd, policy, sandbox, model', async () => {
+      cxp.start()
+      const proc = lastProc()
+      await tick()
+      const init = writes(proc).find(w => w.method === 'initialize')!
+      await feed(proc, { id: init.id, result: {} })
+      const all = writes(proc)
+      expect(all.some(w => w.method === 'initialized' && w.id === undefined)).toBe(true)
+      const ts = all.find(w => w.method === 'thread/start')!
+      expect(ts.params).toMatchObject({
+        cwd: '/tmp',
+        approvalPolicy: 'on-request',
+        sandbox: 'workspace-write',
+        model: 'gpt-5.5',
+      })
+    })
+
+    it('becomes ready and emits system_init after thread/start response', async () => {
+      const inits: string[] = []
+      cxp.on('system_init', (m) => inits.push(m))
+      await handshake(cxp)
+      expect(cxp.isAlive()).toBe(true)
+      expect(cxp.isReady()).toBe(true)
+      expect(cxp.getSessionId()).toBe('thread-1')
+      expect(inits).toEqual(['gpt-5.5'])
+    })
+
+    it('uses thread/resume when a codexThreadId is provided', async () => {
+      const cxp2 = new CodexProcess('/tmp', { codexThreadId: 'thread-old' })
+      cxp2.on('error', () => {})
+      cxp2.start()
+      const proc = lastProc()
+      await tick()
+      const init = writes(proc).find(w => w.method === 'initialize')!
+      await feed(proc, { id: init.id, result: {} })
+      const resume = writes(proc).find(w => w.method === 'thread/resume')!
+      expect(resume.params).toMatchObject({ threadId: 'thread-old' })
+      cxp2.stop()
+    })
+
+    it('maps bypassPermissions to never/danger-full-access', async () => {
+      const cxp2 = new CodexProcess('/tmp', { permissionMode: 'bypassPermissions' })
+      cxp2.on('error', () => {})
+      cxp2.start()
+      const proc = lastProc()
+      await tick()
+      const init = writes(proc).find(w => w.method === 'initialize')!
+      await feed(proc, { id: init.id, result: {} })
+      const ts = writes(proc).find(w => w.method === 'thread/start')!
+      expect(ts.params).toMatchObject({ approvalPolicy: 'never', sandbox: 'danger-full-access' })
+      cxp2.stop()
+    })
+
+    it('maps plan mode to on-request/read-only', async () => {
+      const cxp2 = new CodexProcess('/tmp', { permissionMode: 'plan' })
+      cxp2.on('error', () => {})
+      cxp2.start()
+      const proc = lastProc()
+      await tick()
+      const init = writes(proc).find(w => w.method === 'initialize')!
+      await feed(proc, { id: init.id, result: {} })
+      const ts = writes(proc).find(w => w.method === 'thread/start')!
+      expect(ts.params).toMatchObject({ approvalPolicy: 'on-request', sandbox: 'read-only' })
+      cxp2.stop()
+    })
+
+    it('surfaces auth errors from the handshake as a codex login hint', async () => {
+      cxp.start()
+      const proc = lastProc()
+      await tick()
+      const init = writes(proc).find(w => w.method === 'initialize')!
+      await feed(proc, { id: init.id, error: { code: 401, message: 'unauthorized: not logged in' } })
+      expect(errors.some(e => e.includes('codex login'))).toBe(true)
+      expect(cxp.hasSessionConflict()).toBe(true)
+    })
+
+    it('reports ENOENT spawn failure with install hint', async () => {
+      spawnState.failNext = 'ENOENT'
+      const exits: Array<number | null> = []
+      cxp.on('exit', (code) => exits.push(code))
+      cxp.start()
+      await tick()
+      expect(errors.some(e => e.includes('npm install -g @openai/codex'))).toBe(true)
+      expect(exits).toEqual([1])
+      expect(cxp.hasSpawnFailed()).toBe(true)
+      expect(cxp.isAlive()).toBe(false)
+    })
+
+    it('skips non-JSON banner lines on stdout', async () => {
+      cxp.start()
+      const proc = lastProc()
+      await tick()
+      proc.stdout.write('codex app-server starting...\n')
+      await tick()
+      expect(errors).toEqual([])
+      expect(cxp.hadOutput()).toBe(false)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Notification → event mapping
+  // ---------------------------------------------------------------------------
+
+  describe('event mapping', () => {
+    let proc: MockProc
+
+    beforeEach(async () => {
+      proc = await handshake(cxp)
+    })
+
+    it('maps item/agentMessage/delta to text events', async () => {
+      const texts: string[] = []
+      cxp.on('text', (t) => texts.push(t))
+      await feed(proc, { method: 'item/agentMessage/delta', params: { delta: 'Hello ' } })
+      await feed(proc, { method: 'item/agentMessage/delta', params: { delta: 'world' } })
+      expect(texts).toEqual(['Hello ', 'world'])
+    })
+
+    it('emits full text from item/completed only when no deltas streamed', async () => {
+      const texts: string[] = []
+      cxp.on('text', (t) => texts.push(t))
+      await feed(proc, { method: 'item/completed', params: { item: { type: 'agentMessage', id: 'i1', text: 'Full reply' } } })
+      expect(texts).toEqual(['Full reply'])
+    })
+
+    it('does not duplicate text when deltas were streamed', async () => {
+      const texts: string[] = []
+      cxp.on('text', (t) => texts.push(t))
+      cxp.sendMessage('hi')
+      await tick()
+      await feed(proc, { method: 'item/agentMessage/delta', params: { delta: 'Streamed' } })
+      await feed(proc, { method: 'item/completed', params: { item: { type: 'agentMessage', id: 'i1', text: 'Streamed' } } })
+      expect(texts).toEqual(['Streamed'])
+    })
+
+    it('buffers reasoning summary deltas into a single thinking event per item', async () => {
+      const thoughts: string[] = []
+      cxp.on('thinking', (t) => thoughts.push(t))
+      await feed(proc, { method: 'item/reasoning/summaryTextDelta', params: { itemId: 'r1', delta: 'Considering the' } })
+      await feed(proc, { method: 'item/reasoning/summaryTextDelta', params: { itemId: 'r1', delta: ' best approach.' } })
+      await feed(proc, { method: 'item/reasoning/summaryTextDelta', params: { itemId: 'r1', delta: ' More text after.' } })
+      expect(thoughts).toHaveLength(1)
+    })
+
+    it('falls back to completed reasoning summary when no deltas streamed', async () => {
+      const thoughts: string[] = []
+      cxp.on('thinking', (t) => thoughts.push(t))
+      await feed(proc, { method: 'item/completed', params: { item: { type: 'reasoning', id: 'r1', summary: ['Planning the change.'] } } })
+      expect(thoughts).toEqual(['Planning the change.'])
+    })
+
+    it('maps commandExecution lifecycle to Bash tool events', async () => {
+      const active: Array<[string, string | undefined]> = []
+      const done: Array<[string, string | undefined]> = []
+      const outputs: Array<[string, boolean]> = []
+      cxp.on('tool_active', (name, detail) => active.push([name, detail]))
+      cxp.on('tool_done', (name, summary) => done.push([name, summary]))
+      cxp.on('tool_output', (out, failed) => outputs.push([out, failed]))
+
+      await feed(proc, { method: 'item/started', params: { item: { type: 'commandExecution', id: 'c1', command: 'ls -la' } } })
+      await feed(proc, { method: 'item/completed', params: { item: { type: 'commandExecution', id: 'c1', command: 'ls -la', status: 'completed', aggregatedOutput: 'total 0', exitCode: 0 } } })
+
+      expect(active[0][0]).toBe('Bash')
+      expect(done[0][0]).toBe('Bash')
+      expect(outputs).toEqual([['total 0', false]])
+    })
+
+    it('marks failed command output as failed', async () => {
+      const outputs: Array<[string, boolean]> = []
+      cxp.on('tool_output', (out, failed) => outputs.push([out, failed]))
+      await feed(proc, { method: 'item/completed', params: { item: { type: 'commandExecution', id: 'c1', status: 'failed', aggregatedOutput: 'boom', exitCode: 1 } } })
+      expect(outputs).toEqual([['boom', true]])
+    })
+
+    it('truncates long command output to 2000 chars', async () => {
+      const outputs: string[] = []
+      cxp.on('tool_output', (out) => outputs.push(out))
+      const big = 'x'.repeat(5000)
+      await feed(proc, { method: 'item/completed', params: { item: { type: 'commandExecution', id: 'c1', status: 'completed', aggregatedOutput: big, exitCode: 0 } } })
+      expect(outputs[0].length).toBeLessThan(2100)
+      expect(outputs[0]).toContain('truncated, 5000 chars total')
+    })
+
+    it('maps fileChange items to Edit tool events with paths', async () => {
+      const active: Array<[string, string | undefined]> = []
+      const done: Array<[string, string | undefined]> = []
+      cxp.on('tool_active', (name, detail) => active.push([name, detail]))
+      cxp.on('tool_done', (name, summary) => done.push([name, summary]))
+      const changes = [{ path: 'src/a.ts', kind: 'edit', diff: '' }, { path: 'src/b.ts', kind: 'add', diff: '' }]
+      await feed(proc, { method: 'item/started', params: { item: { type: 'fileChange', id: 'f1', changes } } })
+      await feed(proc, { method: 'item/completed', params: { item: { type: 'fileChange', id: 'f1', status: 'completed', changes } } })
+      expect(active).toEqual([['Edit', 'src/a.ts, src/b.ts']])
+      expect(done).toEqual([['Edit', 'src/a.ts, src/b.ts']])
+    })
+
+    it('maps mcpToolCall and webSearch items', async () => {
+      const active: Array<[string, string | undefined]> = []
+      cxp.on('tool_active', (name, detail) => active.push([name, detail]))
+      await feed(proc, { method: 'item/started', params: { item: { type: 'mcpToolCall', id: 'm1', tool: 'search_issues', server: 'github' } } })
+      await feed(proc, { method: 'item/started', params: { item: { type: 'webSearch', id: 'w1', query: 'vitest docs' } } })
+      expect(active).toEqual([['search_issues', 'github'], ['WebSearch', 'vitest docs']])
+    })
+
+    it('maps turn/plan/updated to todo_update with normalized statuses', async () => {
+      const updates: Array<Array<{ id: string; subject: string; status: string }>> = []
+      cxp.on('todo_update', (tasks) => updates.push(tasks))
+      await feed(proc, {
+        method: 'turn/plan/updated',
+        params: {
+          plan: [
+            { step: 'Read files', status: 'completed' },
+            { step: 'Write code', status: 'inProgress' },
+            { step: 'Run tests', status: 'pending' },
+          ],
+        },
+      })
+      expect(updates[0]).toEqual([
+        { id: '1', subject: 'Read files', status: 'completed' },
+        { id: '2', subject: 'Write code', status: 'in_progress' },
+        { id: '3', subject: 'Run tests', status: 'pending' },
+      ])
+    })
+
+    it('maps turn/completed to a success result', async () => {
+      const results: Array<[string, boolean]> = []
+      cxp.on('result', (msg, isError) => results.push([msg, isError]))
+      await feed(proc, { method: 'turn/completed', params: { turn: { status: 'completed' } } })
+      expect(results).toEqual([['', false]])
+    })
+
+    it('maps failed turn/completed to an error result', async () => {
+      const results: Array<[string, boolean]> = []
+      cxp.on('result', (msg, isError) => results.push([msg, isError]))
+      await feed(proc, { method: 'turn/completed', params: { turn: { status: 'failed', error: { message: 'model exploded' } } } })
+      expect(results).toEqual([['model exploded', true]])
+    })
+
+    it('maps usageLimitExceeded errors to rate_limit + error', async () => {
+      const rateLimits: unknown[] = []
+      cxp.on('rate_limit', (e) => rateLimits.push(e))
+      await feed(proc, { method: 'error', params: { error: { message: 'usage limit reached', codexErrorInfo: 'usageLimitExceeded' } } })
+      expect(rateLimits).toHaveLength(1)
+      expect(errors).toContain('usage limit reached')
+    })
+
+    it('flags unauthorized errors as non-retryable auth failures', async () => {
+      await feed(proc, { method: 'error', params: { error: { message: 'token expired', codexErrorInfo: 'unauthorized' } } })
+      expect(cxp.hasSessionConflict()).toBe(true)
+      expect(errors.some(e => e.includes('codex login'))).toBe(true)
+    })
+
+    it('suppresses transient errors that will be retried', async () => {
+      await feed(proc, { method: 'error', params: { error: { message: 'flaky network' }, willRetry: true } })
+      expect(errors).toEqual([])
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Sending messages / turns
+  // ---------------------------------------------------------------------------
+
+  describe('sendMessage', () => {
+    it('errors when the process is not running', () => {
+      cxp.sendMessage('hello')
+      expect(errors).toEqual(['Codex process is not running'])
+    })
+
+    it('starts a turn with a snake_case text part', async () => {
+      const proc = await handshake(cxp)
+      cxp.sendMessage('do the thing')
+      await tick()
+      const turn = writes(proc).find(w => w.method === 'turn/start')!
+      expect(turn.params).toMatchObject({
+        threadId: 'thread-1',
+        input: [{ type: 'text', text: 'do the thing', text_elements: [] }],
+      })
+    })
+
+    it('queues messages sent before the handshake completes', async () => {
+      cxp.start()
+      const proc = lastProc()
+      await tick()
+      cxp.sendMessage('early message')
+      expect(writes(proc).find(w => w.method === 'turn/start')).toBeUndefined()
+
+      const init = writes(proc).find(w => w.method === 'initialize')!
+      await feed(proc, { id: init.id, result: {} })
+      const ts = writes(proc).find(w => w.method === 'thread/start')!
+      await feed(proc, { id: ts.id, result: { thread: { id: 'thread-1' } } })
+
+      const turn = writes(proc).find(w => w.method === 'turn/start')!
+      expect(turn.params).toMatchObject({ input: [{ type: 'text', text: 'early message', text_elements: [] }] })
+    })
+
+    it('queues messages while a turn is active and dispatches after completion', async () => {
+      const proc = await handshake(cxp)
+      cxp.sendMessage('first')
+      await tick()
+      cxp.sendMessage('second')
+      await tick()
+      expect(writes(proc).filter(w => w.method === 'turn/start')).toHaveLength(1)
+
+      await feed(proc, { method: 'turn/completed', params: { turn: { status: 'completed' } } })
+      const turns = writes(proc).filter(w => w.method === 'turn/start')
+      expect(turns).toHaveLength(2)
+      expect((turns[1].params as { input: Array<{ text: string }> }).input[0].text).toBe('second')
+    })
+
+    it('surfaces turn/start failures as error + result', async () => {
+      const proc = await handshake(cxp)
+      const results: Array<[string, boolean]> = []
+      cxp.on('result', (msg, isError) => results.push([msg, isError]))
+      cxp.sendMessage('hello')
+      await tick()
+      const turn = writes(proc).find(w => w.method === 'turn/start')!
+      await feed(proc, { id: turn.id, error: { message: 'thread is busy' } })
+      expect(results).toEqual([['thread is busy', true]])
+      expect(errors.some(e => e.includes('thread is busy'))).toBe(true)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Approval round-trips
+  // ---------------------------------------------------------------------------
+
+  describe('approvals', () => {
+    let proc: MockProc
+
+    beforeEach(async () => {
+      proc = await handshake(cxp)
+    })
+
+    it('surfaces command approval requests as control_request with Bash tool', async () => {
+      const requests: Array<[string, string, Record<string, unknown>]> = []
+      cxp.on('control_request', (id, tool, input) => requests.push([id, tool, input]))
+      await feed(proc, {
+        id: 99,
+        method: 'item/commandExecution/requestApproval',
+        params: { command: 'rm -rf node_modules', cwd: '/tmp', reason: 'cleanup' },
+      })
+      expect(requests).toEqual([[
+        'codex-approval-99',
+        'Bash',
+        { command: 'rm -rf node_modules', cwd: '/tmp', reason: 'cleanup' },
+      ]])
+    })
+
+    it('answers allow with an accept decision on the original RPC id', async () => {
+      cxp.on('control_request', () => {})
+      await feed(proc, { id: 99, method: 'item/commandExecution/requestApproval', params: { command: 'ls' } })
+      cxp.sendControlResponse('codex-approval-99', 'allow')
+      const reply = writes(proc).find(w => w.id === 99)!
+      expect(reply.result).toEqual({ decision: 'accept' })
+    })
+
+    it('answers deny with a decline decision', async () => {
+      cxp.on('control_request', () => {})
+      await feed(proc, { id: 100, method: 'item/fileChange/requestApproval', params: {} })
+      cxp.sendControlResponse('codex-approval-100', 'deny')
+      const reply = writes(proc).find(w => w.id === 100)!
+      expect(reply.result).toEqual({ decision: 'decline' })
+    })
+
+    it('surfaces fileChange approvals as Edit control_requests', async () => {
+      const requests: Array<[string, string]> = []
+      cxp.on('control_request', (id, tool) => requests.push([id, tool]))
+      await feed(proc, { id: 7, method: 'item/fileChange/requestApproval', params: { reason: 'write file' } })
+      expect(requests).toEqual([['codex-approval-7', 'Edit']])
+    })
+
+    it('ignores responses for unknown approval ids', () => {
+      cxp.sendControlResponse('codex-approval-12345', 'allow')
+      expect(writes(proc).find(w => w.id === 12345)).toBeUndefined()
+    })
+
+    it('rejects unsupported server-initiated requests so the turn does not hang', async () => {
+      await feed(proc, { id: 55, method: 'item/tool/requestUserInput', params: {} })
+      const reply = writes(proc).find(w => w.id === 55)!
+      expect(reply.error).toMatchObject({ code: -32601 })
+    })
+
+    it('auto-accepts fileChange approvals in acceptEdits mode', async () => {
+      const cxp2 = new CodexProcess('/tmp', { permissionMode: 'acceptEdits' })
+      cxp2.on('error', () => {})
+      const requests: string[] = []
+      cxp2.on('control_request', (id) => requests.push(id))
+      const proc2 = await handshake(cxp2)
+      await feed(proc2, { id: 8, method: 'item/fileChange/requestApproval', params: {} })
+      expect(requests).toEqual([])
+      expect(writes(proc2).find(w => w.id === 8)!.result).toEqual({ decision: 'accept' })
+      // Command approvals still surface in acceptEdits mode
+      await feed(proc2, { id: 9, method: 'item/commandExecution/requestApproval', params: { command: 'ls' } })
+      expect(requests).toEqual(['codex-approval-9'])
+      cxp2.stop()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle: stop & crash
+  // ---------------------------------------------------------------------------
+
+  describe('lifecycle', () => {
+    it('emits an error result when the process crashes mid-turn', async () => {
+      const proc = await handshake(cxp)
+      const results: Array<[string, boolean]> = []
+      const exits: Array<number | null> = []
+      cxp.on('result', (msg, isError) => results.push([msg, isError]))
+      cxp.on('exit', (code) => exits.push(code))
+
+      cxp.sendMessage('long task')
+      await tick()
+      proc.emit('close', 137, null)
+      await tick()
+
+      expect(results).toEqual([['Codex exited unexpectedly mid-turn', true]])
+      expect(exits).toEqual([137])
+      expect(cxp.isAlive()).toBe(false)
+    })
+
+    it('sends turn/interrupt and SIGTERM on stop during an active turn', async () => {
+      const proc = await handshake(cxp)
+      cxp.sendMessage('task')
+      await tick()
+      await feed(proc, { method: 'turn/started', params: { turn: { id: 'turn-9' } } })
+      cxp.stop()
+      const interrupt = writes(proc).find(w => w.method === 'turn/interrupt')!
+      expect(interrupt.params).toMatchObject({ threadId: 'thread-1', turnId: 'turn-9' })
+      expect(proc.kill).toHaveBeenCalledWith('SIGTERM')
+    })
+
+    it('settles pending requests and emits exit when the process closes mid-handshake', async () => {
+      const exits: Array<number | null> = []
+      cxp.on('exit', (code) => exits.push(code))
+      cxp.start()
+      const proc = lastProc()
+      await tick()
+      proc.emit('close', 1, null)
+      await tick()
+      // The pending initialize() promise is rejected (no unhandled rejection),
+      // and the error is suppressed in favor of the exit event.
+      expect(exits).toEqual([1])
+      expect(cxp.isAlive()).toBe(false)
+      expect(errors).toEqual([])
+    })
+
+    it('hadOutput reflects whether valid JSON was received', async () => {
+      cxp.start()
+      const proc = lastProc()
+      await tick()
+      expect(cxp.hadOutput()).toBe(false)
+      await feed(proc, { method: 'thread/started', params: { thread: { id: 't' } } })
+      expect(cxp.hadOutput()).toBe(true)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// fetchCodexModels
+// ---------------------------------------------------------------------------
+
+describe('fetchCodexModels', () => {
+  beforeEach(() => {
+    spawnState.procs = []
+    spawnState.failNext = null
+    clearCodexModelCache()
+    vi.clearAllMocks()
+  })
+
+  const tickLocal = async () => {
+    await new Promise<void>(r => setImmediate(r))
+    await new Promise<void>(r => setImmediate(r))
+  }
+
+  it('runs initialize → model/list and maps the response', async () => {
+    const promise = fetchCodexModels()
+    await tickLocal()
+    const proc = spawnState.procs[0] as MockProc
+    proc.stdout.write(JSON.stringify({ id: 1, result: {} }) + '\n')
+    await tickLocal()
+    proc.stdout.write(JSON.stringify({
+      id: 2,
+      result: {
+        data: [
+          { id: 'gpt-5.5', displayName: 'GPT-5.5', description: 'Frontier', isDefault: true },
+          { id: 'gpt-5.4-mini', displayName: 'GPT-5.4 Mini', description: 'Fast', isDefault: false },
+        ],
+      },
+    }) + '\n')
+    await tickLocal()
+    const result = await promise
+    expect(result.models).toEqual([
+      { id: 'gpt-5.5', name: 'GPT-5.5', description: 'Frontier', isDefault: true },
+      { id: 'gpt-5.4-mini', name: 'GPT-5.4 Mini', description: 'Fast', isDefault: false },
+    ])
+    expect(proc.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+
+  it('caches a successful result (no second spawn)', async () => {
+    const promise = fetchCodexModels()
+    await tickLocal()
+    const proc = spawnState.procs[0] as MockProc
+    proc.stdout.write(JSON.stringify({ id: 1, result: {} }) + '\n')
+    await tickLocal()
+    proc.stdout.write(JSON.stringify({ id: 2, result: { data: [{ id: 'm', displayName: 'M', description: '', isDefault: true }] } }) + '\n')
+    await tickLocal()
+    await promise
+
+    const spawnedBefore = spawnState.procs.length
+    const second = await fetchCodexModels()
+    expect(second.models).toHaveLength(1)
+    expect(spawnState.procs.length).toBe(spawnedBefore)
+  })
+
+  it('returns an empty list when the binary is missing', async () => {
+    spawnState.failNext = 'ENOENT'
+    const promise = fetchCodexModels()
+    await tickLocal()
+    const result = await promise
+    expect(result.models).toEqual([])
+  })
+
+  it('returns an empty list when the server exits early', async () => {
+    const promise = fetchCodexModels()
+    await tickLocal()
+    const proc = spawnState.procs[0] as MockProc
+    proc.emit('close', 1, null)
+    const result = await promise
+    expect(result.models).toEqual([])
+  })
+})

--- a/server/codex-process.ts
+++ b/server/codex-process.ts
@@ -1,0 +1,854 @@
+/**
+ * Manages an OpenAI Codex CLI session via `codex app-server` (JSON-RPC 2.0
+ * over stdio, newline-delimited JSON).
+ *
+ * Codex's app-server is OpenAI's documented integration surface for building
+ * UIs on top of Codex (it powers their own IDE extensions). The lifecycle is:
+ *   initialize → initialized → thread/start (or thread/resume) → turn/start
+ * with streamed item/* notifications per turn and server-initiated JSON-RPC
+ * requests for command/file-change approvals.
+ *
+ * This class wraps that protocol behind the same CodingProcess interface
+ * implemented by ClaudeProcess and OpenCodeProcess, so SessionManager works
+ * identically for all three providers.
+ *
+ * Wire schema verified against codex-cli 0.139.0 (`codex app-server generate-ts`):
+ * - approvalPolicy: 'untrusted' | 'on-failure' | 'on-request' | 'never'
+ * - sandbox: 'read-only' | 'workspace-write' | 'danger-full-access'
+ * - approval decisions: 'accept' | 'acceptForSession' | 'decline' | 'cancel'
+ * - text input parts require snake_case `text_elements`
+ *
+ * Auth: the host must be pre-authenticated via `codex login` (writes
+ * ~/.codex/auth.json, reused by app-server with automatic token refresh).
+ */
+
+import { spawn, type ChildProcess } from 'child_process'
+import { createInterface, type Interface } from 'readline'
+import { existsSync } from 'fs'
+import { extname } from 'path'
+import { EventEmitter } from 'events'
+import { randomUUID } from 'crypto'
+import type { ClaudeProcessEvents } from './claude-process.js'
+import { CODEX_CAPABILITIES, type CodingProcess, type CodingProvider, type ProviderCapabilities } from './coding-process.js'
+import type { PermissionMode, TaskItem } from './types.js'
+import { summarizeToolInput } from './tool-labels.js'
+
+// ---------------------------------------------------------------------------
+// Codex app-server protocol types (subset — only what we consume)
+// ---------------------------------------------------------------------------
+
+/** A thread item within a Codex turn (agent message, command execution, etc.). */
+interface CodexThreadItem {
+  type: string
+  id: string
+  /** agentMessage / plan */
+  text?: string
+  /** commandExecution */
+  command?: string
+  cwd?: string
+  status?: string
+  aggregatedOutput?: string | null
+  exitCode?: number | null
+  /** reasoning */
+  summary?: string[]
+  /** fileChange */
+  changes?: Array<{ path: string; kind: string; diff: string }>
+  /** mcpToolCall */
+  server?: string
+  tool?: string
+  /** webSearch */
+  query?: string
+}
+
+/** A parsed JSON-RPC message from the app-server's stdout. */
+interface CodexRpcMessage {
+  id?: number | string
+  method?: string
+  params?: Record<string, unknown>
+  result?: unknown
+  error?: { code?: number; message?: string }
+}
+
+interface PendingRequest {
+  resolve: (result: unknown) => void
+  reject: (err: Error) => void
+  method: string
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+/** Default timeout for client→server JSON-RPC requests. */
+const RPC_TIMEOUT_MS = 30_000
+
+/** Prefix for synthesized approval request IDs surfaced via control_request. */
+const APPROVAL_ID_PREFIX = 'codex-approval-'
+
+const CODEX_BINARY = process.env.CODEX_BINARY || 'codex'
+
+/** Env vars stripped from the child process env (same filtering as opencode-process). */
+const API_KEY_VARS = new Set(['ANTHROPIC_API_KEY', 'CLAUDE_CODE_API_KEY', 'AUTH_TOKEN', 'AUTH_TOKEN_FILE'])
+
+function buildEnv(extraEnv: Record<string, string>): Record<string, string> {
+  return {
+    ...Object.fromEntries(
+      Object.entries(process.env).filter(
+        (entry): entry is [string, string] =>
+          entry[1] != null &&
+          !API_KEY_VARS.has(entry[0]) &&
+          (!entry[0].startsWith('GIT_') || entry[0] === 'GIT_EDITOR')
+      )
+    ),
+    ...extraEnv,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Model discovery
+// ---------------------------------------------------------------------------
+
+/** Codex model info returned from the app-server's model/list method. */
+export interface CodexModelInfo {
+  id: string
+  name: string
+  description: string
+  isDefault: boolean
+}
+
+let modelCache: { models: CodexModelInfo[]; fetchedAt: number } | null = null
+const MODEL_CACHE_TTL_MS = 10 * 60 * 1000
+
+/**
+ * Fetch the available Codex models by spawning a short-lived app-server and
+ * calling model/list. Results reflect what the host's auth allows. Returns an
+ * empty array when the binary is missing or not authenticated. Cached for
+ * 10 minutes (the list only changes on CLI upgrade or auth change).
+ */
+export async function fetchCodexModels(): Promise<{ models: CodexModelInfo[] }> {
+  if (modelCache && Date.now() - modelCache.fetchedAt < MODEL_CACHE_TTL_MS) {
+    return { models: modelCache.models }
+  }
+  return new Promise((resolve) => {
+    let settled = false
+    const done = (models: CodexModelInfo[]) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      try { proc.kill('SIGTERM') } catch { /* already dead */ }
+      if (models.length > 0) modelCache = { models, fetchedAt: Date.now() }
+      resolve({ models })
+    }
+    const timer = setTimeout(() => { done([]) }, 15_000)
+
+    let proc: ChildProcess
+    try {
+      proc = spawn(CODEX_BINARY, ['app-server'], { env: buildEnv({}), stdio: ['pipe', 'pipe', 'ignore'] })
+    } catch {
+      clearTimeout(timer)
+      resolve({ models: [] })
+      return
+    }
+    proc.on('error', () => { done([]) })
+    proc.on('close', () => { done([]) })
+
+    const rl = createInterface({ input: proc.stdout! })
+    const write = (msg: Record<string, unknown>) => {
+      try { proc.stdin!.write(JSON.stringify(msg) + '\n') } catch { done([]) }
+    }
+    rl.on('line', (line) => {
+      let msg: CodexRpcMessage
+      try { msg = JSON.parse(line) as CodexRpcMessage } catch { return }
+      if (msg.id === 1 && msg.result !== undefined) {
+        write({ method: 'initialized' })
+        write({ id: 2, method: 'model/list', params: { includeHidden: false } })
+      } else if (msg.id === 2) {
+        const data = (msg.result as { data?: Array<{ id: string; displayName: string; description: string; isDefault: boolean }> } | undefined)?.data ?? []
+        done(data.map(m => ({ id: m.id, name: m.displayName, description: m.description, isDefault: m.isDefault })))
+      }
+    })
+    write({
+      id: 1,
+      method: 'initialize',
+      params: { clientInfo: { name: 'codekin', title: 'Codekin', version: '1.0.0' }, capabilities: null },
+    })
+  })
+}
+
+/** Reset the model cache (test helper). */
+export function clearCodexModelCache(): void {
+  modelCache = null
+}
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface CodexProcessOptions {
+  /** Absolute path to the project directory. */
+  workingDir: string
+  /** Codekin session ID (used for internal tracking). */
+  sessionId?: string
+  /** Codex's own thread ID (used for resume — returned by getSessionId()). */
+  codexThreadId?: string
+  /** Codex model ID (e.g. 'gpt-5.5'). Omit to use the CLI default. */
+  model?: string
+  /** Additional environment variables (CODEKIN_SESSION_ID, etc.). */
+  extraEnv?: Record<string, string>
+  /** Permission mode — mapped to Codex's approvalPolicy + sandbox. */
+  permissionMode?: PermissionMode
+}
+
+/** Map Codekin's permission mode to Codex approvalPolicy + sandbox values. */
+function policyForMode(mode: PermissionMode | undefined): { approvalPolicy: string; sandbox: string } {
+  switch (mode) {
+    case 'bypassPermissions':
+    case 'dangerouslySkipPermissions':
+      return { approvalPolicy: 'never', sandbox: 'danger-full-access' }
+    case 'plan':
+      return { approvalPolicy: 'on-request', sandbox: 'read-only' }
+    default:
+      return { approvalPolicy: 'on-request', sandbox: 'workspace-write' }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// CodexProcess
+// ---------------------------------------------------------------------------
+
+export class CodexProcess extends EventEmitter<ClaudeProcessEvents> implements CodingProcess {
+  readonly provider: CodingProvider = 'codex'
+  readonly capabilities: ProviderCapabilities = CODEX_CAPABILITIES
+
+  private proc: ChildProcess | null = null
+  private rl: Interface | null = null
+  private alive = false
+  private ready = false
+  private sessionId: string
+  private threadId: string | null = null
+  private workingDir: string
+  private model?: string
+  private extraEnv: Record<string, string>
+  private permissionMode?: PermissionMode
+
+  private startupTimer: ReturnType<typeof setTimeout> | null = null
+  private killTimer: ReturnType<typeof setTimeout> | null = null
+  private stderrTail = ''
+
+  /** Set when spawn() itself fails (ENOENT etc.) — restart should preserve thread id. */
+  private _spawnFailed = false
+  /** Set when Codex reports an auth failure — restarts will not help until `codex login`. */
+  private _authFailed = false
+  /** Set once the process emits at least one valid JSON message on stdout. */
+  private _receivedOutput = false
+
+  // JSON-RPC state
+  private nextRpcId = 1
+  private pending = new Map<number, PendingRequest>()
+  /** Maps synthesized approval requestIds → the originating JSON-RPC request id + method. */
+  private serverApprovals = new Map<string, { rpcId: number | string; method: string }>()
+
+  // Per-turn streaming state
+  private turnActive = false
+  private currentTurnId: string | null = null
+  private receivedDeltas = false
+  private reasoningBuffer = ''
+  private emittedReasoningSummary = false
+  private lastReasoningItemId: string | null = null
+  private queuedMessages: string[] = []
+
+  constructor(workingDir: string, opts?: Partial<CodexProcessOptions>) {
+    super()
+    this.workingDir = workingDir
+    this.sessionId = opts?.sessionId || randomUUID()
+    this.threadId = opts?.codexThreadId || null
+    this.model = opts?.model
+    this.extraEnv = opts?.extraEnv || {}
+    this.permissionMode = opts?.permissionMode
+  }
+
+  /** Spawn `codex app-server` and run the initialize → thread/start handshake. */
+  start(): void {
+    if (this.proc) return
+
+    if (!existsSync(this.workingDir)) {
+      this.emit('error', `Working directory does not exist: ${this.workingDir}`)
+      this.emit('exit', 1, null)
+      return
+    }
+
+    this.alive = true
+    this.proc = spawn(CODEX_BINARY, ['app-server'], {
+      cwd: this.workingDir,
+      env: buildEnv(this.extraEnv),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+
+    this.proc.on('error', (err: NodeJS.ErrnoException) => {
+      this._spawnFailed = true
+      this.alive = false
+      const hint = err.code === 'ENOENT'
+        ? 'Codex CLI not found — install it with: npm install -g @openai/codex'
+        : `Failed to start Codex CLI: ${err.message}`
+      this.emit('error', hint)
+      this.cleanupTimers()
+      this.emit('exit', 1, null)
+    })
+
+    this.proc.stderr?.on('data', (chunk: Buffer) => {
+      this.stderrTail = (this.stderrTail + chunk.toString()).slice(-2000)
+    })
+
+    this.rl = createInterface({ input: this.proc.stdout! })
+    this.rl.on('line', (line) => { this.handleLine(line) })
+
+    this.proc.on('close', (code, signal) => {
+      const wasAlive = this.alive
+      this.alive = false
+      this.ready = false
+      this.cleanupTimers()
+      // Settle outstanding RPC promises so initialize()/sendMessage() don't hang
+      for (const [, req] of this.pending) {
+        if (req.timer) clearTimeout(req.timer)
+        req.reject(new Error(`Codex app-server exited before responding to ${req.method}`))
+      }
+      this.pending.clear()
+      if (wasAlive && this.turnActive) {
+        this.turnActive = false
+        this.emit('result', 'Codex exited unexpectedly mid-turn', true)
+      }
+      this.emit('exit', code, signal as string | null)
+    })
+
+    // Startup timeout — if the handshake never completes, surface an error.
+    this.startupTimer = setTimeout(() => {
+      this.startupTimer = null
+      if (this.alive && !this.ready) {
+        this.emit('error', `Codex process failed to initialize within 60 seconds${this.stderrTail ? ` — stderr: ${this.stderrTail.slice(-300)}` : ''}`)
+        this.stop()
+      }
+    }, 60_000)
+
+    void this.initialize().catch((err: Error) => {
+      if (!this.alive) return
+      const msg = err.message || String(err)
+      if (/unauthorized|not.*logged.*in|auth/i.test(msg)) {
+        this._authFailed = true
+        this.emit('error', 'Codex is not authenticated. Run `codex login` (or `codex login --device-auth`) on the host.')
+      } else {
+        this.emit('error', `Codex initialization failed: ${msg}`)
+      }
+      this.stop()
+    })
+  }
+
+  private async initialize(): Promise<void> {
+    await this.request('initialize', {
+      clientInfo: { name: 'codekin', title: 'Codekin', version: '1.0.0' },
+      capabilities: null,
+    })
+    this.notify('initialized')
+
+    const { approvalPolicy, sandbox } = policyForMode(this.permissionMode)
+    const params: Record<string, unknown> = {
+      cwd: this.workingDir,
+      approvalPolicy,
+      sandbox,
+      ...(this.model ? { model: this.model } : {}),
+    }
+    const res = this.threadId
+      ? await this.request('thread/resume', { threadId: this.threadId, ...params })
+      : await this.request('thread/start', params)
+
+    const data = res as { thread?: { id?: string }; model?: string }
+    if (data.thread?.id) this.threadId = data.thread.id
+
+    if (this.startupTimer) {
+      clearTimeout(this.startupTimer)
+      this.startupTimer = null
+    }
+    this.ready = true
+    this.emit('system_init', this.model || data.model || 'codex')
+
+    // Flush any messages queued while the handshake was in flight
+    const queued = this.queuedMessages
+    this.queuedMessages = []
+    for (const content of queued) this.dispatchTurn(content)
+  }
+
+  // -------------------------------------------------------------------------
+  // JSON-RPC plumbing
+  // -------------------------------------------------------------------------
+
+  private write(msg: Record<string, unknown>): void {
+    if (!this.proc?.stdin?.writable) return
+    try {
+      this.proc.stdin.write(JSON.stringify(msg) + '\n')
+    } catch (err) {
+      this.emit('error', `Failed to write to Codex: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+
+  /** Send a client→server request. timeoutMs=0 disables the timeout (long-running turns). */
+  private request(method: string, params?: Record<string, unknown>, timeoutMs: number = RPC_TIMEOUT_MS): Promise<unknown> {
+    const id = this.nextRpcId++
+    return new Promise((resolve, reject) => {
+      const timer = timeoutMs > 0
+        ? setTimeout(() => {
+            this.pending.delete(id)
+            reject(new Error(`Codex request ${method} timed out after ${timeoutMs / 1000}s`))
+          }, timeoutMs)
+        : null
+      this.pending.set(id, { resolve, reject, method, timer })
+      this.write({ id, method, ...(params !== undefined ? { params } : {}) })
+    })
+  }
+
+  private notify(method: string, params?: Record<string, unknown>): void {
+    this.write({ method, ...(params !== undefined ? { params } : {}) })
+  }
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim()
+    if (!trimmed) return
+    let msg: CodexRpcMessage
+    try {
+      msg = JSON.parse(trimmed) as CodexRpcMessage
+    } catch {
+      // Codex may print non-JSON banners on stdout — skip them.
+      return
+    }
+    this._receivedOutput = true
+
+    if (msg.id !== undefined && msg.method) {
+      // Server-initiated request (approval ask)
+      this.handleServerRequest(msg.id, msg.method, msg.params ?? {})
+      return
+    }
+    if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
+      const req = this.pending.get(msg.id as number)
+      if (!req) return
+      this.pending.delete(msg.id as number)
+      if (req.timer) clearTimeout(req.timer)
+      if (msg.error) req.reject(new Error(msg.error.message || `Codex ${req.method} failed`))
+      else req.resolve(msg.result)
+      return
+    }
+    if (msg.method) {
+      this.handleNotification(msg.method, msg.params ?? {})
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Server-initiated approval requests
+  // -------------------------------------------------------------------------
+
+  private handleServerRequest(rpcId: number | string, method: string, params: Record<string, unknown>): void {
+    const autoApprove = this.permissionMode === 'bypassPermissions' || this.permissionMode === 'dangerouslySkipPermissions'
+
+    switch (method) {
+      case 'item/commandExecution/requestApproval': {
+        if (autoApprove) {
+          this.write({ id: rpcId, result: { decision: 'accept' } })
+          return
+        }
+        const requestId = `${APPROVAL_ID_PREFIX}${rpcId}`
+        this.serverApprovals.set(requestId, { rpcId, method })
+        const input: Record<string, unknown> = {
+          command: params.command,
+          ...(params.cwd ? { cwd: params.cwd } : {}),
+          ...(params.reason ? { reason: params.reason } : {}),
+        }
+        this.emit('control_request', requestId, 'Bash', input)
+        return
+      }
+
+      case 'item/fileChange/requestApproval': {
+        if (autoApprove || this.permissionMode === 'acceptEdits') {
+          this.write({ id: rpcId, result: { decision: 'accept' } })
+          return
+        }
+        const requestId = `${APPROVAL_ID_PREFIX}${rpcId}`
+        this.serverApprovals.set(requestId, { rpcId, method })
+        const input: Record<string, unknown> = {
+          ...(params.reason ? { reason: params.reason } : {}),
+          ...(params.grantRoot ? { grantRoot: params.grantRoot } : {}),
+        }
+        this.emit('control_request', requestId, 'Edit', input)
+        return
+      }
+
+      default:
+        // Unsupported server request (permissions profiles, tool user input,
+        // MCP elicitation, …). Respond with a JSON-RPC error so the turn does
+        // not hang waiting for an answer we cannot provide.
+        console.warn(`[codex] Unsupported server request: ${method} — declining`)
+        this.write({ id: rpcId, error: { code: -32601, message: `Codekin does not support ${method}` } })
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Notification → ClaudeProcessEvents mapping
+  // -------------------------------------------------------------------------
+
+  private handleNotification(method: string, params: Record<string, unknown>): void {
+    switch (method) {
+      case 'thread/started': {
+        const thread = params.thread as { id?: string } | undefined
+        if (thread?.id) this.threadId = thread.id
+        break
+      }
+
+      case 'turn/started': {
+        const turn = params.turn as { id?: string } | undefined
+        this.currentTurnId = turn?.id ?? null
+        this.turnActive = true
+        break
+      }
+
+      case 'item/agentMessage/delta': {
+        const delta = params.delta as string | undefined
+        if (delta) {
+          this.receivedDeltas = true
+          this.emit('text', delta)
+        }
+        break
+      }
+
+      case 'item/reasoning/summaryTextDelta': {
+        const delta = params.delta as string | undefined
+        const itemId = params.itemId as string | undefined
+        if (!delta) break
+        // New reasoning item → allow a fresh thinking summary
+        if (itemId && itemId !== this.lastReasoningItemId) {
+          this.lastReasoningItemId = itemId
+          this.reasoningBuffer = ''
+          this.emittedReasoningSummary = false
+        }
+        this.reasoningBuffer += delta
+        if (this.reasoningBuffer.length > 20 && !this.emittedReasoningSummary) {
+          this.emittedReasoningSummary = true
+          this.emit('thinking', this.summarizeReasoning(this.reasoningBuffer))
+        }
+        break
+      }
+
+      case 'item/started': {
+        const item = params.item as CodexThreadItem | undefined
+        if (item) this.handleItemStarted(item)
+        break
+      }
+
+      case 'item/completed': {
+        const item = params.item as CodexThreadItem | undefined
+        if (item) this.handleItemCompleted(item)
+        break
+      }
+
+      case 'turn/plan/updated': {
+        const plan = params.plan as Array<{ step: string; status: string }> | undefined
+        if (!Array.isArray(plan)) break
+        const tasks: TaskItem[] = plan.map((p, i) => ({
+          id: String(i + 1),
+          subject: p.step,
+          status: p.status === 'inProgress' ? 'in_progress' : p.status === 'completed' ? 'completed' : 'pending',
+        }))
+        this.emit('todo_update', tasks)
+        break
+      }
+
+      case 'turn/completed': {
+        const turn = params.turn as { status?: string; error?: { message?: string } | null } | undefined
+        this.turnActive = false
+        this.currentTurnId = null
+        if (turn?.status === 'failed') {
+          this.emit('result', turn.error?.message || 'Codex turn failed', true)
+        } else {
+          this.emit('result', '', false)
+        }
+        // Start the next queued turn, if any
+        const next = this.queuedMessages.shift()
+        if (next !== undefined) this.dispatchTurn(next)
+        break
+      }
+
+      case 'error': {
+        const error = params.error as { message?: string; codexErrorInfo?: unknown } | undefined
+        const willRetry = params.willRetry === true
+        const message = error?.message || 'Unknown Codex error'
+        if (error?.codexErrorInfo === 'usageLimitExceeded') {
+          this.emit('rate_limit', { ...params })
+          this.emit('error', message)
+        } else if (error?.codexErrorInfo === 'unauthorized') {
+          this._authFailed = true
+          this.emit('error', 'Codex is not authenticated. Run `codex login` on the host.')
+        } else if (!willRetry) {
+          this.emit('error', message)
+        } else {
+          console.warn(`[codex] Transient error (will retry): ${message}`)
+        }
+        break
+      }
+
+      case 'account/rateLimits/updated': {
+        this.emit('rate_limit', { ...params })
+        break
+      }
+
+      default:
+        // Many notifications (token usage, diffs, raw items, …) need no mapping.
+        break
+    }
+  }
+
+  private handleItemStarted(item: CodexThreadItem): void {
+    switch (item.type) {
+      case 'commandExecution':
+        this.emit('tool_active', 'Bash', item.command ? summarizeToolInput('Bash', { command: item.command }) : undefined)
+        break
+      case 'fileChange': {
+        const paths = (item.changes ?? []).map(c => c.path).join(', ')
+        this.emit('tool_active', 'Edit', paths || undefined)
+        break
+      }
+      case 'mcpToolCall':
+        this.emit('tool_active', item.tool || 'MCP', item.server)
+        break
+      case 'webSearch':
+        this.emit('tool_active', 'WebSearch', item.query)
+        break
+    }
+  }
+
+  private handleItemCompleted(item: CodexThreadItem): void {
+    switch (item.type) {
+      case 'agentMessage':
+        // Text normally arrives via deltas; emit the full text only when no
+        // deltas were received this turn (e.g. non-streaming model/config).
+        if (item.text && !this.receivedDeltas) {
+          this.emit('text', item.text)
+        }
+        break
+
+      case 'reasoning': {
+        // Fallback: emit a thinking summary when no summary deltas streamed.
+        const summary = (item.summary ?? []).join(' ').trim()
+        if (summary && !this.emittedReasoningSummary) {
+          this.emittedReasoningSummary = true
+          this.emit('thinking', this.summarizeReasoning(summary))
+        }
+        break
+      }
+
+      case 'commandExecution': {
+        const failed = item.status === 'failed' || (item.exitCode != null && item.exitCode !== 0)
+        const declined = item.status === 'declined'
+        const output = item.aggregatedOutput || ''
+        const summary = declined ? 'Declined' : output ? output.slice(0, 200) : undefined
+        this.emit('tool_done', 'Bash', summary)
+        if (output) {
+          const truncated = output.length > 2000
+            ? output.slice(0, 2000) + `\n… (truncated, ${output.length} chars total)`
+            : output
+          this.emit('tool_output', truncated, failed)
+        }
+        break
+      }
+
+      case 'fileChange': {
+        const declined = item.status === 'declined'
+        const failed = item.status === 'failed'
+        const paths = (item.changes ?? []).map(c => c.path).join(', ')
+        const summary = declined ? 'Declined' : failed ? `Failed: ${paths}` : paths || undefined
+        this.emit('tool_done', 'Edit', summary)
+        break
+      }
+
+      case 'mcpToolCall':
+        this.emit('tool_done', item.tool || 'MCP', item.status === 'failed' ? 'Error' : undefined)
+        break
+
+      case 'webSearch':
+        this.emit('tool_done', 'WebSearch', item.query)
+        break
+    }
+  }
+
+  /** Extract a short first-sentence summary from reasoning text (mirrors OpenCodeProcess). */
+  private summarizeReasoning(text: string): string {
+    const match = text.match(/^(.+?[.!?\n])/)
+    return match && match[1].length <= 120
+      ? match[1].replace(/\n/g, ' ').trim()
+      : text.slice(0, 80).trim()
+  }
+
+  // -------------------------------------------------------------------------
+  // CodingProcess interface
+  // -------------------------------------------------------------------------
+
+  /** Send a user message — starts a new turn (or queues it if one is active). */
+  sendMessage(content: string): void {
+    if (!this.alive) {
+      this.emit('error', 'Codex process is not running')
+      return
+    }
+    if (!this.ready || this.turnActive) {
+      this.queuedMessages.push(content)
+      return
+    }
+    this.dispatchTurn(content)
+  }
+
+  private dispatchTurn(content: string): void {
+    if (!this.threadId) {
+      this.queuedMessages.unshift(content)
+      return
+    }
+    // Reset per-turn streaming state
+    this.turnActive = true
+    this.receivedDeltas = false
+    this.reasoningBuffer = ''
+    this.emittedReasoningSummary = false
+    this.lastReasoningItemId = null
+
+    const input = this.buildInput(content)
+    // No timeout: turn/start's response arrives when the turn is created, but
+    // be safe against servers that respond late in long turns.
+    this.request('turn/start', { threadId: this.threadId, input }, 0).catch((err: Error) => {
+      if (!this.alive) return
+      this.turnActive = false
+      this.emit('error', `Failed to start Codex turn: ${err.message}`)
+      this.emit('result', err.message, true)
+    })
+  }
+
+  /**
+   * Build the turn input parts. Parses the frontend's
+   * `[Attached files: …]` prefix and converts images to localImage parts
+   * (Codex reads them from disk — no base64 upload needed).
+   */
+  private buildInput(content: string): Array<Record<string, unknown>> {
+    const parts: Array<Record<string, unknown>> = []
+    let textContent = content
+    const attachMatch = content.match(/^\[Attached files: ([^\]]+)\]\n?/)
+    if (attachMatch) {
+      textContent = content.slice(attachMatch[0].length)
+      const imageExts = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp'])
+      for (const filePath of attachMatch[1].split(',').map(p => p.trim())) {
+        if (!existsSync(filePath)) {
+          console.warn(`[codex] Attached file not found: ${filePath}`)
+          continue
+        }
+        if (imageExts.has(extname(filePath).toLowerCase())) {
+          parts.push({ type: 'localImage', path: filePath })
+        } else {
+          // Codex has no generic file part — reference the path in text so the
+          // agent can read it with its own tools.
+          textContent = `[Attached file: ${filePath}]\n${textContent}`
+        }
+      }
+    }
+    if (textContent.trim()) {
+      parts.push({ type: 'text', text: textContent, text_elements: [] })
+    }
+    return parts
+  }
+
+  /** No-op for Codex — raw protocol data is Claude-specific. */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  sendRaw(_: string): void {
+    // Codex uses JSON-RPC requests, not raw stdin passthrough
+  }
+
+  /**
+   * Respond to an approval request. Maps Codekin's allow/deny to Codex's
+   * accept/decline decision on the original server-initiated JSON-RPC request.
+   */
+  sendControlResponse(requestId: string, behavior: 'allow' | 'deny'): void {
+    const approval = this.serverApprovals.get(requestId)
+    if (!approval) {
+      console.warn(`[codex] No pending approval for request ${requestId}`)
+      return
+    }
+    this.serverApprovals.delete(requestId)
+    this.write({ id: approval.rpcId, result: { decision: behavior === 'allow' ? 'accept' : 'decline' } })
+  }
+
+  /** Interrupt any active turn, then terminate the app-server child. */
+  stop(): void {
+    if (!this.alive && !this.proc) return
+    this.alive = false
+    this.ready = false
+    this.cleanupTimers()
+
+    if (this.turnActive && this.threadId && this.currentTurnId && this.proc?.stdin?.writable) {
+      // Best-effort interrupt — don't wait for the response.
+      this.write({ id: this.nextRpcId++, method: 'turn/interrupt', params: { threadId: this.threadId, turnId: this.currentTurnId } })
+    }
+
+    if (this.proc && this.proc.exitCode === null && !this.proc.killed) {
+      this.proc.kill('SIGTERM')
+      this.killTimer = setTimeout(() => {
+        this.killTimer = null
+        // killed=true only means SIGTERM was sent — check exitCode to see if
+        // the process actually terminated before escalating to SIGKILL.
+        if (this.proc && this.proc.exitCode === null) this.proc.kill('SIGKILL')
+      }, 5_000)
+    }
+  }
+
+  private cleanupTimers(): void {
+    if (this.startupTimer) {
+      clearTimeout(this.startupTimer)
+      this.startupTimer = null
+    }
+    if (this.killTimer) {
+      clearTimeout(this.killTimer)
+      this.killTimer = null
+    }
+  }
+
+  isAlive(): boolean {
+    return this.alive
+  }
+
+  isReady(): boolean {
+    return this.alive && this.ready && this.threadId !== null
+  }
+
+  getSessionId(): string {
+    return this.threadId ?? this.sessionId
+  }
+
+  waitForExit(timeoutMs = 10000): Promise<void> {
+    if (!this.alive && !this.proc) return Promise.resolve()
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(resolve, timeoutMs)
+      this.once('exit', () => {
+        clearTimeout(timer)
+        resolve()
+      })
+    })
+  }
+
+  // -------------------------------------------------------------------------
+  // Restart-scheduler diagnostics (duck-typed by session-lifecycle.ts)
+  // -------------------------------------------------------------------------
+
+  /**
+   * True when the exit is non-retryable without operator action. For Codex
+   * that means an auth failure — restarting cannot help until `codex login`
+   * is run on the host. (Named for parity with ClaudeProcess's duck-typed
+   * diagnostic; the restart scheduler treats it as "do not auto-restart".)
+   */
+  hasSessionConflict(): boolean {
+    return this._authFailed
+  }
+
+  /** True if the process produced at least one valid JSON message before exiting. */
+  hadOutput(): boolean {
+    return this._receivedOutput
+  }
+
+  /** True if spawn() itself failed (ENOENT, EACCES) — process never started. */
+  hasSpawnFailed(): boolean {
+    return this._spawnFailed
+  }
+}

--- a/server/coding-process.test.ts
+++ b/server/coding-process.test.ts
@@ -1,14 +1,15 @@
 /** Tests for the CodingProcess abstraction layer and provider dispatch. */
 import { describe, it, expect } from 'vitest'
-import { CLAUDE_CAPABILITIES, OPENCODE_CAPABILITIES } from './coding-process.js'
+import { CLAUDE_CAPABILITIES, OPENCODE_CAPABILITIES, CODEX_CAPABILITIES } from './coding-process.js'
 import type { CodingProvider } from './coding-process.js'
 
 describe('CodingProvider type', () => {
-  it('accepts claude and opencode as valid values', () => {
-    const providers: CodingProvider[] = ['claude', 'opencode']
-    expect(providers).toHaveLength(2)
+  it('accepts claude, opencode, and codex as valid values', () => {
+    const providers: CodingProvider[] = ['claude', 'opencode', 'codex']
+    expect(providers).toHaveLength(3)
     expect(providers).toContain('claude')
     expect(providers).toContain('opencode')
+    expect(providers).toContain('codex')
   })
 })
 
@@ -37,8 +38,21 @@ describe('ProviderCapabilities', () => {
     })
   })
 
-  it('Claude is single-provider, OpenCode is multi-provider', () => {
+  it('CODEX_CAPABILITIES has expected defaults', () => {
+    expect(CODEX_CAPABILITIES).toEqual({
+      streaming: true,
+      multiTurn: true,
+      permissionControl: true,
+      toolEvents: true,
+      thinkingDisplay: true,
+      multiProvider: false,
+      planMode: false,
+    })
+  })
+
+  it('Claude and Codex are single-provider, OpenCode is multi-provider', () => {
     expect(CLAUDE_CAPABILITIES.multiProvider).toBe(false)
+    expect(CODEX_CAPABILITIES.multiProvider).toBe(false)
     expect(OPENCODE_CAPABILITIES.multiProvider).toBe(true)
   })
 })

--- a/server/coding-process.ts
+++ b/server/coding-process.ts
@@ -17,8 +17,9 @@ import type { ClaudeProcessEvents } from './claude-process.js'
  * Supported AI coding assistant providers.
  * - 'claude': Claude Code CLI (subprocess, NDJSON on stdin/stdout)
  * - 'opencode': OpenCode server (HTTP REST + SSE)
+ * - 'codex': OpenAI Codex CLI (subprocess, `codex app-server` JSON-RPC on stdin/stdout)
  */
-export type CodingProvider = 'claude' | 'opencode'
+export type CodingProvider = 'claude' | 'opencode' | 'codex'
 
 /**
  * Capabilities that differ between providers. SessionManager and frontend
@@ -112,4 +113,15 @@ export const OPENCODE_CAPABILITIES: ProviderCapabilities = {
   thinkingDisplay: true,
   multiProvider: true,
   planMode: true,
+}
+
+/** Default capabilities for the OpenAI Codex CLI provider. */
+export const CODEX_CAPABILITIES: ProviderCapabilities = {
+  streaming: true,
+  multiTurn: true,
+  permissionControl: true,
+  toolEvents: true,
+  thinkingDisplay: true,
+  multiProvider: false,
+  planMode: false,
 }

--- a/server/provider-dispatch.test.ts
+++ b/server/provider-dispatch.test.ts
@@ -108,6 +108,11 @@ describe('Provider dispatch', () => {
       expect(session.provider).toBe('opencode')
     })
 
+    it('creates sessions with codex provider', () => {
+      const session = sm.create('Test session', '/tmp/repo', { provider: 'codex' })
+      expect(session.provider).toBe('codex')
+    })
+
     it('preserves provider alongside other options', () => {
       const session = sm.create('Test session', '/tmp/repo', {
         provider: 'opencode',

--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -12,6 +12,7 @@ import { existsSync } from 'fs'
 import path from 'path'
 import { ClaudeProcess } from './claude-process.js'
 import { OpenCodeProcess } from './opencode-process.js'
+import { CodexProcess } from './codex-process.js'
 import type { CodingProcess } from './coding-process.js'
 import { ApprovalManager } from './approval-manager.js'
 import type { PromptRouter } from './prompt-router.js'
@@ -153,6 +154,14 @@ export class SessionLifecycle {
       cp = new OpenCodeProcess(session.workingDir, {
         sessionId: sessionId,
         opencodeSessionId: session.claudeSessionId || undefined,
+        model: session.model,
+        extraEnv,
+        permissionMode: session.permissionMode,
+      })
+    } else if (session.provider === 'codex') {
+      cp = new CodexProcess(session.workingDir, {
+        sessionId: sessionId,
+        codexThreadId: session.claudeSessionId || undefined,
         model: session.model,
         extraEnv,
         permissionMode: session.permissionMode,

--- a/server/session-routes.ts
+++ b/server/session-routes.ts
@@ -23,6 +23,7 @@ import { VALID_PROVIDERS, VALID_PERMISSION_MODES } from './types.js'
 import type { CodingProvider } from './coding-process.js'
 import type { PermissionMode } from './types.js'
 import { fetchOpenCodeModels } from './opencode-process.js'
+import { fetchCodexModels } from './codex-process.js'
 
 // ---------------------------------------------------------------------------
 // Request body interfaces for route handlers
@@ -151,6 +152,13 @@ export function createSessionRouter(
     if (!verifyToken(token)) return res.status(401).json({ error: 'Unauthorized' })
     const models = await fetchAnthropicModels()
     res.json({ models })
+  })
+
+  router.get('/api/codex/models', async (req, res) => {
+    const token = extractToken(req)
+    if (!verifyToken(token)) return res.status(401).json({ error: 'Unauthorized' })
+    const result = await fetchCodexModels()
+    res.json(result)
   })
 
   router.get('/api/opencode/models', async (req, res) => {

--- a/server/types.ts
+++ b/server/types.ts
@@ -18,7 +18,7 @@ import type { ProcessCoordinator } from './process-coordinator.js'
 export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'bypassPermissions' | 'dangerouslySkipPermissions'
 
 /** Allow-list for server-side validation of client-supplied provider names. */
-export const VALID_PROVIDERS = new Set<CodingProvider>(['claude', 'opencode'])
+export const VALID_PROVIDERS = new Set<CodingProvider>(['claude', 'opencode', 'codex'])
 
 export const VALID_PERMISSION_MODES = new Set<PermissionMode>(['default', 'acceptEdits', 'plan', 'bypassPermissions', 'dangerouslySkipPermissions'])
 
@@ -270,7 +270,7 @@ export interface TaskItem {
 
 /** Messages sent from the server to browser clients over WebSocket. */
 export type WsServerMessage =
-  | { type: 'connected'; connectionId: string; claudeAvailable: boolean; claudeVersion: string; apiKeySet: boolean }
+  | { type: 'connected'; connectionId: string; claudeAvailable: boolean; claudeVersion: string; apiKeySet: boolean; codexAvailable?: boolean; codexAuthenticated?: boolean }
   | { type: 'session_created'; sessionId: string; sessionName: string; workingDir: string }
   | { type: 'session_joined'; sessionId: string; sessionName: string; workingDir: string; active: boolean; outputBuffer: WsServerMessage[]; model?: string; permissionMode?: PermissionMode }
   | { type: 'session_left' }

--- a/server/workflow-config.ts
+++ b/server/workflow-config.ts
@@ -24,8 +24,8 @@ export interface ReviewRepoConfig {
   customPrompt?: string
   /** Claude model to use for this workflow (e.g. 'claude-sonnet-4-6'). Omit for system default. */
   model?: string
-  /** AI provider to use for this workflow ('claude' or 'opencode'). Defaults to 'claude'. */
-  provider?: 'claude' | 'opencode'
+  /** AI provider to use for this workflow ('claude', 'opencode', or 'codex'). Defaults to 'claude'. */
+  provider?: 'claude' | 'opencode' | 'codex'
 }
 
 export interface WorkflowConfig {

--- a/server/workflow-loader.ts
+++ b/server/workflow-loader.ts
@@ -307,7 +307,7 @@ function registerWorkflow(engine: WorkflowEngine, sessions: SessionManager, def:
           const repoName = (input.repoName as string) || repoPath.split('/').pop() || 'unknown'
 
           const model = (input.model as string | undefined) || def.model
-          const provider = (input.provider as 'claude' | 'opencode' | undefined)
+          const provider = (input.provider as 'claude' | 'opencode' | 'codex' | undefined)
           const session = sessions.create(`${def.sessionPrefix}:${repoName}`, repoPath, {
             source: 'workflow',
             groupDir: repoPath,

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -17,6 +17,7 @@ import { createServer } from 'http'
 import { WebSocketServer, WebSocket } from 'ws'
 import { readFileSync, existsSync } from 'fs'
 import { join } from 'path'
+import { homedir } from 'os'
 import { execFileSync } from 'child_process'
 import { createHash, randomUUID, timingSafeEqual } from 'crypto'
 import { verifySessionToken } from './crypto-utils.js'
@@ -140,6 +141,24 @@ if (claudeAvailable && !apiKeyEnvSet) {
 
 if (!apiKeySet) {
   console.warn('No API key or subscription auth detected (ANTHROPIC_API_KEY, CLAUDE_CODE_API_KEY, or Claude subscription)')
+}
+
+// Detect the OpenAI Codex CLI and its auth state. Codex authenticates via
+// `codex login` (ChatGPT subscription OAuth) which writes ~/.codex/auth.json;
+// the app-server reuses it with automatic token refresh.
+let codexAvailable = false
+let codexAuthenticated = false
+try {
+  const codexVersion = execFileSync(process.env.CODEX_BINARY || 'codex', ['--version'], { timeout: 5000 }).toString().trim()
+  codexAvailable = true
+  console.log(`Codex CLI found: ${codexVersion}`)
+  const codexHome = process.env.CODEX_HOME || join(homedir(), '.codex')
+  codexAuthenticated = existsSync(join(codexHome, 'auth.json')) || !!process.env.OPENAI_API_KEY
+  if (!codexAuthenticated) {
+    console.warn('Codex CLI found but not authenticated — run `codex login` on this host to enable it')
+  }
+} catch {
+  // Codex CLI not installed — provider stays hidden in the UI
 }
 
 // ---------------------------------------------------------------------------
@@ -510,7 +529,7 @@ wss.on('connection', (ws: WebSocket, req) => {
       }
       authenticated = true
       clearTimeout(authTimeout)
-      send({ type: 'connected', connectionId, claudeAvailable, claudeVersion, apiKeySet })
+      send({ type: 'connected', connectionId, claudeAvailable, claudeVersion, apiKeySet, codexAvailable, codexAuthenticated })
 
       // Notify client if a newer version is available
       void getUpdateNotification().then(text => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { useSendMessage } from './hooks/useSendMessage'
 import { useErrorNotification } from './hooks/useErrorNotification'
 import { useGlobalKeyBindings } from './hooks/useGlobalKeyBindings'
 import { useOpenCodeModelSync } from './hooks/useOpenCodeModelSync'
+import { useCodexModelSync } from './hooks/useCodexModelSync'
 import { useProviderValidation } from './hooks/useProviderValidation'
 import { buildSlashCommandList } from './lib/slashCommands'
 import { deriveActivityLabel } from './lib/deriveActivityLabel'
@@ -199,6 +200,7 @@ export default function App() {
   )
   const [claudeDisabled, setClaudeDisabled] = useState(false)
   const [openCodeDisabled, setOpenCodeDisabled] = useState(false)
+  const [codexDisabled, setCodexDisabled] = useState(false)
   // Derive the active session's provider (falls back to the default for new sessions)
   const activeSessionProvider = sessions.find(s => s.id === activeSessionId)?.provider ?? currentProvider
 
@@ -214,12 +216,21 @@ export default function App() {
     setModel,
     openCodeDisabled,
   })
+  const { codexModels, codexConnected, setCodexConnected, reconnect: reconnectCodex } = useCodexModelSync({
+    token: settings.token,
+    activeSessionProvider,
+    currentModel,
+    setModel,
+    codexDisabled,
+  })
   const { claudeModels } = useClaudeModelSync({
     token: settings.token,
     currentModel,
     setModel,
   })
-  const availableModels = activeSessionProvider === 'opencode' ? openCodeModels : claudeModels
+  const availableModels = activeSessionProvider === 'opencode' ? openCodeModels
+    : activeSessionProvider === 'codex' ? codexModels
+    : claudeModels
 
   // Reset file-change tracking when switching sessions
   useEffect(() => {
@@ -273,6 +284,8 @@ export default function App() {
     setModel(model)
     if (activeSessionProvider === 'opencode') {
       localStorage.setItem('opencode-model', model)
+    } else if (activeSessionProvider === 'codex') {
+      localStorage.setItem('codex-model', model)
     }
   }, [setModel, activeSessionProvider])
 
@@ -496,6 +509,20 @@ export default function App() {
     }
   }, [openCodeDisabled, activeSessionProvider, activeSessionId, leaveSession, reconnectOpenCode, setOpenCodeConnected])
 
+  const handleToggleCodex = useCallback(() => {
+    if (codexDisabled) {
+      setCodexDisabled(false)
+      reconnectCodex()
+    } else {
+      setCodexDisabled(true)
+      setCodexConnected(false)
+      // Leave the current session if it's a Codex session
+      if (activeSessionProvider === 'codex' && activeSessionId) {
+        leaveSession()
+      }
+    }
+  }, [codexDisabled, activeSessionProvider, activeSessionId, leaveSession, reconnectCodex, setCodexConnected])
+
   const activeSession = sessions.find(s => s.id === activeSessionId)
   const activeSessionName = activeSession?.name ?? null
   const activeRepoName = activeRepo?.name ?? activeWorkingDir?.split('/').pop() ?? null
@@ -526,6 +553,9 @@ export default function App() {
         openCodeDisabled={openCodeDisabled}
         onToggleClaude={handleToggleClaude}
         onToggleOpenCode={handleToggleOpenCode}
+        codexConnected={codexConnected}
+        codexDisabled={codexDisabled}
+        onToggleCodex={handleToggleCodex}
         view={view}
         archiveRefreshKey={archiveRefreshKey}
         onSelectSession={(id) => { docsBrowser.close(); if (view === 'orchestrator') navigate(`/s/${id}`); handleSelectSession(id) }}
@@ -697,7 +727,8 @@ export default function App() {
             moveToWorktree={moveToWorktree}
             worktreePath={activeSession?.worktreePath}
             openCodeConnected={activeSessionProvider === 'opencode' ? (openCodeDisabled ? false : openCodeConnected) : null}
-            claudeDisabled={activeSessionProvider !== 'opencode' && claudeDisabled}
+            codexConnected={activeSessionProvider === 'codex' ? (codexDisabled ? false : codexConnected) : null}
+            claudeDisabled={activeSessionProvider === 'claude' && claudeDisabled}
           />
         ) : (
           <RepoSelector groups={groups} token={settings.token} ghMissing={ghMissing} onOpen={handleOpenSession} onRefreshRepos={refreshRepos} />

--- a/src/components/ConnectionPopup.tsx
+++ b/src/components/ConnectionPopup.tsx
@@ -1,5 +1,5 @@
 /**
- * ConnectionPopup — shows status of Claude Code and OpenCode connections
+ * ConnectionPopup — shows status of Claude Code, OpenCode, and Codex connections
  * with toggle buttons to temporarily disable/enable each.
  */
 
@@ -19,6 +19,12 @@ interface Props {
   openCodeDisabled: boolean
   /** Toggle OpenCode connection on/off. */
   onToggleOpenCode: () => void
+  /** Codex connection state: true=connected, false=disconnected, null=unknown/not configured. */
+  codexConnected: boolean | null
+  /** Whether Codex connection is disabled by the user. */
+  codexDisabled: boolean
+  /** Toggle Codex connection on/off. */
+  onToggleCodex: () => void
   /** Close the popup. */
   onClose: () => void
 }
@@ -34,6 +40,9 @@ export function ConnectionPopup({
   openCodeConnected,
   openCodeDisabled,
   onToggleOpenCode,
+  codexConnected,
+  codexDisabled,
+  onToggleCodex,
   onClose,
 }: Props) {
   const ref = useRef<HTMLDivElement>(null)
@@ -59,6 +68,13 @@ export function ConnectionPopup({
   const ocLabel = openCodeDisabled
     ? 'Disabled'
     : openCodeConnected === true ? 'Connected' : openCodeConnected === false ? 'Disconnected' : 'Not configured'
+
+  const codexDotColor = codexDisabled
+    ? 'bg-neutral-6'
+    : codexConnected === true ? 'bg-success-7' : codexConnected === false ? 'bg-error-7' : 'bg-neutral-6'
+  const codexLabel = codexDisabled
+    ? 'Disabled'
+    : codexConnected === true ? 'Connected' : codexConnected === false ? 'Run `codex login` on the host' : 'Not configured'
 
   return (
     <div
@@ -104,6 +120,25 @@ export function ConnectionPopup({
           }`}
         >
           {openCodeDisabled ? 'Enable' : 'Disable'}
+        </button>
+      </div>
+
+      {/* Codex */}
+      <div className="px-3 py-2.5 flex items-center gap-2 border-t border-neutral-8/20">
+        <StatusDot color={codexDotColor} />
+        <div className="flex-1 min-w-0">
+          <div className="text-[13px] text-neutral-2 font-medium">Codex</div>
+          <div className="text-[11px] text-neutral-5">{codexLabel}</div>
+        </div>
+        <button
+          onClick={onToggleCodex}
+          className={`text-[11px] px-2 py-0.5 rounded border transition-colors ${
+            codexDisabled
+              ? 'border-success-8/50 text-success-5 hover:bg-success-9/20'
+              : 'border-neutral-8/50 text-neutral-4 hover:bg-neutral-8/30'
+          }`}
+        >
+          {codexDisabled ? 'Enable' : 'Disable'}
         </button>
       </div>
     </div>

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -103,6 +103,12 @@ interface Props {
   onToggleClaude: () => void
   /** Toggle OpenCode connection on/off. */
   onToggleOpenCode: () => void
+  /** Codex connection state: true=connected, false=disconnected, null=unknown. */
+  codexConnected: boolean | null
+  /** Whether Codex connection is disabled by the user. */
+  codexDisabled: boolean
+  /** Toggle Codex connection on/off. */
+  onToggleCodex: () => void
   /** Current route view ('chat' | 'workflows'). */
   view: string
   /** Agent display name for the orchestrator button. */
@@ -166,6 +172,9 @@ export function LeftSidebar({
   openCodeDisabled,
   onToggleClaude,
   onToggleOpenCode,
+  codexConnected,
+  codexDisabled,
+  onToggleCodex,
   view,
   archiveRefreshKey,
   onSelectSession,
@@ -308,6 +317,9 @@ export function LeftSidebar({
                 openCodeConnected={openCodeConnected}
                 openCodeDisabled={openCodeDisabled}
                 onToggleOpenCode={onToggleOpenCode}
+                codexConnected={codexConnected}
+                codexDisabled={codexDisabled}
+                onToggleCodex={onToggleCodex}
                 onClose={() => setConnPopupOpen(false)}
               />
             )}
@@ -495,6 +507,9 @@ export function LeftSidebar({
                 openCodeConnected={openCodeConnected}
                 openCodeDisabled={openCodeDisabled}
                 onToggleOpenCode={onToggleOpenCode}
+                codexConnected={codexConnected}
+                codexDisabled={codexDisabled}
+                onToggleCodex={onToggleCodex}
                 onClose={() => setConnPopupOpen(false)}
               />
             )}

--- a/src/components/RepoSection.tsx
+++ b/src/components/RepoSection.tsx
@@ -291,6 +291,14 @@ export function RepoSection({
                         OC
                       </span>
                     )}
+                    {s.provider === 'codex' && (
+                      <span
+                        title="Codex session"
+                        className="text-[10px] px-1 py-0 rounded bg-neutral-7 text-neutral-4 font-medium leading-tight"
+                      >
+                        CX
+                      </span>
+                    )}
                     {sessionDisplayName(s)}
                   </span>
                 )}
@@ -332,6 +340,13 @@ export function RepoSection({
               >
                 <IconPlus size={12} stroke={2} className="flex-shrink-0" />
                 <span>OpenCode</span>
+              </button>
+              <button
+                onClick={() => onNewSession('codex')}
+                className="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-[13px] text-neutral-5 hover:text-neutral-2 hover:bg-neutral-6/50 transition-colors"
+              >
+                <IconPlus size={12} stroke={2} className="flex-shrink-0" />
+                <span>Codex</span>
               </button>
             </div>
           )}

--- a/src/components/SessionContent.tsx
+++ b/src/components/SessionContent.tsx
@@ -58,6 +58,8 @@ export interface SessionContentProps {
   worktreePath: string | undefined
   /** null = not an OpenCode session, true = connected, false = not connected */
   openCodeConnected: boolean | null
+  /** null = not a Codex session, true = connected, false = not connected */
+  codexConnected: boolean | null
   /** Whether Claude Code connection has been disabled by the user. */
   claudeDisabled?: boolean
 }
@@ -101,10 +103,12 @@ export function SessionContent({
   moveToWorktree,
   worktreePath,
   openCodeConnected,
+  codexConnected,
   claudeDisabled,
 }: SessionContentProps) {
   const isOpenCodeDisconnected = openCodeConnected === false
-  const isProviderDisabled = claudeDisabled || isOpenCodeDisconnected
+  const isCodexDisconnected = codexConnected === false
+  const isProviderDisabled = claudeDisabled || isOpenCodeDisconnected || isCodexDisconnected
   return (
     <div className="flex flex-1 flex-col overflow-hidden min-h-0">
       <div className="relative flex-1 min-h-0 flex flex-col">
@@ -139,6 +143,19 @@ export function SessionContent({
                 Install OpenCode to use this session. Visit{' '}
                 <a href="https://opencode.ai" target="_blank" rel="noopener noreferrer" className="text-primary-5 hover:underline">opencode.ai</a>
                 {' '}and run <code className="bg-neutral-10 px-1.5 py-0.5 rounded text-[12px]">opencode serve</code> to start the server.
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* Codex not connected banner */}
+        {isCodexDisconnected && !claudeDisabled && (
+          <div className="absolute inset-0 flex items-center justify-center z-10 bg-neutral-12/90">
+            <div className="flex flex-col items-center gap-3 text-center px-6 max-w-md">
+              <div className="text-[15px] font-medium text-neutral-3">Codex is not connected</div>
+              <p className="text-[13px] text-neutral-5 leading-relaxed">
+                Install the Codex CLI with <code className="bg-neutral-10 px-1.5 py-0.5 rounded text-[12px]">npm i -g @openai/codex</code>
+                {' '}and authenticate by running <code className="bg-neutral-10 px-1.5 py-0.5 rounded text-[12px]">codex login</code> on the host.
               </p>
             </div>
           </div>
@@ -194,7 +211,7 @@ export function SessionContent({
         onSendInput={onSendInput}
         isWaiting={!!activePrompt}
         disabled={disabled || isProviderDisabled}
-        placeholder={claudeDisabled ? 'Claude Code is disabled' : isOpenCodeDisconnected ? 'OpenCode is not connected' : undefined}
+        placeholder={claudeDisabled ? 'Claude Code is disabled' : isOpenCodeDisconnected ? 'OpenCode is not connected' : isCodexDisconnected ? 'Codex is not connected' : undefined}
         onEscape={() => {}}
         pendingFiles={pendingFiles}
         onAddFiles={onAddFiles}

--- a/src/components/workflows/ProviderModelSection.tsx
+++ b/src/components/workflows/ProviderModelSection.tsx
@@ -1,13 +1,13 @@
 /**
  * Combined provider selector + model picker for workflow modals.
  *
- * Fetches OpenCode models on mount to determine availability.
- * Shows provider toggle only when OpenCode is available.
+ * Fetches OpenCode and Codex models on mount to determine availability.
+ * Shows provider toggle only when an alternative provider is available.
  * Delegates model rendering to WorkflowModelPicker.
  */
 
 import { useState, useEffect } from 'react'
-import { fetchClaudeModels, fetchOpenCodeModels } from '../../lib/ccApi'
+import { fetchClaudeModels, fetchOpenCodeModels, fetchCodexModels } from '../../lib/ccApi'
 import { MODEL_OPTIONS } from '../../lib/workflowHelpers'
 import type { ModelOption, CodingProvider } from '../../types'
 import { WorkflowModelPicker } from './WorkflowModelPicker'
@@ -38,8 +38,11 @@ interface Props {
 export function ProviderModelSection({ token, workingDir, provider, model, onProviderChange, onModelChange }: Props) {
   const [openCodeAvailable, setOpenCodeAvailable] = useState<boolean | null>(null)
   const [openCodeModels, setOpenCodeModels] = useState<ModelOption[]>([])
+  const [codexAvailable, setCodexAvailable] = useState<boolean | null>(null)
+  const [codexModels, setCodexModels] = useState<ModelOption[]>([])
   const [claudeWorkflowModels, setClaudeWorkflowModels] = useState(FALLBACK_WORKFLOW_MODELS)
   const [loadingOcModels, setLoadingOcModels] = useState(true)
+  const [loadingCodexModels, setLoadingCodexModels] = useState(true)
 
   // Fetch Claude models dynamically on mount
   useEffect(() => {
@@ -74,22 +77,45 @@ export function ProviderModelSection({ token, workingDir, provider, model, onPro
     return () => { cancelled = true }
   }, [token, workingDir])
 
+  // Check Codex availability on mount
+  useEffect(() => {
+    let cancelled = false
+    fetchCodexModels(token).then(result => {
+      if (cancelled) return
+      if (result.models.length > 0) {
+        setCodexAvailable(true)
+        setCodexModels(result.models.map(m => ({ id: m.id, label: m.name || m.id })))
+      } else {
+        setCodexAvailable(false)
+      }
+    }).catch(() => {
+      if (!cancelled) setCodexAvailable(false)
+    }).finally(() => {
+      if (!cancelled) setLoadingCodexModels(false)
+    })
+    return () => { cancelled = true }
+  }, [token])
+
   // When switching provider, select a sensible default for the new provider
   const handleProviderChange = (newProvider: CodingProvider) => {
     if (newProvider === provider) return
     onProviderChange(newProvider)
     // Pick the first model from the new provider's list ('' = Default Opus for Claude)
-    const newModels = newProvider === 'opencode' ? openCodeModels : claudeWorkflowModels
+    const newModels = newProvider === 'opencode' ? openCodeModels
+      : newProvider === 'codex' ? codexModels
+      : claudeWorkflowModels
     onModelChange(newModels[0]?.id ?? '')
   }
 
-  const currentModels: ModelOption[] = provider === 'opencode' ? openCodeModels : claudeWorkflowModels
-  const isLoadingModels = provider === 'opencode' && loadingOcModels
+  const currentModels: ModelOption[] = provider === 'opencode' ? openCodeModels
+    : provider === 'codex' ? codexModels
+    : claudeWorkflowModels
+  const isLoadingModels = (provider === 'opencode' && loadingOcModels) || (provider === 'codex' && loadingCodexModels)
 
   return (
     <div className="flex flex-wrap items-end gap-4">
-      {/* Provider selector — only show when OpenCode is available */}
-      {openCodeAvailable && (
+      {/* Provider selector — only show when an alternative provider is available */}
+      {(openCodeAvailable || codexAvailable) && (
         <div>
           <label className="block text-[13px] font-medium text-neutral-3 mb-1">Provider</label>
           <div className="flex gap-1">
@@ -100,13 +126,24 @@ export function ProviderModelSection({ token, workingDir, provider, model, onPro
             >
               Claude Code
             </button>
-            <button
-              type="button"
-              onClick={() => handleProviderChange('opencode')}
-              className={providerBtnClass(provider === 'opencode')}
-            >
-              OpenCode
-            </button>
+            {openCodeAvailable && (
+              <button
+                type="button"
+                onClick={() => handleProviderChange('opencode')}
+                className={providerBtnClass(provider === 'opencode')}
+              >
+                OpenCode
+              </button>
+            )}
+            {codexAvailable && (
+              <button
+                type="button"
+                onClick={() => handleProviderChange('codex')}
+                className={providerBtnClass(provider === 'codex')}
+              >
+                Codex
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/src/hooks/useCodexModelSync.ts
+++ b/src/hooks/useCodexModelSync.ts
@@ -1,0 +1,80 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { fetchCodexModels } from '../lib/ccApi'
+import type { ModelOption, CodingProvider } from '../types'
+
+interface UseCodexModelSyncOptions {
+  token: string
+  activeSessionProvider: CodingProvider
+  currentModel: string | null
+  setModel: (model: string) => void
+  codexDisabled: boolean
+}
+
+/**
+ * Manages Codex model list and connectivity state.
+ * - Probes Codex availability on startup.
+ * - Fetches models when switching to a Codex session.
+ * - Auto-selects an appropriate default model when current selection is invalid.
+ */
+export function useCodexModelSync({
+  token,
+  activeSessionProvider,
+  currentModel,
+  setModel,
+  codexDisabled,
+}: UseCodexModelSyncOptions) {
+  const [codexModels, setCodexModels] = useState<ModelOption[]>([])
+  const [codexConnected, setCodexConnected] = useState<boolean | null>(null)
+  const currentModelRef = useRef(currentModel)
+  useEffect(() => { currentModelRef.current = currentModel }, [currentModel])
+
+  // Probe Codex availability on startup
+  useEffect(() => {
+    if (!token || codexDisabled) return
+    fetchCodexModels(token).then(result => {
+      setCodexConnected(result.models.length > 0)
+    }).catch(() => { setCodexConnected(false) })
+  }, [token, codexDisabled])
+
+  // Fetch models when switching to a Codex session
+  useEffect(() => {
+    if (activeSessionProvider !== 'codex' || !token) return
+    const currentIsValidCodex = currentModelRef.current && codexModels.some(m => m.id === currentModelRef.current)
+    if (codexModels.length > 0 && currentIsValidCodex) return
+    fetchCodexModels(token).then(result => {
+      const models: ModelOption[] = result.models.map(m => ({
+        id: m.id,
+        label: m.name,
+      }))
+      setCodexModels(models)
+      setCodexConnected(models.length > 0)
+      const currentIsCodex = currentModelRef.current && models.some(m => m.id === currentModelRef.current)
+      if (!currentIsCodex) {
+        const savedModel = localStorage.getItem('codex-model')
+        const savedIsValid = savedModel && models.some(m => m.id === savedModel)
+        if (savedIsValid) {
+          setModel(savedModel)
+        } else {
+          const defaultModel = result.models.find(m => m.isDefault)
+          if (defaultModel) setModel(defaultModel.id)
+          else if (models.length > 0) setModel(models[0].id)
+        }
+      }
+    }).catch(() => { setCodexConnected(false) })
+  }, [activeSessionProvider, token, codexModels.length, setModel])
+
+  /** Re-fetch models to check connection (used when re-enabling Codex). */
+  const reconnect = useCallback(() => {
+    if (!token) return
+    fetchCodexModels(token).then(result => {
+      const models: ModelOption[] = result.models.map(m => ({
+        id: m.id,
+        label: m.name,
+      }))
+      setCodexModels(models)
+      setCodexConnected(models.length > 0)
+    }).catch(() => { setCodexConnected(false) })
+  }, [token])
+
+  return { codexModels, codexConnected, setCodexConnected, reconnect }
+}

--- a/src/lib/ccApi.ts
+++ b/src/lib/ccApi.ts
@@ -482,6 +482,21 @@ export async function fetchOpenCodeModels(
   }>(res)
 }
 
+/** Fetch available models from the Codex CLI (via short-lived app-server). */
+export async function fetchCodexModels(
+  token: string,
+): Promise<{
+  models: Array<{ id: string; name: string; description?: string; isDefault?: boolean }>
+}> {
+  const res = await fetch(`${BASE}/api/codex/models`, {
+    headers: { Authorization: `Bearer ${token}` },
+  })
+  if (!res.ok) return { models: [] }
+  return jsonBody<{
+    models: Array<{ id: string; name: string; description?: string; isDefault?: boolean }>
+  }>(res)
+}
+
 /** Fetch available Claude models from the Anthropic API (via server proxy). */
 export async function fetchClaudeModels(
   token: string,

--- a/src/lib/workflowApi.ts
+++ b/src/lib/workflowApi.ts
@@ -72,8 +72,8 @@ export interface ReviewRepoConfig {
   kind?: string
   customPrompt?: string
   model?: string
-  /** AI provider to use for this workflow ('claude' or 'opencode'). Defaults to 'claude'. */
-  provider?: 'claude' | 'opencode'
+  /** AI provider to use for this workflow ('claude', 'opencode', or 'codex'). Defaults to 'claude'. */
+  provider?: 'claude' | 'opencode' | 'codex'
 }
 
 export interface WorkflowConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,17 +48,27 @@ export type PermissionMode = 'default' | 'acceptEdits' | 'plan' | 'bypassPermiss
  * Supported AI coding assistant providers.
  * - 'claude': Claude Code CLI (subprocess, NDJSON on stdin/stdout)
  * - 'opencode': OpenCode server (HTTP REST + SSE)
+ * - 'codex': OpenAI Codex CLI (subprocess, `codex app-server` JSON-RPC on stdin/stdout)
  */
-export type CodingProvider = 'claude' | 'opencode'
+export type CodingProvider = 'claude' | 'opencode' | 'codex'
 
 /** Provider metadata for the UI selector. */
 export const PROVIDERS: { id: CodingProvider; label: string; description: string }[] = [
   { id: 'claude', label: 'Claude Code', description: 'Anthropic Claude Code CLI' },
   { id: 'opencode', label: 'OpenCode', description: 'OpenCode server (multi-provider)' },
+  { id: 'codex', label: 'Codex', description: 'OpenAI Codex CLI (ChatGPT subscription)' },
 ]
 
 /** Model option for UI selectors. */
 export interface ModelOption { id: string; label: string }
+
+/** Static models for the OpenAI Codex CLI. Used as fallback before dynamic discovery completes. */
+export const CODEX_MODELS: ModelOption[] = [
+  { id: 'gpt-5.5', label: 'GPT-5.5' },
+  { id: 'gpt-5.4', label: 'GPT-5.4' },
+  { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+  { id: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
+]
 
 /** Static models for Claude Code CLI. Used as fallback before dynamic discovery completes. */
 export const CLAUDE_MODELS: ModelOption[] = [
@@ -161,7 +171,7 @@ export interface TaskItem {
  * `webhook_event` and `workflow_event` are broadcast to all clients, not session-scoped.
  */
 export type WsServerMessage =
-  | { type: 'connected'; connectionId: string; claudeAvailable: boolean; claudeVersion: string; apiKeySet: boolean }
+  | { type: 'connected'; connectionId: string; claudeAvailable: boolean; claudeVersion: string; apiKeySet: boolean; codexAvailable?: boolean; codexAuthenticated?: boolean }
   | { type: 'session_created'; sessionId: string; sessionName: string; workingDir: string }
   | { type: 'session_joined'; sessionId: string; sessionName: string; workingDir: string; active: boolean; outputBuffer: WsServerMessage[]; model?: string; permissionMode?: PermissionMode }
   | { type: 'session_left' }


### PR DESCRIPTION
## Summary
- Integrates `codex app-server` (JSON-RPC 2.0 over stdio) behind the existing `CodingProcess` interface, making Codex a third provider alongside Claude Code and OpenCode — unlocking ChatGPT-subscription-gated OpenAI models for interactive sessions and workflows
- New `CodexProcess` adapter: initialize → thread/start handshake, streaming event mapping to `ClaudeProcessEvents` (text deltas, thinking summaries, tool events, plan → todos), command/file-change approval round-trips, thread resume across restarts, permission-mode → approvalPolicy/sandbox mapping, and non-retryable auth-failure detection
- Model discovery via a short-lived app-server (`model/list`, 10-min cache) exposed at `GET /api/codex/models`; startup detection of the `codex` binary and `~/.codex/auth.json` surfaced in the `connected` WS message
- Frontend: Codex session button in the repo tree (`CX` badge), workflow provider toggle + model picker, `useCodexModelSync` hook, ConnectionPopup row, and a not-connected banner with `codex login` guidance
- 54 new tests covering the adapter against a mocked app-server (handshake, every event-mapping row, approval allow/deny, ENOENT, mid-turn crash, usage-limit → rate_limit, auth failure)

## Notes
- Wire schema verified against codex-cli 0.139.0 via `codex app-server generate-ts`
- Auth v1 is host pre-auth: run `codex login` on the server; no in-UI OAuth flow
- Unsupported server-initiated requests get a JSON-RPC `-32601` error response so turns never hang

## Test plan
- [x] `npm run build` (typecheck + production build)
- [x] `npm test` — 2214/2214 passing (89 files)
- [x] `npm run lint` — 0 errors
- [ ] Manual e2e on a host with `codex login`: create a Codex session, verify streaming, approval allow/deny, multi-turn, backend restart → thread resume
- [ ] Run a workflow with `provider: codex`
- [ ] UI states: codex not installed / installed-but-unauthenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)