### PR TITLE
feat: OpenCode resilience — hydration, restart recovery, queueing, diff fix, version check

### DIFF
--- a/server/opencode-process.test.ts
+++ b/server/opencode-process.test.ts
@@ -26,7 +26,10 @@ vi.mock('child_process', async (importOriginal) => {
   }
 })
 
-import { OpenCodeProcess, stopOpenCodeServer, permissionRulesetFor, OPENCODE_SYSTEM_CONTEXT } from './opencode-process.js'
+import { OpenCodeProcess, stopOpenCodeServer, permissionRulesetFor, OPENCODE_SYSTEM_CONTEXT, isVersionOlder, MIN_TESTED_OPENCODE_VERSION } from './opencode-process.js'
+import { writeFileSync, mkdtempSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import { OPENCODE_CAPABILITIES } from './coding-process.js'
 
 describe('OpenCodeProcess', () => {
@@ -1355,6 +1358,264 @@ describe('OpenCodeProcess', () => {
       })
 
       expect(resultHandler).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Resume hydration (missed history tail)
+  // ---------------------------------------------------------------------------
+
+  describe('resume hydration', () => {
+    const makeResumed = (recentOutputText: string) => {
+      const proc = new OpenCodeProcess('/tmp/test-repo', {
+        sessionId: 'resume-session',
+        opencodeSessionId: 'oc-session-1',
+        recentOutputText,
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(proc as any).alive = true
+      return proc
+    }
+
+    const historyResponse = (entries: unknown[]) => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => entries })
+    }
+
+    it('re-emits a completed assistant message lost while detached', async () => {
+      const proc = makeResumed('Earlier output that was shown.')
+      const textHandler = vi.fn()
+      proc.on('text', textHandler)
+
+      historyResponse([
+        { info: { role: 'user', time: { created: 1 } } },
+        {
+          info: { role: 'assistant', time: { created: 2, completed: 3 } },
+          parts: [{ type: 'text', text: 'Answer generated during the crash' }],
+        },
+      ])
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (proc as any).hydrateMissedTail('http://localhost:1234')
+
+      expect(textHandler).toHaveBeenCalledWith('Answer generated during the crash')
+      proc.stop()
+    })
+
+    it('does not re-emit text that was already displayed', async () => {
+      const proc = makeResumed('intro... The final answer is 42. ...outro')
+      const textHandler = vi.fn()
+      proc.on('text', textHandler)
+
+      historyResponse([
+        {
+          info: { role: 'assistant', time: { completed: 3 } },
+          parts: [{ type: 'text', text: 'The final answer is 42.' }],
+        },
+      ])
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (proc as any).hydrateMissedTail('http://localhost:1234')
+
+      expect(textHandler).not.toHaveBeenCalled()
+      proc.stop()
+    })
+
+    it('does not hydrate when the last entry is a user message', async () => {
+      const proc = makeResumed('')
+      const textHandler = vi.fn()
+      proc.on('text', textHandler)
+
+      historyResponse([
+        {
+          info: { role: 'assistant', time: { completed: 2 } },
+          parts: [{ type: 'text', text: 'Old answer' }],
+        },
+        { info: { role: 'user', time: { created: 3 } } },
+      ])
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (proc as any).hydrateMissedTail('http://localhost:1234')
+
+      expect(textHandler).not.toHaveBeenCalled()
+      proc.stop()
+    })
+
+    it('does not hydrate an incomplete (in-flight) assistant message', async () => {
+      const proc = makeResumed('')
+      const textHandler = vi.fn()
+      proc.on('text', textHandler)
+
+      historyResponse([
+        {
+          info: { role: 'assistant', time: { created: 2 } },
+          parts: [{ type: 'text', text: 'Still streaming...' }],
+        },
+      ])
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (proc as any).hydrateMissedTail('http://localhost:1234')
+
+      expect(textHandler).not.toHaveBeenCalled()
+      proc.stop()
+    })
+
+    it('survives a failed history fetch', async () => {
+      const proc = makeResumed('')
+      const textHandler = vi.fn()
+      proc.on('text', textHandler)
+      mockFetch.mockRejectedValueOnce(new Error('connection refused'))
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await expect((proc as any).hydrateMissedTail('http://localhost:1234')).resolves.toBeUndefined()
+      expect(textHandler).not.toHaveBeenCalled()
+      proc.stop()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Mid-turn message queueing
+  // ---------------------------------------------------------------------------
+
+  describe('mid-turn message queueing', () => {
+    const connect = (proc: OpenCodeProcess) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(proc as any).alive = true
+      setSessionId(proc, 'oc-session-1')
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) })
+    }
+
+    const promptCalls = () =>
+      mockFetch.mock.calls.filter(([url]) => typeof url === 'string' && url.includes('/prompt_async'))
+
+    it('queues a message sent while a turn is in flight', () => {
+      connect(ocp)
+      ocp.sendMessage('first')
+      ocp.sendMessage('second')
+
+      expect(promptCalls()).toHaveLength(1)
+      const body = JSON.parse((promptCalls()[0][1] as { body: string }).body) as { parts: Array<{ text: string }> }
+      expect(body.parts[0].text).toBe('first')
+    })
+
+    it('sends the queued message when the turn completes', async () => {
+      connect(ocp)
+      ocp.sendMessage('first')
+      ocp.sendMessage('second')
+
+      callHandleSSE(ocp, {
+        type: 'session.idle',
+        properties: { sessionID: 'oc-session-1' },
+      })
+      // Queued send is deferred via setImmediate
+      await new Promise((r) => setImmediate(r))
+
+      expect(promptCalls()).toHaveLength(2)
+      const body = JSON.parse((promptCalls()[1][1] as { body: string }).body) as { parts: Array<{ text: string }> }
+      expect(body.parts[0].text).toBe('second')
+    })
+
+    it('preserves queue order across multiple turns', async () => {
+      connect(ocp)
+      ocp.sendMessage('first')
+      ocp.sendMessage('second')
+      ocp.sendMessage('third')
+
+      callHandleSSE(ocp, { type: 'session.idle', properties: { sessionID: 'oc-session-1' } })
+      await new Promise((r) => setImmediate(r))
+      callHandleSSE(ocp, { type: 'session.idle', properties: { sessionID: 'oc-session-1' } })
+      await new Promise((r) => setImmediate(r))
+
+      const texts = promptCalls().map(([, init]) =>
+        (JSON.parse((init as { body: string }).body) as { parts: Array<{ text: string }> }).parts[0].text)
+      expect(texts).toEqual(['first', 'second', 'third'])
+    })
+
+    it('drops queued messages on stop', async () => {
+      connect(ocp)
+      ocp.sendMessage('first')
+      ocp.sendMessage('second')
+
+      ocp.stop()
+      await new Promise((r) => setImmediate(r))
+
+      expect(promptCalls()).toHaveLength(1)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Version comparison
+  // ---------------------------------------------------------------------------
+
+  describe('isVersionOlder', () => {
+    it('compares major/minor/patch numerically', () => {
+      expect(isVersionOlder('1.14.9', '1.15.0')).toBe(true)
+      expect(isVersionOlder('1.15.0', '1.15.0')).toBe(false)
+      expect(isVersionOlder('1.16.0', '1.15.0')).toBe(false)
+      expect(isVersionOlder('0.9.9', '1.0.0')).toBe(true)
+      expect(isVersionOlder('1.15', '1.15.0')).toBe(false)
+      expect(isVersionOlder('2.0.0', MIN_TESTED_OPENCODE_VERSION)).toBe(false)
+    })
+
+    it('treats unparseable versions as not older', () => {
+      expect(isVersionOlder('dev', '1.15.0')).toBe(false)
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // Attachments
+  // ---------------------------------------------------------------------------
+
+  describe('attachments', () => {
+    let dir: string
+
+    beforeEach(() => {
+      dir = mkdtempSync(join(tmpdir(), 'codekin-attach-'))
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ;(ocp as any).alive = true
+      setSessionId(ocp, 'oc-session-1')
+      mockFetch.mockResolvedValue({ ok: true, json: async () => ({}) })
+    })
+
+    afterEach(() => {
+      rmSync(dir, { recursive: true, force: true })
+    })
+
+    const sentParts = () => {
+      const [, init] = mockFetch.mock.calls[mockFetch.mock.calls.length - 1] as [string, { body: string }]
+      return (JSON.parse(init.body) as { parts: Array<Record<string, unknown>> }).parts
+    }
+
+    it('sends PDFs as data-URL file parts', () => {
+      const pdfPath = join(dir, 'doc.pdf')
+      writeFileSync(pdfPath, Buffer.from('%PDF-1.4 fake'))
+
+      ocp.sendMessage(`[Attached files: ${pdfPath}]\nsummarize this`)
+
+      const filePart = sentParts().find((p) => p.type === 'file')
+      expect(filePart).toBeDefined()
+      expect(filePart!.mime).toBe('application/pdf')
+      expect(String(filePart!.url)).toMatch(/^data:application\/pdf;base64,/)
+    })
+
+    it('inlines unknown text-like files (no extension allowlist)', () => {
+      const tsPath = join(dir, 'snippet.tsx')
+      writeFileSync(tsPath, 'export const x = 1\n')
+
+      ocp.sendMessage(`[Attached files: ${tsPath}]\nreview`)
+
+      const textParts = sentParts().filter((p) => p.type === 'text')
+      expect(textParts.some((p) => String(p.text).includes('--- snippet.tsx ---') && String(p.text).includes('export const x = 1'))).toBe(true)
+    })
+
+    it('skips binary files with a visible note', () => {
+      const binPath = join(dir, 'blob.bin')
+      writeFileSync(binPath, Buffer.from([0x7f, 0x45, 0x4c, 0x46, 0x00, 0x01, 0x02]))
+
+      ocp.sendMessage(`[Attached files: ${binPath}]\nwhat is this`)
+
+      const parts = sentParts()
+      expect(parts.some((p) => p.type === 'file')).toBe(false)
+      expect(parts.some((p) => p.type === 'text' && String(p.text).includes('unsupported binary format'))).toBe(true)
     })
   })
 })

--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -203,6 +203,9 @@ async function startOpenCodeServer(workingDir: string): Promise<void> {
       if (res.ok) {
         serverState.ready = true
         console.log(`[opencode-server] Ready on port ${serverState.port}`)
+        // One-shot version check — warns when the server is older than the
+        // version this integration was built against. Non-fatal.
+        void checkServerVersion(baseUrl)
         return
       }
     } catch {
@@ -216,6 +219,49 @@ async function startOpenCodeServer(workingDir: string): Promise<void> {
     serverState.process = null
   }
   throw new Error(`OpenCode server failed to start within ${maxAttempts}s`)
+}
+
+/** Minimum OpenCode version this integration is tested against. */
+export const MIN_TESTED_OPENCODE_VERSION = '1.15.0'
+
+/** Returns true when version `a` is older than version `b` (semver-ish numeric compare). */
+export function isVersionOlder(a: string, b: string): boolean {
+  const pa = a.split('.').map(Number)
+  const pb = b.split('.').map(Number)
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] ?? 0
+    const y = pb[i] ?? 0
+    if (Number.isNaN(x) || Number.isNaN(y)) return false
+    if (x !== y) return x < y
+  }
+  return false
+}
+
+/**
+ * Query the server's version (GET /global/health) and warn when it's older
+ * than the version this integration was built against. Older servers may
+ * lack endpoints we rely on (summarize, abort, permission replies).
+ */
+async function checkServerVersion(baseUrl: string): Promise<void> {
+  try {
+    const res = await fetch(`${baseUrl}/global/health`, {
+      headers: authHeaders(),
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!res.ok) return
+    const data = await res.json() as { version?: string }
+    if (typeof data.version !== 'string') return
+    if (isVersionOlder(data.version, MIN_TESTED_OPENCODE_VERSION)) {
+      console.warn(
+        `[opencode-server] Server version ${data.version} is older than the tested version ${MIN_TESTED_OPENCODE_VERSION} — ` +
+        'some features (compact, abort, native permissions) may not work. Consider upgrading OpenCode.'
+      )
+    } else {
+      console.log(`[opencode-server] Version ${data.version}`)
+    }
+  } catch {
+    // Older servers may not expose /global/health — nothing to report.
+  }
 }
 
 /** Build auth headers for OpenCode API calls. */
@@ -319,6 +365,12 @@ export interface OpenCodeProcessOptions {
   extraEnv?: Record<string, string>
   /** Permission mode — mapped to OpenCode's permission config. */
   permissionMode?: PermissionMode
+  /**
+   * Recent assistant output already shown to the user (concatenated text from
+   * the session's output history). Used on resume to avoid re-emitting an
+   * assistant message that was already displayed when hydrating missed history.
+   */
+  recentOutputText?: string
 }
 
 // ---------------------------------------------------------------------------
@@ -354,6 +406,10 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   private usageByMessage = new Map<string, { input: number; output: number; cost: number }>()
   /** Last emitted usage totals, serialized — suppresses duplicate usage events. */
   private lastEmittedUsage = ''
+  /** Messages received while a turn was in flight — sent when the turn completes. */
+  private pendingMessages: string[] = []
+  /** Recent already-displayed assistant text (from output history) for resume hydration dedup. */
+  private recentOutputText = ''
   private taskSeq = 0
   /**
    * Watchdog that detects turns stalled by a missed completion event.
@@ -395,6 +451,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     this.opencodeSessionId = opts?.opencodeSessionId || null
     this.model = opts?.model
     this.permissionMode = opts?.permissionMode
+    this.recentOutputText = opts?.recentOutputText ?? ''
   }
 
   /** Connect to the OpenCode server, create a session, and subscribe to SSE events. */
@@ -448,6 +505,9 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
           console.warn('[opencode] Failed to update session permissions:', err)
         }
       }
+      // Hydrate any assistant response that completed while we were detached
+      // (backend crash/restart mid-turn) — non-fatal on failure.
+      void this.hydrateMissedTail(baseUrl)
     } else {
       const createRes = await fetch(`${baseUrl}/session`, {
         method: 'POST',
@@ -522,16 +582,50 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   }
 
   /** Subscribe to the OpenCode SSE event stream and map events to CodingProcess events. */
-  private subscribeToEvents(baseUrl: string): void {
+  private subscribeToEvents(initialBaseUrl: string): void {
     this.abortController = new AbortController()
     let reconnectDelay = 1000
     const MAX_RECONNECT_DELAY = 30_000
     const MAX_RECONNECT_ATTEMPTS = 20
 
     let reconnectAttempts = 0
+    let firstConnect = true
 
-    const connectSSE = () => {
+    /** Count a failed attempt and schedule a retry. Returns false when retries are exhausted. */
+    const scheduleReconnect = (reason: string): boolean => {
+      reconnectAttempts++
+      if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
+        this.emit('error', `SSE reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts (${reason})`)
+        this.stop()
+        return false
+      }
+      console.warn(`[opencode-sse] ${reason}, reconnecting in ${reconnectDelay / 1000}s (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`)
+      setTimeout(() => { void connectSSE() }, reconnectDelay)
+      reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY)
+      return true
+    }
+
+    const connectSSE = async () => {
       if (!this.alive) return
+
+      // Re-resolve the base URL on every attempt: if the shared OpenCode
+      // server died, it respawns on a NEW random port — reconnecting to the
+      // old URL would never succeed. ensureOpenCodeServer respawns the server
+      // if needed and returns the current URL. The first connect reuses the
+      // URL from initialize() to avoid a redundant health check.
+      let baseUrl = initialBaseUrl
+      if (!firstConnect) {
+        try {
+          baseUrl = await ensureOpenCodeServer(this.workingDir)
+        } catch (err) {
+          if (this.alive) {
+            scheduleReconnect(`Server unavailable (${err instanceof Error ? err.message : String(err)})`)
+          }
+          return
+        }
+        if (!this.alive) return
+      }
+      firstConnect = false
 
       void fetch(`${baseUrl}/event`, {
         headers: {
@@ -543,15 +637,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       }).then(async (res) => {
         if (!res.ok || !res.body) {
           if (this.alive) {
-            reconnectAttempts++
-            if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
-              this.emit('error', `SSE reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts (last status: ${res.status})`)
-              this.stop()
-              return
-            }
-            console.warn(`[opencode-sse] Non-2xx ${res.status}, reconnecting in ${reconnectDelay / 1000}s (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`)
-            setTimeout(connectSSE, reconnectDelay)
-            reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY)
+            scheduleReconnect(`Non-2xx ${res.status}`)
           }
           return
         }
@@ -596,33 +682,17 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
 
         // Clean EOF — reconnect if still alive (server restart, proxy timeout, etc.)
         if (this.alive) {
-          reconnectAttempts++
-          if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
-            this.emit('error', `SSE reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts`)
-            this.stop()
-            return
-          }
-          console.warn(`[opencode-sse] Stream closed cleanly, reconnecting in ${reconnectDelay / 1000}s (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`)
-          setTimeout(connectSSE, reconnectDelay)
-          reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY)
+          scheduleReconnect('Stream closed cleanly')
         }
-      }).catch((err) => {
+      }).catch((err: unknown) => {
         if (err instanceof Error && err.name === 'AbortError') return
         if (this.alive) {
-          reconnectAttempts++
-          if (reconnectAttempts > MAX_RECONNECT_ATTEMPTS) {
-            this.emit('error', `SSE reconnect failed after ${MAX_RECONNECT_ATTEMPTS} attempts`)
-            this.stop()
-            return
-          }
-          console.warn(`[opencode-sse] Connection lost, reconnecting in ${reconnectDelay / 1000}s (attempt ${reconnectAttempts}/${MAX_RECONNECT_ATTEMPTS})...`, err)
-          setTimeout(connectSSE, reconnectDelay)
-          reconnectDelay = Math.min(reconnectDelay * 2, MAX_RECONNECT_DELAY)
+          scheduleReconnect(`Connection lost (${err instanceof Error ? err.message : String(err)})`)
         }
       })
     }
 
-    connectSSE()
+    void connectSSE()
   }
 
   /**
@@ -666,6 +736,11 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     this.clearTurnWatchdog()
     this.flushDeltaBuffer()
     this.emit('result', '', false)
+    // Send the next queued message (received mid-turn) after result handlers run.
+    const next = this.pendingMessages.shift()
+    if (next !== undefined && this.alive) {
+      setImmediate(() => { this.sendMessage(next) })
+    }
   }
 
   /** Map an OpenCode SSE event to CodingProcess events. */
@@ -1106,6 +1181,48 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   }
 
   /**
+   * On resume, recover the tail of the conversation that may have been lost
+   * while Codekin was detached (backend crash/restart mid-turn). Fetches the
+   * session's message history from OpenCode and re-emits the last assistant
+   * message's text — unless it was already displayed (present in the
+   * persisted output history passed via recentOutputText).
+   */
+  private async hydrateMissedTail(baseUrl: string): Promise<void> {
+    if (!this.opencodeSessionId) return
+    try {
+      const res = await fetch(`${baseUrl}/session/${this.opencodeSessionId}/message`, {
+        headers: {
+          ...authHeaders(),
+          'x-opencode-directory': this.workingDir,
+        },
+        signal: AbortSignal.timeout(10_000),
+      })
+      if (!res.ok) return
+      const messages = await res.json() as Array<Record<string, unknown>>
+      if (!Array.isArray(messages) || messages.length === 0) return
+      const last = messages[messages.length - 1]
+      const info = (last.info ?? last) as { role?: string; time?: { completed?: number }; parts?: OpenCodeMessagePart[] }
+      // Only hydrate a *completed* assistant message that is the latest entry —
+      // an in-flight turn is handled by the watchdog, and a trailing user
+      // message means there's nothing of ours to recover.
+      if (info.role !== 'assistant' || !info.time?.completed) return
+      const parts = (last.parts ?? info.parts) as OpenCodeMessagePart[] | undefined
+      if (!Array.isArray(parts)) return
+      const text = parts
+        .filter((p) => p.type === 'text' && p.text)
+        .map((p) => p.text)
+        .join('\n')
+      if (!text) return
+      // Already shown before the restart — nothing was lost.
+      if (this.recentOutputText.includes(text)) return
+      console.warn(`[opencode] Hydrating ${text.length} chars of missed assistant text on resume for ${this.opencodeSessionId}`)
+      this.emit('text', text)
+    } catch (err) {
+      console.warn(`[opencode] Resume hydration failed for ${this.opencodeSessionId}:`, err)
+    }
+  }
+
+  /**
    * Reply to an OpenCode permission request via HTTP, with retries.
    * A dropped reply leaves OpenCode blocked on the permission forever, so
    * failures are retried and ultimately surfaced as a session error instead
@@ -1202,6 +1319,15 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       return
     }
 
+    // A turn is already running server-side — queue locally and send when it
+    // completes. Sending prompt_async mid-turn would reset our turn latches,
+    // letting the FIRST turn's idle event instantly "complete" the second
+    // turn and confuse the watchdog. (Claude's CLI queues stdin natively.)
+    if (this.turnInFlight && !this.turnComplete) {
+      this.pendingMessages.push(content)
+      return
+    }
+
     this.turnComplete = false // reset completion latch for new turn
     this.turnInFlight = true
     this.receivedDeltas = false
@@ -1223,11 +1349,12 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     if (attachMatch) {
       textContent = content.slice(attachMatch[0].length)
       const filePaths = attachMatch[1].split(',').map(p => p.trim())
-      const imageMimeMap: Record<string, string> = {
+      // Binary formats sent as data-URL file parts (provider handles decoding).
+      const fileMimeMap: Record<string, string> = {
         '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
         '.gif': 'image/gif', '.webp': 'image/webp',
+        '.pdf': 'application/pdf',
       }
-      const textExtensions = new Set(['.md', '.txt', '.csv', '.json', '.xml', '.yaml', '.yml', '.log'])
       for (const filePath of filePaths) {
         if (!existsSync(filePath)) {
           console.warn(`[opencode] Attached file not found: ${filePath}`)
@@ -1241,17 +1368,23 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
           continue
         }
         const ext = extname(filePath).toLowerCase()
-        const imageMime = imageMimeMap[ext]
-        if (imageMime) {
+        const fileMime = fileMimeMap[ext]
+        const fileName = filePath.split('/').pop() || filePath
+        if (fileMime) {
           const base64 = readFileSync(filePath).toString('base64')
-          parts.push({ type: 'file', mime: imageMime, filename: filePath.split('/').pop(), url: `data:${imageMime};base64,${base64}` })
-        } else if (textExtensions.has(ext)) {
-          // Send text-based files as inline text content
-          const fileContent = readFileSync(filePath, 'utf-8')
-          const fileName = filePath.split('/').pop() || filePath
-          parts.push({ type: 'text', text: `--- ${fileName} ---\n${fileContent}` })
+          parts.push({ type: 'file', mime: fileMime, filename: fileName, url: `data:${fileMime};base64,${base64}` })
         } else {
-          console.warn(`[opencode] Unsupported file type for attachment: ${ext} (${filePath})`)
+          // Everything else: inline as text when the content looks like text
+          // (no NUL byte in the first 8 KB) — covers source code, configs,
+          // logs, etc. without maintaining an extension allowlist.
+          const buf = readFileSync(filePath)
+          const probe = buf.subarray(0, 8192)
+          if (probe.includes(0)) {
+            console.warn(`[opencode] Unsupported binary attachment: ${ext || '(no extension)'} (${filePath})`)
+            parts.push({ type: 'text', text: `[Attachment skipped: ${fileName} is an unsupported binary format]` })
+          } else {
+            parts.push({ type: 'text', text: `--- ${fileName} ---\n${buf.toString('utf-8')}` })
+          }
         }
       }
     }
@@ -1378,6 +1511,7 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   stop(): void {
     if (!this.alive) return
     this.alive = false
+    this.pendingMessages = []
     if (this.turnInFlight && this.opencodeSessionId) {
       this.turnInFlight = false
       void fetch(`http://localhost:${serverState.port}/session/${this.opencodeSessionId}/abort`, {

--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -150,12 +150,20 @@ export class SessionLifecycle {
     const mergedAllowedTools = [...new Set([...(session.allowedTools || []), ...registryPatterns])]
     let cp: CodingProcess
     if (session.provider === 'opencode') {
+      // Recent assistant text already shown to the user — lets the resumed
+      // process skip re-emitting messages during missed-history hydration.
+      const recentOutputText = session.outputHistory
+        .filter((m): m is { type: 'output'; data: string } => m.type === 'output')
+        .slice(-100)
+        .map((m) => m.data)
+        .join('')
       cp = new OpenCodeProcess(session.workingDir, {
         sessionId: sessionId,
         opencodeSessionId: session.claudeSessionId || undefined,
         model: session.model,
         extraEnv,
         permissionMode: session.permissionMode,
+        recentOutputText,
       })
     } else {
       cp = new ClaudeProcess(session.workingDir, {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -181,8 +181,10 @@ export default function App() {
         diffHandleMessageRef.current(msg)
       } else if (msg.type === 'tool_done') {
         diffHandleToolDoneRef.current(msg.toolName, msg.summary)
-        // Track file-mutating tools to show Code Review button
-        if (msg.toolName === 'Edit' || msg.toolName === 'Write') {
+        // Track file-mutating tools to show Code Review button.
+        // Case-insensitive: Claude reports 'Edit'/'Write', OpenCode 'edit'/'write'/'patch'.
+        const tool = msg.toolName.toLowerCase()
+        if (tool === 'edit' || tool === 'write' || tool === 'patch') {
           setHasFileChanges(true)
         }
       }

--- a/src/hooks/useDiff.ts
+++ b/src/hooks/useDiff.ts
@@ -89,21 +89,25 @@ export function useDiff({ send, isOpen }: UseDiffOptions) {
   const handleToolDone = useCallback((toolName: string, toolSummary?: string) => {
     if (!isOpenRef.current) return
 
-    // Always refresh for Edit and Write
-    if (toolName === 'Edit' || toolName === 'Write') {
+    // Case-insensitive: Claude reports 'Edit'/'Write'/'Bash', OpenCode
+    // lowercase 'edit'/'write'/'patch'/'bash'.
+    const tool = toolName.toLowerCase()
+
+    // Always refresh for file-mutating tools
+    if (tool === 'edit' || tool === 'write' || tool === 'patch') {
       scheduleRefresh()
       return
     }
 
     // For Bash, skip if summary looks like a read-only command
-    if (toolName === 'Bash' && toolSummary) {
+    if (tool === 'bash' && toolSummary) {
       const trimmed = toolSummary.trim().toLowerCase()
       const isReadOnly = READ_ONLY_PREFIXES.some(prefix => trimmed.startsWith(prefix))
       if (isReadOnly) return
     }
 
     // For Bash without a recognizable read-only prefix, refresh
-    if (toolName === 'Bash') {
+    if (tool === 'bash') {
       scheduleRefresh()
     }
   }, [scheduleRefresh])


### PR DESCRIPTION
## Summary
- **Resume hydration**: on session resume, fetch the last assistant message via `GET /session/:id/message` and re-emit any completed response that was lost while detached (deduped against persisted output history)
- **Server-restart recovery**: SSE reconnect now re-resolves the OpenCode server baseUrl via `ensureOpenCodeServer()`, so a respawned server on a new port/password is found instead of retrying a dead endpoint
- **Mid-turn message queueing**: messages sent while a turn is in flight are queued locally and flushed on idle, preventing `prompt_async` from resetting turn latches mid-turn
- **Diff-panel fix**: file-change detection in `App.tsx`/`useDiff` was case-sensitive (`Edit`/`Write`); OpenCode's lowercase tool names never matched, so the Diff button never appeared for OpenCode sessions — now lowercased and includes `patch`
- **Version check**: at server startup, query `/global/health` and warn if the OpenCode version is older than the minimum tested (`1.15.0`)
- **Broader attachments**: PDFs sent as file parts, arbitrary text files inlined, binaries detected via NUL probe and skipped with a note

## Test plan
- [x] 12 new unit tests: resume hydration (5), mid-turn queueing (4), attachments (3), plus `isVersionOlder` cases
- [x] Full suite passes: 89 files / 2236 tests
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)