### PR TITLE
fix: mock child_process in clone tests to prevent CI timeout

### DIFF
--- a/server/upload-routes.test.ts
+++ b/server/upload-routes.test.ts
@@ -40,6 +40,23 @@ vi.mock('fs', async (importOriginal) => {
   }
 })
 
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>()
+  return {
+    ...actual,
+    execFile: ((...args: unknown[]) => {
+      // Immediately fail gh clone commands so tests don't depend on real gh credentials.
+      const cb = args[args.length - 1]
+      if (typeof cb === 'function') {
+        (cb as (err: Error) => void)(new Error('gh mock: no credentials'))
+        return
+      }
+      // Fallback for non-callback usage (shouldn't happen with promisify)
+      return actual.execFile(...(args as Parameters<typeof actual.execFile>))
+    }) as typeof actual.execFile,
+  }
+})
+
 // Imported after vi.mock so the router picks up the mocked fs.
 import { localRepoPath, createUploadRouter } from './upload-routes.js'
 


### PR DESCRIPTION
## Summary
- The `allows clone when owner dir does not exist` test in `server/upload-routes.test.ts` was invoking the real `gh repo clone` command, which takes >5s to fail in CI without `GH_TOKEN`, causing a 5000ms vitest timeout
- Added a `vi.mock('child_process')` that stubs `execFile` to immediately return an error, so clone boundary-check tests don't depend on real `gh` credentials
- All 2296 tests pass locally

## Test plan
- [x] `npx vitest run server/upload-routes.test.ts` — all 12 tests pass (was 11/12)
- [x] `npx vitest run` — full suite: 2296 passed, 0 failed
- [ ] CI should pass on this branch

Fixes CI run #1233.

🤖 Generated with [Claude Code](https://claude.com/claude-code)