### PR TITLE
fix: reliable todo panel updates + close when work stops

### DIFF
--- a/server/claude-process.test.ts
+++ b/server/claude-process.test.ts
@@ -133,14 +133,16 @@ describe('handleTaskTool', () => {
       expect(cp.tasks.size).toBe(1)
     })
 
-    it('clears existing tasks and resets ID sequence', () => {
+    it('clears existing tasks but keeps the ID sequence monotonic', () => {
       cp.handleTaskTool('TaskCreate', { subject: 'Old task' })
       expect(cp.tasks.size).toBe(1)
       cp.handleTaskTool('TodoWrite', {
         todos: [{ content: 'New', status: 'in_progress' }],
       })
       expect(cp.tasks.size).toBe(1)
-      expect(cp.tasks.get('1')!.subject).toBe('New')
+      // New list gets a fresh id (not reused '1') so the frontend can detect
+      // a replaced list and later TaskCreate/TaskUpdate ids never collide.
+      expect(cp.tasks.get('2')!.subject).toBe('New')
     })
 
     it('returns false for non-array todos', () => {
@@ -182,8 +184,18 @@ describe('handleTaskTool', () => {
       expect(cp.tasks.has('1')).toBe(false)
     })
 
-    it('returns false for nonexistent task', () => {
-      expect(cp.handleTaskTool('TaskUpdate', { taskId: '999', status: 'completed' })).toBe(false)
+    it('upserts a task for an unknown id instead of dropping the update', () => {
+      expect(cp.handleTaskTool('TaskUpdate', { taskId: '999', status: 'completed' })).toBe(true)
+      expect(cp.tasks.get('999')!.status).toBe('completed')
+      expect(cp.tasks.get('999')!.subject).toBe('Task 999')
+    })
+
+    it('returns false for unknown id with deleted status', () => {
+      expect(cp.handleTaskTool('TaskUpdate', { taskId: '999', status: 'deleted' })).toBe(false)
+    })
+
+    it('returns false for missing taskId', () => {
+      expect(cp.handleTaskTool('TaskUpdate', { status: 'completed' })).toBe(false)
     })
 
     it('updates subject and activeForm', () => {
@@ -195,6 +207,23 @@ describe('handleTaskTool', () => {
 
   it('returns false for unknown tool', () => {
     expect(cp.handleTaskTool('UnknownTool', {})).toBe(false)
+  })
+
+  describe('seedTasks', () => {
+    it('restores tasks and continues the id sequence past seeded ids', () => {
+      cp.seedTasks([
+        { id: '3', subject: 'Restored A', status: 'completed' },
+        { id: '4', subject: 'Restored B', status: 'in_progress' },
+      ])
+      expect(cp.tasks.size).toBe(2)
+      // TaskUpdate against a pre-restart id now resolves to the real task
+      cp.handleTaskTool('TaskUpdate', { taskId: '4', status: 'completed' })
+      expect(cp.tasks.get('4')!.status).toBe('completed')
+      expect(cp.tasks.get('4')!.subject).toBe('Restored B')
+      // New TaskCreate ids do not collide with seeded ids
+      cp.handleTaskTool('TaskCreate', { subject: 'Next' })
+      expect(cp.tasks.get('5')!.subject).toBe('Next')
+    })
   })
 })
 

--- a/server/claude-process.ts
+++ b/server/claude-process.ts
@@ -486,7 +486,9 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
       if (isTask && TOOL_DEBUG) console.log('[task-debug] tool:', this.tool.name, 'input:', JSON.stringify(parsed).slice(0, 200))
       if (this.handleTaskTool(this.tool.name!, parsed)) {
         if (TOOL_DEBUG) console.log('[task-debug] emitting todo_update, tasks:', this.tasks.size)
-        this.emit('todo_update', Array.from(this.tasks.values()))
+        // Copy items so later in-place TaskUpdate mutations don't alias into
+        // previously broadcast/history-stored snapshots.
+        this.emit('todo_update', Array.from(this.tasks.values(), t => ({ ...t })))
       }
     } catch (err) {
       console.warn(`[claude] Failed to parse tool input for ${this.tool.name}:`, err instanceof Error ? err.message : err)
@@ -648,14 +650,17 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
    * Returns true if the task list changed (caller should emit todo_update).
    */
   private handleTaskTool(toolName: string, input: Record<string, unknown>): boolean {
-    // TodoWrite sends the entire list at once
+    // TodoWrite sends the entire list at once.
+    // Note: taskSeq is intentionally NOT reset — keeping ids monotonic across
+    // list generations lets the frontend detect a brand-new list by id and
+    // avoids id collisions with later TaskCreate/TaskUpdate calls.
     if (toolName === 'TodoWrite') {
       const todos = input.todos as Array<Record<string, unknown>> | undefined
       if (!Array.isArray(todos)) return false
       this.tasks.clear()
-      this.taskSeq = 0
       for (const item of todos) {
         const id = String(item.id || ++this.taskSeq)
+        this.syncTaskSeq(id)
         const status = item.status as string
         if (status !== 'pending' && status !== 'in_progress' && status !== 'completed') continue
         this.tasks.set(id, {
@@ -669,7 +674,8 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
     }
     // TaskCreate/TaskUpdate are the newer tool names
     if (toolName === 'TaskCreate') {
-      const id = String(++this.taskSeq)
+      const id = String(input.taskId || input.id || ++this.taskSeq)
+      this.syncTaskSeq(id)
       this.tasks.set(id, {
         id,
         subject: String(input.subject || ''),
@@ -680,8 +686,17 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
     }
     if (toolName === 'TaskUpdate') {
       const id = String(input.taskId || '')
-      const task = this.tasks.get(id)
-      if (!task) return false
+      if (!id) return false
+      let task = this.tasks.get(id)
+      if (!task) {
+        // Unknown id — our in-memory map can diverge from the CLI's real task
+        // list (e.g. after a process restart mid-session). Upsert instead of
+        // dropping the update, otherwise the UI shows a stale list forever.
+        if (input.status === 'deleted') return false
+        task = { id, subject: String(input.subject || `Task ${id}`), status: 'pending' }
+        this.tasks.set(id, task)
+        this.syncTaskSeq(id)
+      }
       const status = input.status as string | undefined
       if (status === 'deleted') {
         this.tasks.delete(id)
@@ -695,6 +710,25 @@ export class ClaudeProcess extends EventEmitter<ClaudeProcessEvents> implements 
       return true
     }
     return false
+  }
+
+  /** Keep taskSeq ahead of any numeric id we have seen, so generated ids never collide. */
+  private syncTaskSeq(id: string): void {
+    const n = Number(id)
+    if (Number.isInteger(n) && n > this.taskSeq) this.taskSeq = n
+  }
+
+  /**
+   * Seed task state from a previous process's last known list (session restore).
+   * Without this, a restarted process starts with an empty map and TaskUpdate
+   * calls referencing pre-restart task ids would otherwise be lost.
+   */
+  seedTasks(tasks: TaskItem[]): void {
+    this.tasks.clear()
+    for (const t of tasks) {
+      this.tasks.set(t.id, { ...t })
+      this.syncTaskSeq(t.id)
+    }
   }
 
   /**

--- a/server/codex-process.ts
+++ b/server/codex-process.ts
@@ -805,6 +805,12 @@ export class CodexProcess extends EventEmitter<ClaudeProcessEvents> implements C
     }
   }
 
+  /**
+   * No-op: Codex emits the full plan on every turn/plan/updated notification,
+   * so there is no incremental task state to seed after a restart.
+   */
+  seedTasks(): void {}
+
   isAlive(): boolean {
     return this.alive
   }

--- a/server/coding-process.ts
+++ b/server/coding-process.ts
@@ -12,6 +12,7 @@
 
 import type { EventEmitter } from 'events'
 import type { ClaudeProcessEvents } from './claude-process.js'
+import type { TaskItem } from './types.js'
 
 /**
  * Supported AI coding assistant providers.
@@ -80,6 +81,9 @@ export interface CodingProcess extends EventEmitter<ClaudeProcessEvents> {
    * don't support runtime mode changes omit this — callers fall back to restart.
    */
   setPermissionMode?(mode: import('./types.js').PermissionMode): Promise<boolean>
+
+  /** Seed task/todo state from a previous process's last known list (session restore). */
+  seedTasks(tasks: TaskItem[]): void
 
   /** Whether the process is currently running and accepting input. */
   isAlive(): boolean

--- a/server/opencode-process.ts
+++ b/server/opencode-process.ts
@@ -889,13 +889,13 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
               this.emit('tool_active', toolName, inputStr)
               // Detect task/todo tool calls and emit todo_update
               if (part.state?.input && this.handleTaskTool(toolName, part.state.input)) {
-                this.emit('todo_update', Array.from(this.tasks.values()))
+                this.emit('todo_update', Array.from(this.tasks.values(), t => ({ ...t })))
               }
             } else if (status === 'completed') {
               // Also check for task tools at completion (some providers only
               // populate input at this stage, not during 'running')
               if (part.state?.input && this.handleTaskTool(toolName, part.state.input)) {
-                this.emit('todo_update', Array.from(this.tasks.values()))
+                this.emit('todo_update', Array.from(this.tasks.values(), t => ({ ...t })))
               }
               const output = part.state?.output
               const summary = output ? output.slice(0, 200) : undefined
@@ -1265,13 +1265,16 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
   private handleTaskTool(toolName: string, input: Record<string, unknown>): boolean {
     // Normalize tool name — OpenCode may report as 'todowrite', 'TodoWrite', 'todo_write', etc.
     const normalized = toolName.toLowerCase().replace(/_/g, '')
+    // Note: taskSeq is intentionally NOT reset on TodoWrite — keeping ids
+    // monotonic across list generations lets the frontend detect a brand-new
+    // list by id and avoids collisions with later TaskCreate/TaskUpdate calls.
     if (normalized === 'todowrite') {
       const todos = input.todos as Array<Record<string, unknown>> | undefined
       if (!Array.isArray(todos)) return false
       this.tasks.clear()
-      this.taskSeq = 0
       for (const item of todos) {
         const id = String(item.id || ++this.taskSeq)
+        this.syncTaskSeq(id)
         const status = item.status as string
         if (status !== 'pending' && status !== 'in_progress' && status !== 'completed') continue
         this.tasks.set(id, {
@@ -1284,7 +1287,8 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       return true
     }
     if (normalized === 'taskcreate') {
-      const id = String(++this.taskSeq)
+      const id = String(input.taskId || input.id || ++this.taskSeq)
+      this.syncTaskSeq(id)
       this.tasks.set(id, {
         id,
         subject: String(input.subject || ''),
@@ -1295,8 +1299,17 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
     }
     if (normalized === 'taskupdate') {
       const id = String(input.taskId || '')
-      const task = this.tasks.get(id)
-      if (!task) return false
+      if (!id) return false
+      let task = this.tasks.get(id)
+      if (!task) {
+        // Unknown id — our in-memory map can diverge from the provider's real
+        // task list (e.g. after a process restart mid-session). Upsert instead
+        // of dropping the update, otherwise the UI shows a stale list forever.
+        if (input.status === 'deleted') return false
+        task = { id, subject: String(input.subject || `Task ${id}`), status: 'pending' }
+        this.tasks.set(id, task)
+        this.syncTaskSeq(id)
+      }
       const status = input.status as string | undefined
       if (status === 'deleted') {
         this.tasks.delete(id)
@@ -1310,6 +1323,25 @@ export class OpenCodeProcess extends EventEmitter<ClaudeProcessEvents> implement
       return true
     }
     return false
+  }
+
+  /** Keep taskSeq ahead of any numeric id we have seen, so generated ids never collide. */
+  private syncTaskSeq(id: string): void {
+    const n = Number(id)
+    if (Number.isInteger(n) && n > this.taskSeq) this.taskSeq = n
+  }
+
+  /**
+   * Seed task state from a previous process's last known list (session restore).
+   * Without this, a restarted process starts with an empty map and TaskUpdate
+   * calls referencing pre-restart task ids would otherwise be lost.
+   */
+  seedTasks(tasks: TaskItem[]): void {
+    this.tasks.clear()
+    for (const t of tasks) {
+      this.tasks.set(t.id, { ...t })
+      this.syncTaskSeq(t.id)
+    }
   }
 
   /** Send a user message to the OpenCode session. */

--- a/server/session-lifecycle.ts
+++ b/server/session-lifecycle.ts
@@ -188,6 +188,18 @@ export class SessionLifecycle {
 
     this.wireClaudeEvents(cp, session, sessionId)
 
+    // On resume, carry the last known task list into the new process so
+    // TaskUpdate calls referencing pre-restart task ids aren't dropped.
+    if (resume) {
+      for (let i = session.outputHistory.length - 1; i >= 0; i--) {
+        const msg = session.outputHistory[i]
+        if (msg.type === 'todo_update') {
+          cp.seedTasks(msg.tasks)
+          break
+        }
+      }
+    }
+
     cp.start()
     session.claudeProcess = cp
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -666,6 +666,7 @@ export default function App() {
             planningMode={planningMode}
             activityLabel={activityLabel}
             tasks={tasks}
+            isProcessing={isProcessing}
             activePrompt={activePrompt}
             sendPromptResponse={sendPromptResponse}
             inputBarRef={inputBarRef}
@@ -733,6 +734,7 @@ export default function App() {
             planningMode={planningMode}
             activityLabel={activityLabel}
             tasks={tasks}
+            isProcessing={isProcessing}
             disabled={!settings.token}
             hasFileChanges={hasFileChanges}
             diffPanelOpen={diffPanelOpen}

--- a/src/components/OrchestratorContent.tsx
+++ b/src/components/OrchestratorContent.tsx
@@ -27,6 +27,7 @@ export interface OrchestratorContentProps {
   planningMode: boolean
   activityLabel?: string
   tasks: TaskItem[]
+  isProcessing: boolean
   activePrompt: PromptEntry | null
   sendPromptResponse: (value: string | string[], requestId?: string) => void
   inputBarRef: RefObject<InputBarHandle | null>
@@ -55,6 +56,7 @@ export function OrchestratorContent({
   planningMode,
   activityLabel,
   tasks,
+  isProcessing,
   activePrompt,
   sendPromptResponse,
   inputBarRef,
@@ -93,7 +95,7 @@ export function OrchestratorContent({
               variant="orchestrator"
               agentName={agentName}
             />
-            <TodoPanel tasks={tasks} />
+            <TodoPanel tasks={tasks} isProcessing={isProcessing} />
           </div>
           {activePrompt && (
             <PromptButtons

--- a/src/components/SessionContent.tsx
+++ b/src/components/SessionContent.tsx
@@ -26,6 +26,7 @@ export interface SessionContentProps {
   planningMode: boolean
   activityLabel?: string
   tasks: TaskItem[]
+  isProcessing: boolean
   disabled: boolean
   hasFileChanges: boolean
   diffPanelOpen: boolean
@@ -76,6 +77,7 @@ export function SessionContent({
   planningMode,
   activityLabel,
   tasks,
+  isProcessing,
   disabled,
   hasFileChanges,
   diffPanelOpen,
@@ -126,7 +128,7 @@ export function SessionContent({
           activityLabel={isProviderDisabled ? undefined : activityLabel}
           isMobile={isMobile}
         />
-        <TodoPanel tasks={tasks} />
+        <TodoPanel tasks={tasks} isProcessing={isProcessing} />
 
         {/* Claude Code disabled banner */}
         {claudeDisabled && (

--- a/src/components/TodoPanel.test.tsx
+++ b/src/components/TodoPanel.test.tsx
@@ -1,0 +1,137 @@
+/** Tests for TodoPanel — verifies show/hide/collapse behavior across task list updates and turn boundaries. */
+// @vitest-environment jsdom
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { TodoPanel } from './TodoPanel.js'
+import type { TaskItem } from '../types'
+
+/* ------------------------------------------------------------------ */
+/*  Minimal component renderer                                          */
+/* ------------------------------------------------------------------ */
+
+let activeRoot: ReturnType<typeof createRoot> | null = null
+let activeContainer: HTMLElement | null = null
+
+function render(ui: React.ReactElement): HTMLElement {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  act(() => {
+    activeRoot = createRoot(container)
+    activeRoot.render(ui)
+  })
+  activeContainer = container
+  return container
+}
+
+function rerender(ui: React.ReactElement) {
+  act(() => {
+    activeRoot!.render(ui)
+  })
+}
+
+afterEach(() => {
+  if (activeRoot) act(() => activeRoot!.unmount())
+  activeContainer?.remove()
+  activeRoot = null
+  activeContainer = null
+})
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                             */
+/* ------------------------------------------------------------------ */
+
+function task(id: string, status: TaskItem['status'], subject = `Task ${id}`): TaskItem {
+  return { id, subject, status }
+}
+
+function isVisible(container: HTMLElement): boolean {
+  return container.children.length > 0
+}
+
+function isExpanded(container: HTMLElement): boolean {
+  return container.textContent?.includes('Tasks') ?? false
+}
+
+/* ------------------------------------------------------------------ */
+/*  Tests                                                               */
+/* ------------------------------------------------------------------ */
+
+describe('TodoPanel', () => {
+  it('renders nothing with no tasks', () => {
+    const c = render(<TodoPanel tasks={[]} isProcessing />)
+    expect(isVisible(c)).toBe(false)
+  })
+
+  it('auto-expands when new tasks arrive while processing', () => {
+    const c = render(<TodoPanel tasks={[]} isProcessing />)
+    rerender(<TodoPanel tasks={[task('1', 'in_progress'), task('2', 'pending')]} isProcessing />)
+    expect(isVisible(c)).toBe(true)
+    expect(isExpanded(c)).toBe(true)
+  })
+
+  it('shows a collapsed pill (not expanded) when restoring an unfinished list while idle', () => {
+    const c = render(<TodoPanel tasks={[task('1', 'in_progress')]} isProcessing={false} />)
+    expect(isVisible(c)).toBe(true)
+    expect(isExpanded(c)).toBe(false)
+  })
+
+  it('auto-dismisses 3s after all tasks complete once the turn is over', () => {
+    const c = render(<TodoPanel tasks={[task('1', 'in_progress')]} isProcessing />)
+    rerender(<TodoPanel tasks={[task('1', 'completed')]} isProcessing={false} />)
+    expect(isVisible(c)).toBe(true)
+    act(() => { vi.advanceTimersByTime(3000) })
+    expect(isVisible(c)).toBe(false)
+  })
+
+  it('keeps the panel for 10s after completion while still processing', () => {
+    const c = render(<TodoPanel tasks={[task('1', 'in_progress')]} isProcessing />)
+    rerender(<TodoPanel tasks={[task('1', 'completed')]} isProcessing />)
+    act(() => { vi.advanceTimersByTime(3000) })
+    expect(isVisible(c)).toBe(true)
+    act(() => { vi.advanceTimersByTime(7000) })
+    expect(isVisible(c)).toBe(false)
+  })
+
+  it('collapses to the pill when a turn ends with unfinished tasks', () => {
+    const c = render(<TodoPanel tasks={[]} isProcessing />)
+    rerender(<TodoPanel tasks={[task('1', 'in_progress'), task('2', 'pending')]} isProcessing />)
+    expect(isExpanded(c)).toBe(true)
+    rerender(<TodoPanel tasks={[task('1', 'in_progress'), task('2', 'pending')]} isProcessing={false} />)
+    expect(isVisible(c)).toBe(true)
+    expect(isExpanded(c)).toBe(false)
+  })
+
+  it('re-shows a dismissed panel when a replaced list with new ids arrives (same length)', () => {
+    const c = render(<TodoPanel tasks={[]} isProcessing />)
+    rerender(<TodoPanel tasks={[task('1', 'in_progress')]} isProcessing />)
+    // complete + dismiss
+    rerender(<TodoPanel tasks={[task('1', 'completed')]} isProcessing={false} />)
+    act(() => { vi.advanceTimersByTime(3000) })
+    expect(isVisible(c)).toBe(false)
+    // new list generation, same length but different id
+    rerender(<TodoPanel tasks={[task('2', 'in_progress')]} isProcessing />)
+    expect(isVisible(c)).toBe(true)
+  })
+
+  it('dismisses immediately when restoring an already-completed list', () => {
+    const c = render(<TodoPanel tasks={[task('1', 'completed')]} isProcessing={false} />)
+    act(() => { vi.advanceTimersByTime(0) })
+    expect(isVisible(c)).toBe(false)
+  })
+
+  it('updates the progress count in the pill', () => {
+    const c = render(<TodoPanel tasks={[task('1', 'completed'), task('2', 'in_progress')]} isProcessing={false} />)
+    expect(c.textContent).toContain('1/2')
+  })
+})

--- a/src/components/TodoPanel.tsx
+++ b/src/components/TodoPanel.tsx
@@ -12,28 +12,40 @@ import type { TaskItem } from '../types'
 
 interface Props {
   tasks: TaskItem[]
+  /** Whether the session is currently processing a turn. Used to close/collapse the panel when work stops. */
+  isProcessing?: boolean
 }
 
-export function TodoPanel({ tasks }: Props) {
+export function TodoPanel({ tasks, isProcessing = false }: Props) {
   const [expanded, setExpanded] = useState(false)
   const [dismissed, setDismissed] = useState(false)
-  const prevCountRef = useRef(0)
+  const prevIdSigRef = useRef('')
   const hadActiveTaskRef = useRef(false)
   const prevCompletedRef = useRef(0)
+  const prevProcessingRef = useRef(isProcessing)
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments -- new Map() infers Map<any,any>
   const taskRefs = useRef<Map<string, HTMLDivElement>>(new Map())
 
   const completed = tasks.filter(t => t.status === 'completed').length
   const allDone = tasks.length > 0 && completed === tasks.length
+  // Signature of task identity — detects replaced lists, not just count growth
+  const idSig = tasks.map(t => t.id).join(',')
 
-  // Auto-expand when new tasks appear
+  // Auto-show when a new or replaced task list with active work appears.
+  // Compares task ids (not just count) so a fresh list of equal/smaller size
+  // still re-shows a previously dismissed panel.
   useEffect(() => {
-    if (tasks.length > prevCountRef.current) {
-      setExpanded(true) // eslint-disable-line react-hooks/set-state-in-effect -- auto-expand on new tasks
-      setDismissed(false)  
+    if (idSig !== prevIdSigRef.current) {
+      prevIdSigRef.current = idSig
+      if (idSig && !allDone) {
+        /* eslint-disable react-hooks/set-state-in-effect -- auto-show on new task list */
+        setDismissed(false)
+        // Expand only while actively processing; on idle restore show the pill
+        if (isProcessing) setExpanded(true)
+        /* eslint-enable react-hooks/set-state-in-effect */
+      }
     }
-    prevCountRef.current = tasks.length
-  }, [tasks.length])
+  }, [idSig, allDone, isProcessing])
 
   // Track if we ever saw a non-completed task (distinguishes live vs restore)
   useEffect(() => {
@@ -42,16 +54,28 @@ export function TodoPanel({ tasks }: Props) {
     }
   }, [tasks, allDone])
 
-  // Auto-dismiss after all tasks complete
+  // Auto-dismiss after all tasks complete: quickly once the turn is over,
+  // with a longer grace period while Claude is still working.
   useEffect(() => {
     if (allDone) {
-      const delay = hadActiveTaskRef.current ? 10000 : 0
+      const delay = !hadActiveTaskRef.current ? 0 : isProcessing ? 10000 : 3000
       const timer = setTimeout(() => { setDismissed(true); }, delay)
       return () => { clearTimeout(timer); }
     }
     setDismissed(false) // eslint-disable-line react-hooks/set-state-in-effect -- reset dismissed when tasks become active
     return undefined
-  }, [allDone])
+  }, [allDone, isProcessing])
+
+  // When a turn ends with unfinished tasks (Claude often forgets the final
+  // update), collapse the expanded card to the compact pill so it stops
+  // obstructing the chat while still showing progress.
+  useEffect(() => {
+    const wasProcessing = prevProcessingRef.current
+    prevProcessingRef.current = isProcessing
+    if (wasProcessing && !isProcessing && tasks.length > 0 && !allDone) {
+      setExpanded(false) // eslint-disable-line react-hooks/set-state-in-effect -- collapse on turn end
+    }
+  }, [isProcessing, tasks.length, allDone])
 
   // Auto-scroll to first non-completed task when completed count increases
   useEffect(() => {


### PR DESCRIPTION
## Summary
- **Server**: `TaskUpdate` with an unknown task id was silently dropped (no `todo_update` emitted), leaving the chat todo panel stale and unable to ever reach all-done. Causes: `taskSeq` reset on every `TodoWrite` and an empty task map after process restarts while the CLI's task list survives the resume. Now: upsert unknown ids, keep ids monotonic across list generations, honor explicit `taskId`/`id` on `TaskCreate`, and seed restarted processes from the last `todo_update` in session history. Emitted snapshots are copied to avoid aliasing into stored history. Same fixes mirrored in `OpenCodeProcess`.
- **Frontend**: `TodoPanel` is now turn-aware via an `isProcessing` prop — auto-dismisses 3s after all tasks complete once the turn ends (10s while still processing), collapses to the compact pill when a turn ends with unfinished tasks (Claude often forgets the final update), and detects replaced task lists by id signature (not just count) so a dismissed panel re-shows for the next list.
- Adds component tests for TodoPanel show/hide/collapse behavior and updates server task-tool tests.

## Test plan
- [x] `npm run build` (typecheck + vite) passes
- [x] `npm test` — 2170 tests pass, incl. 9 new TodoPanel tests covering turn transitions with fake timers
- [x] `npm run lint` — 0 errors, no new warnings in touched files
- [ ] Manual: run a multi-task session, verify panel updates live, collapses on turn end, and dismisses after completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)