### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-13
+
 ### Added
 - **OpenAI Codex provider** — Integrate `codex app-server` (JSON-RPC 2.0 over stdio) as a third coding-agent backend behind the existing `CodingProcess` interface, unlocking ChatGPT-subscription-gated OpenAI models for sessions and workflows. Includes a `CodexProcess` adapter (handshake, event mapping, command/file-change approvals, thread resume across restarts, permission-mode → approvalPolicy/sandbox mapping), model discovery at `/api/codex/models`, startup binary/auth detection, and a frontend provider option with `codex login` guidance (#499)
 - **Claude Fable 5 model support** (#492)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codekin",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "codekin",
-      "version": "0.6.5",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codekin",
-  "version": "0.6.5",
+  "version": "0.7.0",
   "license": "MIT",
   "licenseNotes": "dompurify is dual-licensed (MPL-2.0 OR Apache-2.0); both are permissively compatible with MIT for library use. lightningcss (MPL-2.0) is a build-time-only dependency used by TailwindCSS and is not included in distributed artifacts.",
   "author": "multiplier-labs",


### PR DESCRIPTION
## Summary
Cuts the **v0.7.0** release.

- Bump version `0.6.5` → `0.7.0` (root `package.json` + `package-lock.json`)
- Promote CHANGELOG `[Unreleased]` → `[0.7.0] - 2026-06-13`, covering the Codex provider, OpenCode resilience, the full Agent Joe resilience suite, dynamic model discovery, and the UI/visual updates (#474–#510)

After merge, tagging `v0.7.0` will trigger `.github/workflows/publish.yml` to publish to npm.

## Test plan
- [ ] CI green (test-and-lint)
- [ ] After merge: push tag `v0.7.0` and confirm the publish workflow succeeds