### PR TITLE
feat: GoalRun loop engine — durable act→verify→continue loops with maker-checker + deterministic PR finalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "bin/",
     "dist/",
     "server/dist/",
-    "server/workflows/"
+    "server/workflows/",
+    "server/loops/"
   ],
   "scripts": {
     "dev": "vite",

--- a/server/glob-match.test.ts
+++ b/server/glob-match.test.ts
@@ -1,0 +1,50 @@
+/** Tests for the glob matcher used by Goal Run readonly constraints. */
+import { describe, it, expect } from 'vitest'
+import { globToRegExp, matchesAnyGlob } from './glob-match.js'
+
+describe('globToRegExp', () => {
+  it('matches a directory tree with **', () => {
+    const re = globToRegExp('.github/workflows/**')
+    expect(re.test('.github/workflows/ci.yml')).toBe(true)
+    expect(re.test('.github/workflows/nested/deploy.yml')).toBe(true)
+    expect(re.test('.github/other/ci.yml')).toBe(false)
+  })
+
+  it('* does not cross path separators', () => {
+    const re = globToRegExp('src/*.ts')
+    expect(re.test('src/index.ts')).toBe(true)
+    expect(re.test('src/sub/index.ts')).toBe(false)
+  })
+
+  it('? matches a single non-slash character', () => {
+    const re = globToRegExp('v?.txt')
+    expect(re.test('v1.txt')).toBe(true)
+    expect(re.test('v12.txt')).toBe(false)
+    expect(re.test('v/.txt')).toBe(false)
+  })
+
+  it('matches an extension glob', () => {
+    const re = globToRegExp('*.lock')
+    expect(re.test('yarn.lock')).toBe(true)
+    expect(re.test('package-lock.json')).toBe(false)
+  })
+
+  it('escapes regex metacharacters in literals', () => {
+    const re = globToRegExp('a.b+c')
+    expect(re.test('a.b+c')).toBe(true)
+    expect(re.test('axbxc')).toBe(false)
+  })
+})
+
+describe('matchesAnyGlob', () => {
+  it('returns true when any pattern matches', () => {
+    const globs = ['.github/workflows/**', 'tests/security/**']
+    expect(matchesAnyGlob('tests/security/auth.test.ts', globs)).toBe(true)
+    expect(matchesAnyGlob('.github/workflows/ci.yml', globs)).toBe(true)
+    expect(matchesAnyGlob('src/index.ts', globs)).toBe(false)
+  })
+
+  it('returns false for an empty pattern list', () => {
+    expect(matchesAnyGlob('anything', [])).toBe(false)
+  })
+})

--- a/server/glob-match.ts
+++ b/server/glob-match.ts
@@ -1,0 +1,44 @@
+/**
+ * Minimal glob matcher for Goal Run readonly constraints.
+ *
+ * Supports the subset needed by loop specs (e.g. `.github/workflows/**`,
+ * `tests/security/**`, `*.lock`):
+ *   **  — any run of characters, including '/'
+ *   *   — any run of characters except '/'
+ *   ?   — a single character except '/'
+ * Everything else is matched literally. Patterns are anchored to the full path.
+ *
+ * Intentionally dependency-free — the codebase ships no glob library, and the
+ * constraint set is small and author-controlled, so a focused matcher beats
+ * pulling in micromatch.
+ */
+
+const REGEX_SPECIAL = new Set(['.', '+', '^', '$', '{', '}', '(', ')', '|', '[', ']', '\\'])
+
+/** Convert a glob to a RegExp anchored to the whole string. */
+export function globToRegExp(glob: string): RegExp {
+  let out = ''
+  for (let i = 0; i < glob.length; i++) {
+    const ch = glob[i]
+    if (ch === '*') {
+      if (glob[i + 1] === '*') {
+        out += '.*'
+        i++ // consume the second '*'
+      } else {
+        out += '[^/]*'
+      }
+    } else if (ch === '?') {
+      out += '[^/]'
+    } else if (REGEX_SPECIAL.has(ch)) {
+      out += `\\${ch}`
+    } else {
+      out += ch
+    }
+  }
+  return new RegExp(`^${out}$`)
+}
+
+/** True when `path` matches any of the supplied globs. */
+export function matchesAnyGlob(path: string, globs: string[]): boolean {
+  return globs.some((g) => globToRegExp(g).test(path))
+}

--- a/server/goal-run-controller.test.ts
+++ b/server/goal-run-controller.test.ts
@@ -1,6 +1,6 @@
 /** Tests for GoalRunController — drives the loop with a fake session host + verifier and asserts state transitions and the evidence ledger. */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
-import { GoalRunController, type SessionHost, type VerifierApi } from './goal-run-controller.js'
+import { GoalRunController, parseCheckerVerdict, type SessionHost, type VerifierApi } from './goal-run-controller.js'
 import { GoalRunStore, type CreateGoalRunInput, type GoalRunSpec } from './goal-run-store.js'
 import type { VerifyResult } from './verifier-runner.js'
 
@@ -17,12 +17,14 @@ class FakeHost implements SessionHost {
   sent: string[] = []
   stopped: string[] = []
   worktreePath = '/wt/feat'
-  private listener: ((sessionId: string, isError: boolean) => void) | null = null
+  private listeners: ((sessionId: string, isError: boolean) => void)[] = []
   private nextId = 1
   lastSessionId = ''
+  createdIds: string[] = []
 
   create(): { id: string } {
     this.lastSessionId = `sess-${this.nextId++}`
+    this.createdIds.push(this.lastSessionId)
     return { id: this.lastSessionId }
   }
   createWorktree(): Promise<string | null> {
@@ -41,14 +43,18 @@ class FakeHost implements SessionHost {
     return { outputHistory: this.outputHistory, worktreePath: this.worktreePath }
   }
   onSessionResult(listener: (sessionId: string, isError: boolean) => void): () => void {
-    this.listener = listener
+    this.listeners.push(listener)
     return () => {
-      this.listener = null
+      this.listeners = this.listeners.filter((l) => l !== listener)
     }
   }
-  /** Simulate a maker turn ending. */
+  /** Simulate the maker (first created session) turn ending. */
   async fire(isError = false): Promise<void> {
-    this.listener?.(this.lastSessionId, isError)
+    await this.fireSession(this.createdIds[0], isError)
+  }
+  /** Simulate a specific session's turn ending. */
+  async fireSession(sessionId: string, isError = false): Promise<void> {
+    for (const l of [...this.listeners]) l(sessionId, isError)
     await flush()
   }
 }
@@ -56,6 +62,7 @@ class FakeHost implements SessionHost {
 class FakeVerifier implements VerifierApi {
   changed: string[] = ['src/a.ts']
   diff = 'src/a.ts | 2 +-'
+  diffText = 'diff --git a/src/a.ts b/src/a.ts\n+const x = 1'
   queue: VerifyResult[] = []
   fallback: VerifyResult = PASS
   runVerifier(): Promise<VerifyResult> {
@@ -63,6 +70,9 @@ class FakeVerifier implements VerifierApi {
   }
   getDiffSummary(): Promise<string> {
     return Promise.resolve(this.diff)
+  }
+  getDiff(): Promise<string> {
+    return Promise.resolve(this.diffText)
   }
   getChangedFiles(): Promise<string[]> {
     return Promise.resolve(this.changed)
@@ -186,5 +196,86 @@ describe('GoalRunController', () => {
     await host.fire()
     expect(store.getRun(run.id)?.status).toBe('running')
     expect(host.sent.some((s) => s.includes('No file changes detected'))).toBe(true)
+  })
+
+  describe('maker–checker (Cut 2)', () => {
+    const withChecker = () => spec({ checker: { provider: 'opencode' }, maxTurns: 20 })
+
+    it('runs a second-provider checker after verify passes, then finalizes on approve', async () => {
+      host.outputHistory.push({ type: 'output', data: 'Looks correct and in scope.\nVERDICT: approve' })
+      const run = await controller.startRun(input(withChecker()))
+
+      await host.fire() // maker turn 1 → verify passes → checker spawned
+      expect(store.getRun(run.id)?.status).toBe('checking')
+      expect(host.createdIds).toHaveLength(2)
+      expect(host.sent.some((s) => s.includes('# Goal Run Review'))).toBe(true)
+
+      await host.fireSession(host.createdIds[1]) // checker → approve
+      const updated = store.getRun(run.id)
+      expect(updated?.status).toBe('succeeded')
+      expect(host.sent.some((s) => s.includes('open a pull request'))).toBe(true)
+      expect(host.stopped).toContain(host.createdIds[1]) // checker torn down
+      const checkerTurn = store.listTurns(run.id).find((t) => t.role === 'checker')
+      expect(checkerTurn?.verdict).toBe('approve')
+      expect(controller.activeRunIds()).toHaveLength(0)
+    })
+
+    it('feeds request_changes back to the maker and approves on the next round', async () => {
+      host.outputHistory.push({ type: 'output', data: 'VERDICT: request_changes\nREASON: add a regression test' })
+      const run = await controller.startRun(input(withChecker()))
+
+      await host.fire() // maker turn 1 → verify pass → checker
+      await host.fireSession(host.createdIds[1]) // checker → request_changes
+      expect(store.getRun(run.id)?.status).toBe('running')
+      expect(host.sent.some((s) => s.includes('add a regression test'))).toBe(true)
+      expect(host.stopped).toContain(host.createdIds[1])
+
+      verifier.diff = 'src/a.ts | 9 +++++++--' // diff changed so verify re-runs
+      host.outputHistory.push({ type: 'output', data: 'Now correct.\nVERDICT: approve' })
+      await host.fire() // maker turn 2 → verify pass → new checker
+      expect(host.createdIds).toHaveLength(3)
+      await host.fireSession(host.createdIds[2]) // checker → approve
+      expect(store.getRun(run.id)?.status).toBe('succeeded')
+    })
+
+    it('escalates to a human on an escalate verdict', async () => {
+      host.outputHistory.push({ type: 'output', data: 'VERDICT: escalate\nREASON: risky data migration' })
+      const run = await controller.startRun(input(spec({ checker: { provider: 'codex' } })))
+
+      await host.fire()
+      await host.fireSession(host.createdIds[1])
+      const updated = store.getRun(run.id)
+      expect(updated?.status).toBe('awaiting_human')
+      expect(host.stopped).toContain(host.createdIds[0]) // maker stopped
+    })
+
+    it('escalates when the checker verdict cannot be parsed', async () => {
+      host.outputHistory.push({ type: 'output', data: 'I am not really sure about this change.' })
+      const run = await controller.startRun(input(withChecker()))
+
+      await host.fire()
+      await host.fireSession(host.createdIds[1])
+      expect(store.getRun(run.id)?.status).toBe('awaiting_human')
+      const checkerTurn = store.listTurns(run.id).find((t) => t.role === 'checker')
+      expect(checkerTurn?.verdict).toBeNull()
+    })
+  })
+})
+
+describe('parseCheckerVerdict', () => {
+  it('parses a trailing verdict line with a reason', () => {
+    expect(parseCheckerVerdict('Some review.\nVERDICT: request_changes\nREASON: missing test')).toEqual({
+      verdict: 'request_changes',
+      reason: 'missing test',
+    })
+  })
+
+  it('takes the last verdict when instructions are echoed', () => {
+    const text = 'Options: VERDICT: approve, VERDICT: escalate.\n\nMy decision:\nVERDICT: approve'
+    expect(parseCheckerVerdict(text)).toEqual({ verdict: 'approve' })
+  })
+
+  it('returns null when no verdict marker is present', () => {
+    expect(parseCheckerVerdict('looks fine to me')).toBeNull()
   })
 })

--- a/server/goal-run-controller.test.ts
+++ b/server/goal-run-controller.test.ts
@@ -2,6 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import { GoalRunController, parseCheckerVerdict, type SessionHost, type VerifierApi } from './goal-run-controller.js'
 import { GoalRunStore, type CreateGoalRunInput, type GoalRunSpec } from './goal-run-store.js'
+import type { FinalizeOptions, FinalizeResult, FinalizerApi } from './goal-run-finalizer.js'
 import type { VerifyResult } from './verifier-runner.js'
 
 const PASS: VerifyResult = { passed: true, results: [{ command: 'npm test', exitCode: 0, outputTail: 'ok', durationMs: 1, timedOut: false }] }
@@ -79,6 +80,18 @@ class FakeVerifier implements VerifierApi {
   }
 }
 
+class FakeFinalizer implements FinalizerApi {
+  calls: FinalizeOptions[] = []
+  result: FinalizeResult = {
+    prUrl: 'https://github.com/acme/repo/pull/7',
+    note: 'Verification passed; opened PR: https://github.com/acme/repo/pull/7',
+  }
+  finalize(opts: FinalizeOptions): Promise<FinalizeResult> {
+    this.calls.push(opts)
+    return Promise.resolve(this.result)
+  }
+}
+
 function spec(overrides: Partial<GoalRunSpec> = {}): GoalRunSpec {
   return {
     maker: { provider: 'claude' },
@@ -100,13 +113,15 @@ describe('GoalRunController', () => {
   let store: GoalRunStore
   let host: FakeHost
   let verifier: FakeVerifier
+  let finalizer: FakeFinalizer
   let controller: GoalRunController
 
   beforeEach(() => {
     store = new GoalRunStore(':memory:')
     host = new FakeHost()
     verifier = new FakeVerifier()
-    controller = new GoalRunController(host, store, verifier)
+    finalizer = new FakeFinalizer()
+    controller = new GoalRunController(host, store, verifier, finalizer)
   })
 
   afterEach(() => {
@@ -121,18 +136,36 @@ describe('GoalRunController', () => {
     expect(host.sent[0]).toContain('make checks pass')
   })
 
-  it('finalizes as succeeded when the verifier passes', async () => {
+  it('finalizes deterministically and captures the PR url when the verifier passes', async () => {
     const run = await controller.startRun(input(spec()))
     await host.fire()
     const updated = store.getRun(run.id)
     expect(updated?.status).toBe('succeeded')
     expect(updated?.completedAt).toBeTruthy()
-    // a finalize (push + PR) instruction was sent
-    expect(host.sent.some((s) => s.includes('open a pull request'))).toBe(true)
-    // evidence ledger has a verifier row that passed
+    // Codekin finalized deterministically: the maker was stopped and the finalizer
+    // was invoked with the run's worktree, branch and completion policy.
+    expect(host.stopped).toContain('sess-1')
+    expect(finalizer.calls).toHaveLength(1)
+    expect(finalizer.calls[0].branch).toBe('fix/ci')
+    expect(finalizer.calls[0].policy).toBe('pr')
+    expect(finalizer.calls[0].cwd).toBe('/wt/feat')
+    // the captured PR url is persisted and the note recorded in the ledger
+    expect(updated?.prUrl).toBe('https://github.com/acme/repo/pull/7')
     const turns = store.listTurns(run.id)
     expect(turns.some((t) => t.role === 'verifier' && t.exitCode === 0)).toBe(true)
+    expect(turns.some((t) => t.outputTail?.includes('opened PR'))).toBe(true)
     expect(controller.activeRunIds()).toHaveLength(0)
+  })
+
+  it('still succeeds (with null prUrl) when finalization fails to open a PR', async () => {
+    finalizer.result = { prUrl: null, note: 'Verification passed; branch pushed but PR creation failed: offline' }
+    const run = await controller.startRun(input(spec()))
+    await host.fire()
+    const updated = store.getRun(run.id)
+    expect(updated?.status).toBe('succeeded')
+    expect(updated?.prUrl).toBeNull()
+    const turns = store.listTurns(run.id)
+    expect(turns.some((t) => t.outputTail?.includes('PR creation failed'))).toBe(true)
   })
 
   it('feeds a verify failure back to the maker, then succeeds on the next turn', async () => {
@@ -213,7 +246,8 @@ describe('GoalRunController', () => {
       await host.fireSession(host.createdIds[1]) // checker → approve
       const updated = store.getRun(run.id)
       expect(updated?.status).toBe('succeeded')
-      expect(host.sent.some((s) => s.includes('open a pull request'))).toBe(true)
+      expect(finalizer.calls).toHaveLength(1) // deterministic finalization ran on approve
+      expect(updated?.prUrl).toBe('https://github.com/acme/repo/pull/7')
       expect(host.stopped).toContain(host.createdIds[1]) // checker torn down
       const checkerTurn = store.listTurns(run.id).find((t) => t.role === 'checker')
       expect(checkerTurn?.verdict).toBe('approve')

--- a/server/goal-run-controller.test.ts
+++ b/server/goal-run-controller.test.ts
@@ -260,6 +260,46 @@ describe('GoalRunController', () => {
       expect(checkerTurn?.verdict).toBeNull()
     })
   })
+
+  describe('abortRun (Cut 4)', () => {
+    it('stops the maker and marks an active run aborted', async () => {
+      const run = await controller.startRun(input(spec()))
+      expect(controller.activeRunIds()).toContain(run.id)
+
+      const aborted = controller.abortRun(run.id)
+      expect(aborted).toBe(true)
+      expect(store.getRun(run.id)?.status).toBe('aborted')
+      expect(store.getRun(run.id)?.completedAt).not.toBeNull()
+      expect(host.stopped).toContain(run.makerSessionId)
+      expect(controller.activeRunIds()).not.toContain(run.id)
+      // An abort note is recorded in the evidence ledger.
+      expect(store.listTurns(run.id).some((t) => t.outputTail === 'Run aborted by user.')).toBe(true)
+    })
+
+    it('returns false for an unknown run', () => {
+      expect(controller.abortRun('does-not-exist')).toBe(false)
+    })
+
+    it('refuses to abort an already-terminal run', async () => {
+      const run = await controller.startRun(input(spec()))
+      host.outputHistory.push({ type: 'usage', costUsd: 0.1 })
+      await host.fire() // verify passes (no checker) → succeeded
+      expect(store.getRun(run.id)?.status).toBe('succeeded')
+
+      expect(controller.abortRun(run.id)).toBe(false)
+      expect(store.getRun(run.id)?.status).toBe('succeeded')
+    })
+
+    it('marks a persisted-but-inactive run aborted without a session stop', () => {
+      const run = store.createRun(input(spec()))
+      store.patchRun(run.id, { status: 'running' })
+
+      const aborted = controller.abortRun(run.id)
+      expect(aborted).toBe(true)
+      expect(store.getRun(run.id)?.status).toBe('aborted')
+      expect(host.stopped).toHaveLength(0)
+    })
+  })
 })
 
 describe('parseCheckerVerdict', () => {

--- a/server/goal-run-controller.test.ts
+++ b/server/goal-run-controller.test.ts
@@ -1,0 +1,190 @@
+/** Tests for GoalRunController — drives the loop with a fake session host + verifier and asserts state transitions and the evidence ledger. */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { GoalRunController, type SessionHost, type VerifierApi } from './goal-run-controller.js'
+import { GoalRunStore, type CreateGoalRunInput, type GoalRunSpec } from './goal-run-store.js'
+import type { VerifyResult } from './verifier-runner.js'
+
+const PASS: VerifyResult = { passed: true, results: [{ command: 'npm test', exitCode: 0, outputTail: 'ok', durationMs: 1, timedOut: false }] }
+const FAIL: VerifyResult = { passed: false, results: [{ command: 'npm test', exitCode: 1, outputTail: 'FAIL a.test', durationMs: 1, timedOut: false }] }
+
+/** Flush the controller's resolved-promise async chain. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0))
+}
+
+class FakeHost implements SessionHost {
+  outputHistory: { type: string; data?: string; costUsd?: number }[] = []
+  sent: string[] = []
+  stopped: string[] = []
+  worktreePath = '/wt/feat'
+  private listener: ((sessionId: string, isError: boolean) => void) | null = null
+  private nextId = 1
+  lastSessionId = ''
+
+  create(): { id: string } {
+    this.lastSessionId = `sess-${this.nextId++}`
+    return { id: this.lastSessionId }
+  }
+  createWorktree(): Promise<string | null> {
+    return Promise.resolve(this.worktreePath)
+  }
+  startClaude(): boolean {
+    return true
+  }
+  sendInput(_sessionId: string, data: string): void {
+    this.sent.push(data)
+  }
+  stopClaude(sessionId: string): void {
+    this.stopped.push(sessionId)
+  }
+  get(): { outputHistory: { type: string; data?: string; costUsd?: number }[]; worktreePath?: string } {
+    return { outputHistory: this.outputHistory, worktreePath: this.worktreePath }
+  }
+  onSessionResult(listener: (sessionId: string, isError: boolean) => void): () => void {
+    this.listener = listener
+    return () => {
+      this.listener = null
+    }
+  }
+  /** Simulate a maker turn ending. */
+  async fire(isError = false): Promise<void> {
+    this.listener?.(this.lastSessionId, isError)
+    await flush()
+  }
+}
+
+class FakeVerifier implements VerifierApi {
+  changed: string[] = ['src/a.ts']
+  diff = 'src/a.ts | 2 +-'
+  queue: VerifyResult[] = []
+  fallback: VerifyResult = PASS
+  runVerifier(): Promise<VerifyResult> {
+    return Promise.resolve(this.queue.shift() ?? this.fallback)
+  }
+  getDiffSummary(): Promise<string> {
+    return Promise.resolve(this.diff)
+  }
+  getChangedFiles(): Promise<string[]> {
+    return Promise.resolve(this.changed)
+  }
+}
+
+function spec(overrides: Partial<GoalRunSpec> = {}): GoalRunSpec {
+  return {
+    maker: { provider: 'claude' },
+    checker: null,
+    verify: ['npm test'],
+    readonly: ['.github/workflows/**'],
+    maxTurns: 12,
+    maxCostUsd: 5,
+    completionPolicy: 'pr',
+    ...overrides,
+  }
+}
+
+function input(s: GoalRunSpec): CreateGoalRunInput {
+  return { kind: 'ci-autorepair', goal: 'make checks pass', spec: s, repo: '/repo', branch: 'fix/ci' }
+}
+
+describe('GoalRunController', () => {
+  let store: GoalRunStore
+  let host: FakeHost
+  let verifier: FakeVerifier
+  let controller: GoalRunController
+
+  beforeEach(() => {
+    store = new GoalRunStore(':memory:')
+    host = new FakeHost()
+    verifier = new FakeVerifier()
+    controller = new GoalRunController(host, store, verifier)
+  })
+
+  afterEach(() => {
+    store.close()
+  })
+
+  it('spawns a maker in a worktree and sends the goal prompt', async () => {
+    const run = await controller.startRun(input(spec()))
+    expect(run.status).toBe('running')
+    expect(run.makerSessionId).toBe('sess-1')
+    expect(host.sent[0]).toContain('# Goal Run: ci-autorepair')
+    expect(host.sent[0]).toContain('make checks pass')
+  })
+
+  it('finalizes as succeeded when the verifier passes', async () => {
+    const run = await controller.startRun(input(spec()))
+    await host.fire()
+    const updated = store.getRun(run.id)
+    expect(updated?.status).toBe('succeeded')
+    expect(updated?.completedAt).toBeTruthy()
+    // a finalize (push + PR) instruction was sent
+    expect(host.sent.some((s) => s.includes('open a pull request'))).toBe(true)
+    // evidence ledger has a verifier row that passed
+    const turns = store.listTurns(run.id)
+    expect(turns.some((t) => t.role === 'verifier' && t.exitCode === 0)).toBe(true)
+    expect(controller.activeRunIds()).toHaveLength(0)
+  })
+
+  it('feeds a verify failure back to the maker, then succeeds on the next turn', async () => {
+    verifier.queue = [FAIL]
+    const run = await controller.startRun(input(spec()))
+
+    await host.fire() // turn 1 → fail
+    expect(store.getRun(run.id)?.status).toBe('running')
+    expect(host.sent.some((s) => s.includes('Verification failed'))).toBe(true)
+
+    verifier.diff = 'src/a.ts | 5 +++--' // diff changed so verify re-runs (debounce miss)
+    await host.fire() // turn 2 → pass (fallback)
+    expect(store.getRun(run.id)?.status).toBe('succeeded')
+    const failingTurn = store.listTurns(run.id).find((t) => t.role === 'verifier' && t.exitCode === 1)
+    expect(failingTurn?.outputTail).toContain('FAIL a.test')
+  })
+
+  it('fails the run when the turn budget is exhausted', async () => {
+    verifier.fallback = FAIL
+    const run = await controller.startRun(input(spec({ maxTurns: 2 })))
+
+    verifier.diff = 'd1'
+    await host.fire() // turn 1 → fail, re-prompt
+    expect(store.getRun(run.id)?.status).toBe('running')
+
+    verifier.diff = 'd2'
+    await host.fire() // turn 2 → budget exhausted
+    const updated = store.getRun(run.id)
+    expect(updated?.status).toBe('failed')
+    expect(updated?.turnCount).toBe(2)
+    expect(host.stopped).toContain('sess-1')
+  })
+
+  it('fails immediately when the cost budget is exceeded', async () => {
+    const run = await controller.startRun(input(spec({ maxCostUsd: 5 })))
+    host.outputHistory.push({ type: 'usage', costUsd: 6 })
+    await host.fire()
+    const updated = store.getRun(run.id)
+    expect(updated?.status).toBe('failed')
+    expect(updated?.costUsd).toBe(6)
+  })
+
+  it('re-prompts on readonly violations and escalates after repeated strikes', async () => {
+    verifier.changed = ['.github/workflows/ci.yml']
+    const run = await controller.startRun(input(spec({ maxTurns: 20 })))
+
+    await host.fire() // strike 1
+    await host.fire() // strike 2
+    expect(store.getRun(run.id)?.status).toBe('running')
+    expect(host.sent.filter((s) => s.includes('protected files')).length).toBe(2)
+
+    await host.fire() // strike 3 → escalate
+    const updated = store.getRun(run.id)
+    expect(updated?.status).toBe('awaiting_human')
+    expect(host.stopped).toContain('sess-1')
+  })
+
+  it('nudges and stays running when no files changed yet', async () => {
+    verifier.changed = []
+    const run = await controller.startRun(input(spec()))
+    await host.fire()
+    expect(store.getRun(run.id)?.status).toBe('running')
+    expect(host.sent.some((s) => s.includes('No file changes detected'))).toBe(true)
+  })
+})

--- a/server/goal-run-controller.ts
+++ b/server/goal-run-controller.ts
@@ -39,6 +39,7 @@ import {
   type VerifyResult,
 } from './verifier-runner.js'
 import { matchesAnyGlob } from './glob-match.js'
+import { defaultFinalizer, type FinalizerApi } from './goal-run-finalizer.js'
 
 // ---------------------------------------------------------------------------
 // Injected dependencies
@@ -125,6 +126,7 @@ export class GoalRunController {
     private readonly host: SessionHost,
     private readonly store: GoalRunStore,
     private readonly verifier: VerifierApi = defaultVerifier,
+    private readonly finalizer: FinalizerApi = defaultFinalizer,
   ) {}
 
   /** Create and start a goal run. Resolves once the maker has been kicked off. */
@@ -310,7 +312,7 @@ export class GoalRunController {
    */
   private async onVerifyPassed(ctx: RunCtx, run: GoalRun): Promise<void> {
     if (!run.spec.checker) {
-      this.finalizeSucceeded(ctx, run)
+      await this.finalizeSucceeded(ctx, run)
       return
     }
     await this.startChecker(ctx, run, run.spec.checker)
@@ -335,7 +337,7 @@ export class GoalRunController {
     this.store.patchRun(run.id, { status: 'checking', checkerSessionId: session.id })
     ctx.checkerDispose = this.host.onSessionResult((sid, isError) => {
       if (sid !== ctx.checkerSessionId) return
-      this.onCheckerResult(ctx, isError)
+      void this.onCheckerResult(ctx, isError)
     })
     this.host.startClaude(session.id)
     this.host.sendInput(session.id, buildCheckerPrompt(run, diff))
@@ -347,7 +349,7 @@ export class GoalRunController {
    * notes back to the maker and resume the loop; escalate or an unparseable
    * verdict → human checkpoint.
    */
-  private onCheckerResult(ctx: RunCtx, isError: boolean): void {
+  private async onCheckerResult(ctx: RunCtx, isError: boolean): Promise<void> {
     if (ctx.checkerProcessing) return
     ctx.checkerProcessing = true
     try {
@@ -379,7 +381,7 @@ export class GoalRunController {
         return
       }
       if (parsed.verdict === 'approve') {
-        this.finalizeSucceeded(ctx, run)
+        await this.finalizeSucceeded(ctx, run)
         return
       }
       if (parsed.verdict === 'escalate') {
@@ -394,17 +396,31 @@ export class GoalRunController {
     }
   }
 
-  private finalizeSucceeded(ctx: RunCtx, run: GoalRun): void {
-    this.host.sendInput(ctx.makerSessionId, buildFinalizePrompt(run.spec))
+  /**
+   * Verification passed: land the verified tree deterministically rather than
+   * trusting the maker to commit/push/PR. The maker is stopped (its work is done),
+   * Codekin commits the verified tree and — per completion policy — pushes and
+   * opens a PR. A push/PR failure does not fail the run (verification passed); the
+   * outcome is recorded in the ledger and `prUrl` left null.
+   */
+  private async finalizeSucceeded(ctx: RunCtx, run: GoalRun): Promise<void> {
+    this.host.stopClaude(ctx.makerSessionId)
+    const { prUrl, note } = await this.finalizer.finalize({
+      cwd: ctx.cwd,
+      branch: run.branch,
+      policy: run.spec.completionPolicy,
+      title: buildPrTitle(run),
+      body: buildPrBody(run),
+    })
     this.store.appendTurn({
       runId: run.id,
       turnIndex: ctx.turnCount,
       role: 'maker',
       diffSummary: ctx.lastDiff,
-      outputTail: 'Verification passed; finalize instruction sent.',
+      outputTail: note,
       costUsd: totalCost(ctx),
     })
-    this.store.patchRun(run.id, { status: 'succeeded', completedAt: new Date().toISOString() })
+    this.store.patchRun(run.id, { status: 'succeeded', prUrl, completedAt: new Date().toISOString() })
     this.teardown(ctx)
   }
 
@@ -508,14 +524,21 @@ export function buildReadonlyFeedback(violations: string[], readonly: string[]):
   ].join('\n')
 }
 
-export function buildFinalizePrompt(spec: GoalRunSpec): string {
-  if (spec.completionPolicy === 'pr') {
-    return 'Verification passed. Commit your changes, push the branch, and open a pull request with a clear summary of what changed and why. Do not merge it.'
-  }
-  if (spec.completionPolicy === 'merge') {
-    return 'Verification passed. Commit your changes and push the branch to the remote. Do not open a pull request.'
-  }
-  return 'Verification passed. Commit your changes locally. Do not push or open a pull request.'
+export function buildPrTitle(run: GoalRun): string {
+  const firstLine = run.goal.split('\n')[0].trim()
+  return firstLine ? `${run.kind}: ${firstLine}` : `${run.kind} (GoalRun)`
+}
+
+export function buildPrBody(run: GoalRun): string {
+  const lines = [
+    run.goal.trim(),
+    '',
+    '## Verification',
+    ...run.spec.verify.map((c) => `- \`${c}\``),
+    '',
+    `Opened automatically by a Codekin GoalRun (\`${run.kind}\`). Do not merge without review.`,
+  ]
+  return lines.join('\n')
 }
 
 /** Concatenate the assistant's text output from a session's history. */

--- a/server/goal-run-controller.ts
+++ b/server/goal-run-controller.ts
@@ -1,0 +1,370 @@
+/**
+ * GoalRunController — the loop engine (Cut 1, single-provider).
+ *
+ * Drives a durable act → verify → continue/stop loop around an existing coding
+ * session:
+ *
+ *   1. spawn a maker session in an isolated worktree on the run's branch
+ *   2. send the goal prompt
+ *   3. on each maker turn (onSessionResult):
+ *        - update turn/cost budgets; stop with `failed` if exhausted
+ *        - enforce readonly-glob constraints against the diff
+ *        - run the deterministic verifier (debounced to changed diffs)
+ *        - verify fails  → feed the failure back as the next turn
+ *        - verify passes → finalize (completion policy 'pr'; never auto-merge)
+ *
+ * The maker–checker review pass (Cut 2) plugs in at the single seam marked
+ * `onVerifyPassed` — when a checker provider is configured, that hook will spawn
+ * a second-provider session on the maker's branch and route its verdict. Until
+ * then, a passing verifier finalizes directly.
+ *
+ * Dependencies (SessionHost, VerifierApi) are injected so the loop logic is
+ * unit-testable without spawning a real Claude process or touching git.
+ */
+
+import {
+  GoalRunStore,
+  type CreateGoalRunInput,
+  type GoalRun,
+  type GoalRunSpec,
+  type LoopProvider,
+} from './goal-run-store.js'
+import {
+  runVerifier,
+  getDiffSummary,
+  getChangedFiles,
+  type VerifyResult,
+} from './verifier-runner.js'
+import { matchesAnyGlob } from './glob-match.js'
+
+// ---------------------------------------------------------------------------
+// Injected dependencies
+// ---------------------------------------------------------------------------
+
+interface CreateOpts {
+  provider?: LoopProvider
+  model?: string
+  source?: 'agent'
+}
+
+interface HistoryMsg {
+  type: string
+  data?: string
+  costUsd?: number
+}
+
+interface SessionView {
+  outputHistory: HistoryMsg[]
+  worktreePath?: string
+}
+
+/** The slice of SessionManager the controller depends on. */
+export interface SessionHost {
+  create(name: string, workingDir: string, options?: CreateOpts): { id: string }
+  createWorktree(sessionId: string, workingDir: string, targetBranch?: string, baseBranch?: string): Promise<string | null>
+  startClaude(sessionId: string): boolean
+  sendInput(sessionId: string, data: string): void
+  stopClaude(sessionId: string): void
+  get(sessionId: string): SessionView | undefined
+  onSessionResult(listener: (sessionId: string, isError: boolean) => void): () => void
+}
+
+/** The verifier surface — defaults to the real implementations. */
+export interface VerifierApi {
+  runVerifier(opts: { cwd: string; commands: string[] }): Promise<VerifyResult>
+  getDiffSummary(cwd: string): Promise<string>
+  getChangedFiles(cwd: string): Promise<string[]>
+}
+
+const defaultVerifier: VerifierApi = { runVerifier, getDiffSummary, getChangedFiles }
+
+/** Max consecutive readonly-glob violations before escalating to a human. */
+const MAX_READONLY_STRIKES = 2
+
+// ---------------------------------------------------------------------------
+// Per-run runtime context (not persisted — rebuilt from the store on restart)
+// ---------------------------------------------------------------------------
+
+interface RunCtx {
+  runId: string
+  makerSessionId: string
+  cwd: string
+  turnCount: number
+  costUsd: number
+  /** Diff stat at the last verify, used to debounce re-running the verifier. */
+  lastDiff: string | null
+  lastVerifyPassed: boolean
+  readonlyStrikes: number
+  /** Re-entrancy guard — one result is processed at a time per run. */
+  processing: boolean
+  dispose: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Controller
+// ---------------------------------------------------------------------------
+
+export class GoalRunController {
+  private active = new Map<string, RunCtx>()
+
+  constructor(
+    private readonly host: SessionHost,
+    private readonly store: GoalRunStore,
+    private readonly verifier: VerifierApi = defaultVerifier,
+  ) {}
+
+  /** Create and start a goal run. Resolves once the maker has been kicked off. */
+  async startRun(input: CreateGoalRunInput): Promise<GoalRun> {
+    const run = this.store.createRun(input)
+    const session = this.host.create(`goal:${run.kind}:${run.branch}`, run.repo, {
+      provider: run.spec.maker.provider,
+      model: run.spec.maker.model,
+      source: 'agent',
+    })
+    const worktree = await this.host.createWorktree(session.id, run.repo, run.branch)
+    const cwd = worktree ?? run.repo
+
+    this.store.patchRun(run.id, { status: 'running', makerSessionId: session.id })
+
+    const ctx: RunCtx = {
+      runId: run.id,
+      makerSessionId: session.id,
+      cwd,
+      turnCount: 0,
+      costUsd: 0,
+      lastDiff: null,
+      lastVerifyPassed: false,
+      readonlyStrikes: 0,
+      processing: false,
+      dispose: () => {},
+    }
+    ctx.dispose = this.host.onSessionResult((sid, isError) => {
+      if (sid !== ctx.makerSessionId) return
+      void this.onMakerResult(ctx, isError)
+    })
+    this.active.set(run.id, ctx)
+
+    this.host.startClaude(session.id)
+    this.host.sendInput(session.id, buildMakerPrompt(run))
+    return this.store.getRun(run.id) ?? run
+  }
+
+  /** Currently-tracked active run ids (test/introspection aid). */
+  activeRunIds(): string[] {
+    return [...this.active.keys()]
+  }
+
+  private async onMakerResult(ctx: RunCtx, isError: boolean): Promise<void> {
+    if (ctx.processing) return
+    ctx.processing = true
+    try {
+      const run = this.store.getRun(ctx.runId)
+      if (!run || !this.active.has(ctx.runId)) return
+
+      ctx.turnCount += 1
+      ctx.costUsd = readCumulativeCost(this.host.get(ctx.makerSessionId)?.outputHistory ?? [])
+      this.store.patchRun(run.id, { turnCount: ctx.turnCount, costUsd: ctx.costUsd })
+
+      // A process-level error ends the turn with nothing to verify — treat a
+      // failed result as a maker error and re-prompt within budget.
+      if (isError) {
+        if (this.budgetExhausted(ctx, run.spec)) {
+          this.finalizeFailed(ctx, 'maker session errored and budget is exhausted')
+          return
+        }
+        this.host.sendInput(ctx.makerSessionId, 'The previous turn ended with an error. Review the goal and continue.')
+        this.store.patchRun(run.id, { status: 'running' })
+        return
+      }
+
+      if (this.budgetExhausted(ctx, run.spec)) {
+        this.finalizeFailed(ctx, budgetReason(ctx, run.spec))
+        return
+      }
+
+      const changedFiles = await this.verifier.getChangedFiles(ctx.cwd)
+      const diffSummary = await this.verifier.getDiffSummary(ctx.cwd)
+
+      // Readonly enforcement: a touched protected path re-prompts the maker, and
+      // repeated violations escalate rather than spin against the budget.
+      const readonlyGlobs = run.spec.readonly ?? []
+      const violations = readonlyGlobs.length
+        ? changedFiles.filter((f) => matchesAnyGlob(f, readonlyGlobs))
+        : []
+      if (violations.length) {
+        this.store.appendTurn({
+          runId: run.id,
+          turnIndex: ctx.turnCount,
+          role: 'maker',
+          diffSummary,
+          outputTail: `Readonly violation: ${violations.join(', ')}`,
+          costUsd: ctx.costUsd,
+        })
+        ctx.readonlyStrikes += 1
+        if (ctx.readonlyStrikes > MAX_READONLY_STRIKES) {
+          this.finalizeEscalated(ctx, `repeatedly modified readonly paths: ${violations.join(', ')}`)
+          return
+        }
+        this.host.sendInput(ctx.makerSessionId, buildReadonlyFeedback(violations, readonlyGlobs))
+        this.store.patchRun(run.id, { status: 'running' })
+        return
+      }
+      ctx.readonlyStrikes = 0
+
+      // Nothing changed yet — the maker hasn't produced a fix. Don't let a
+      // clean tree masquerade as success; nudge and continue within budget.
+      if (changedFiles.length === 0) {
+        this.host.sendInput(ctx.makerSessionId, 'No file changes detected yet. Make the changes required to satisfy the goal.')
+        this.store.patchRun(run.id, { status: 'running' })
+        return
+      }
+
+      // Debounce: skip re-running verify when the diff is unchanged since last time.
+      let result: VerifyResult
+      if (diffSummary === ctx.lastDiff) {
+        result = { passed: ctx.lastVerifyPassed, results: [] }
+      } else {
+        this.store.patchRun(run.id, { status: 'verifying' })
+        result = await this.verifier.runVerifier({ cwd: ctx.cwd, commands: run.spec.verify })
+        ctx.lastDiff = diffSummary
+        ctx.lastVerifyPassed = result.passed
+        const failing = result.results.find((r) => r.exitCode !== 0)
+        this.store.appendTurn({
+          runId: run.id,
+          turnIndex: ctx.turnCount,
+          role: 'verifier',
+          diffSummary,
+          verifyCmd: failing?.command ?? result.results[result.results.length - 1].command,
+          exitCode: failing ? failing.exitCode : 0,
+          outputTail: failing?.outputTail ?? null,
+          costUsd: ctx.costUsd,
+        })
+      }
+
+      if (result.passed) {
+        this.onVerifyPassed(ctx, run)
+        return
+      }
+
+      // Verify failed — feed the first failure back to the maker as the next turn.
+      const failing = result.results.find((r) => r.exitCode !== 0)
+      this.host.sendInput(ctx.makerSessionId, buildVerifyFeedback(failing?.command, failing?.outputTail))
+      this.store.patchRun(run.id, { status: 'running' })
+    } finally {
+      ctx.processing = false
+    }
+  }
+
+  /**
+   * Seam for Cut 2 (maker–checker). When `spec.checker` is set, this is where a
+   * second-provider checker session will be spawned on the maker's branch and
+   * its verdict routed (approve → finalize, request_changes → re-prompt maker,
+   * escalate → human). For Cut 1 a passing verifier finalizes directly.
+   */
+  private onVerifyPassed(ctx: RunCtx, run: GoalRun): void {
+    this.host.sendInput(ctx.makerSessionId, buildFinalizePrompt(run.spec))
+    this.store.appendTurn({
+      runId: run.id,
+      turnIndex: ctx.turnCount,
+      role: 'maker',
+      diffSummary: ctx.lastDiff,
+      outputTail: 'Verification passed; finalize instruction sent.',
+      costUsd: ctx.costUsd,
+    })
+    this.store.patchRun(run.id, { status: 'succeeded', completedAt: new Date().toISOString() })
+    this.teardown(ctx)
+  }
+
+  private budgetExhausted(ctx: RunCtx, spec: GoalRunSpec): boolean {
+    return ctx.turnCount >= spec.maxTurns || ctx.costUsd >= spec.maxCostUsd
+  }
+
+  private finalizeFailed(ctx: RunCtx, reason: string): void {
+    this.store.appendTurn({ runId: ctx.runId, turnIndex: ctx.turnCount, role: 'verifier', outputTail: reason, costUsd: ctx.costUsd })
+    this.store.patchRun(ctx.runId, { status: 'failed', completedAt: new Date().toISOString() })
+    this.host.stopClaude(ctx.makerSessionId)
+    this.teardown(ctx)
+  }
+
+  private finalizeEscalated(ctx: RunCtx, reason: string): void {
+    this.store.appendTurn({ runId: ctx.runId, turnIndex: ctx.turnCount, role: 'verifier', outputTail: `Escalated: ${reason}`, costUsd: ctx.costUsd })
+    this.store.patchRun(ctx.runId, { status: 'awaiting_human', completedAt: new Date().toISOString() })
+    this.host.stopClaude(ctx.makerSessionId)
+    this.teardown(ctx)
+  }
+
+  private teardown(ctx: RunCtx): void {
+    ctx.dispose()
+    this.active.delete(ctx.runId)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (pure)
+// ---------------------------------------------------------------------------
+
+/** Latest cumulative session cost from the usage messages in output history. */
+function readCumulativeCost(history: HistoryMsg[]): number {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const m = history[i]
+    if (m.type === 'usage' && typeof m.costUsd === 'number') return m.costUsd
+  }
+  return 0
+}
+
+function budgetReason(ctx: RunCtx, spec: GoalRunSpec): string {
+  if (ctx.turnCount >= spec.maxTurns) return `turn budget exhausted (${ctx.turnCount}/${spec.maxTurns})`
+  return `cost budget exhausted ($${ctx.costUsd.toFixed(2)}/$${spec.maxCostUsd.toFixed(2)})`
+}
+
+export function buildMakerPrompt(run: GoalRun): string {
+  const lines = [
+    `# Goal Run: ${run.kind}`,
+    '',
+    `## Goal`,
+    run.goal,
+    '',
+    `## Verification (these commands must pass)`,
+    ...run.spec.verify.map((c) => `- \`${c}\``),
+  ]
+  if (run.spec.readonly && run.spec.readonly.length) {
+    lines.push('', `## Do NOT modify these paths`, ...run.spec.readonly.map((g) => `- \`${g}\``))
+  }
+  lines.push(
+    '',
+    `## Rules`,
+    `- Work on branch \`${run.branch}\` in this worktree.`,
+    `- Make the smallest change that satisfies the goal. Do not weaken or delete tests to pass verification.`,
+    `- I will run the verification commands after each turn and report failures back to you.`,
+  )
+  return lines.join('\n')
+}
+
+export function buildVerifyFeedback(command: string | undefined, outputTail: string | null | undefined): string {
+  return [
+    `Verification failed.`,
+    command ? `Command: \`${command}\`` : '',
+    outputTail ? `\nOutput:\n${outputTail}` : '',
+    `\nFix the cause and continue. Do not modify tests to make them pass.`,
+  ]
+    .filter(Boolean)
+    .join('\n')
+}
+
+export function buildReadonlyFeedback(violations: string[], readonly: string[]): string {
+  return [
+    `You modified protected files that must not change: ${violations.join(', ')}.`,
+    `Readonly patterns: ${readonly.join(', ')}.`,
+    `Revert those changes and achieve the goal without touching them.`,
+  ].join('\n')
+}
+
+export function buildFinalizePrompt(spec: GoalRunSpec): string {
+  if (spec.completionPolicy === 'pr') {
+    return 'Verification passed. Commit your changes, push the branch, and open a pull request with a clear summary of what changed and why. Do not merge it.'
+  }
+  if (spec.completionPolicy === 'merge') {
+    return 'Verification passed. Commit your changes and push the branch to the remote. Do not open a pull request.'
+  }
+  return 'Verification passed. Commit your changes locally. Do not push or open a pull request.'
+}

--- a/server/goal-run-controller.ts
+++ b/server/goal-run-controller.ts
@@ -172,6 +172,34 @@ export class GoalRunController {
     return [...this.active.keys()]
   }
 
+  /**
+   * Abort a run on user request. An active run has its maker (and any in-flight
+   * checker) stopped and is torn down; a run that is only persisted (e.g. after a
+   * server restart) is marked aborted in the store. Already-terminal runs are
+   * left untouched. Returns true if the run transitioned to `aborted`.
+   */
+  abortRun(runId: string): boolean {
+    const run = this.store.getRun(runId)
+    if (!run) return false
+    const ctx = this.active.get(runId)
+    if (ctx) {
+      this.store.appendTurn({
+        runId,
+        turnIndex: ctx.turnCount,
+        role: 'verifier',
+        outputTail: 'Run aborted by user.',
+        costUsd: totalCost(ctx),
+      })
+      this.host.stopClaude(ctx.makerSessionId)
+      this.store.patchRun(runId, { status: 'aborted', completedAt: new Date().toISOString() })
+      this.teardown(ctx)
+      return true
+    }
+    if (run.status === 'succeeded' || run.status === 'failed' || run.status === 'aborted') return false
+    this.store.patchRun(runId, { status: 'aborted', completedAt: new Date().toISOString() })
+    return true
+  }
+
   private async onMakerResult(ctx: RunCtx, isError: boolean): Promise<void> {
     if (ctx.processing) return
     ctx.processing = true

--- a/server/goal-run-controller.ts
+++ b/server/goal-run-controller.ts
@@ -28,10 +28,13 @@ import {
   type GoalRun,
   type GoalRunSpec,
   type LoopProvider,
+  type ProviderRole,
+  type CheckerVerdict,
 } from './goal-run-store.js'
 import {
   runVerifier,
   getDiffSummary,
+  getDiff,
   getChangedFiles,
   type VerifyResult,
 } from './verifier-runner.js'
@@ -73,13 +76,17 @@ export interface SessionHost {
 export interface VerifierApi {
   runVerifier(opts: { cwd: string; commands: string[] }): Promise<VerifyResult>
   getDiffSummary(cwd: string): Promise<string>
+  getDiff(cwd: string): Promise<string>
   getChangedFiles(cwd: string): Promise<string[]>
 }
 
-const defaultVerifier: VerifierApi = { runVerifier, getDiffSummary, getChangedFiles }
+const defaultVerifier: VerifierApi = { runVerifier, getDiffSummary, getDiff, getChangedFiles }
 
 /** Max consecutive readonly-glob violations before escalating to a human. */
 const MAX_READONLY_STRIKES = 2
+
+/** Max chars of the diff embedded in the checker prompt (rest is truncated). */
+const MAX_CHECKER_DIFF_CHARS = 60_000
 
 // ---------------------------------------------------------------------------
 // Per-run runtime context (not persisted — rebuilt from the store on restart)
@@ -90,14 +97,21 @@ interface RunCtx {
   makerSessionId: string
   cwd: string
   turnCount: number
+  /** Maker session cumulative cost. */
   costUsd: number
+  /** Checker session cumulative cost (summed into the run's total). */
+  checkerCostUsd: number
   /** Diff stat at the last verify, used to debounce re-running the verifier. */
   lastDiff: string | null
   lastVerifyPassed: boolean
   readonlyStrikes: number
-  /** Re-entrancy guard — one result is processed at a time per run. */
+  /** Re-entrancy guard — one maker result is processed at a time per run. */
   processing: boolean
   dispose: () => void
+  /** Live checker session, set only while a maker–checker review is in flight. */
+  checkerSessionId: string | null
+  checkerProcessing: boolean
+  checkerDispose: () => void
 }
 
 // ---------------------------------------------------------------------------
@@ -132,11 +146,15 @@ export class GoalRunController {
       cwd,
       turnCount: 0,
       costUsd: 0,
+      checkerCostUsd: 0,
       lastDiff: null,
       lastVerifyPassed: false,
       readonlyStrikes: 0,
       processing: false,
       dispose: () => {},
+      checkerSessionId: null,
+      checkerProcessing: false,
+      checkerDispose: () => {},
     }
     ctx.dispose = this.host.onSessionResult((sid, isError) => {
       if (sid !== ctx.makerSessionId) return
@@ -163,7 +181,7 @@ export class GoalRunController {
 
       ctx.turnCount += 1
       ctx.costUsd = readCumulativeCost(this.host.get(ctx.makerSessionId)?.outputHistory ?? [])
-      this.store.patchRun(run.id, { turnCount: ctx.turnCount, costUsd: ctx.costUsd })
+      this.store.patchRun(run.id, { turnCount: ctx.turnCount, costUsd: totalCost(ctx) })
 
       // A process-level error ends the turn with nothing to verify — treat a
       // failed result as a maker error and re-prompt within budget.
@@ -242,7 +260,7 @@ export class GoalRunController {
       }
 
       if (result.passed) {
-        this.onVerifyPassed(ctx, run)
+        await this.onVerifyPassed(ctx, run)
         return
       }
 
@@ -256,12 +274,99 @@ export class GoalRunController {
   }
 
   /**
-   * Seam for Cut 2 (maker–checker). When `spec.checker` is set, this is where a
-   * second-provider checker session will be spawned on the maker's branch and
-   * its verdict routed (approve → finalize, request_changes → re-prompt maker,
-   * escalate → human). For Cut 1 a passing verifier finalizes directly.
+   * The deterministic verifier passed. With no checker configured this finalizes
+   * directly (Cut 1). With a `spec.checker`, it hands off to a second-provider
+   * review pass — the verifier is the cheap objective gate; the checker is the
+   * subjective one (does the change actually achieve the goal without gaming the
+   * tests?). Using a *different* provider avoids a model grading its own work.
    */
-  private onVerifyPassed(ctx: RunCtx, run: GoalRun): void {
+  private async onVerifyPassed(ctx: RunCtx, run: GoalRun): Promise<void> {
+    if (!run.spec.checker) {
+      this.finalizeSucceeded(ctx, run)
+      return
+    }
+    await this.startChecker(ctx, run, run.spec.checker)
+  }
+
+  /**
+   * Spawn the checker on its own review branch off the maker's branch. Git forbids
+   * two worktrees on the same branch, and the maker's edits are uncommitted (so a
+   * sibling worktree can't see them) — the diff therefore travels in the prompt,
+   * and the checker reviews read-only.
+   */
+  private async startChecker(ctx: RunCtx, run: GoalRun, checker: ProviderRole): Promise<void> {
+    const diff = await this.verifier.getDiff(ctx.cwd)
+    const session = this.host.create(`goal:${run.kind}:check:${run.branch}`, run.repo, {
+      provider: checker.provider,
+      model: checker.model,
+      source: 'agent',
+    })
+    await this.host.createWorktree(session.id, run.repo, `${run.branch}-review`, run.branch)
+    ctx.checkerSessionId = session.id
+    ctx.checkerProcessing = false
+    this.store.patchRun(run.id, { status: 'checking', checkerSessionId: session.id })
+    ctx.checkerDispose = this.host.onSessionResult((sid, isError) => {
+      if (sid !== ctx.checkerSessionId) return
+      this.onCheckerResult(ctx, isError)
+    })
+    this.host.startClaude(session.id)
+    this.host.sendInput(session.id, buildCheckerPrompt(run, diff))
+  }
+
+  /**
+   * Route the checker's verdict (parsed from its last message — there is no
+   * structured verdict event). approve → finalize; request_changes → feed the
+   * notes back to the maker and resume the loop; escalate or an unparseable
+   * verdict → human checkpoint.
+   */
+  private onCheckerResult(ctx: RunCtx, isError: boolean): void {
+    if (ctx.checkerProcessing) return
+    ctx.checkerProcessing = true
+    try {
+      const run = this.store.getRun(ctx.runId)
+      if (!run || !this.active.has(ctx.runId) || !ctx.checkerSessionId) return
+
+      const history = this.host.get(ctx.checkerSessionId)?.outputHistory ?? []
+      ctx.checkerCostUsd = readCumulativeCost(history)
+      const parsed = isError ? null : parseCheckerVerdict(extractAssistantText(history))
+      const reason = parsed?.reason ?? (isError ? 'checker session errored' : 'unparseable checker verdict')
+
+      this.store.appendTurn({
+        runId: run.id,
+        turnIndex: ctx.turnCount,
+        role: 'checker',
+        diffSummary: ctx.lastDiff,
+        verdict: parsed?.verdict ?? null,
+        outputTail: reason,
+        costUsd: totalCost(ctx),
+      })
+      this.store.patchRun(run.id, {
+        costUsd: totalCost(ctx),
+        verdict: JSON.stringify(parsed ?? { verdict: 'escalate', reason }),
+      })
+      this.disposeChecker(ctx)
+
+      if (!parsed) {
+        this.finalizeEscalated(ctx, reason)
+        return
+      }
+      if (parsed.verdict === 'approve') {
+        this.finalizeSucceeded(ctx, run)
+        return
+      }
+      if (parsed.verdict === 'escalate') {
+        this.finalizeEscalated(ctx, parsed.reason ?? 'checker requested human review')
+        return
+      }
+      // request_changes — feed the reviewer's notes back to the maker and resume.
+      this.host.sendInput(ctx.makerSessionId, buildCheckerFeedback(parsed.reason))
+      this.store.patchRun(run.id, { status: 'running' })
+    } finally {
+      ctx.checkerProcessing = false
+    }
+  }
+
+  private finalizeSucceeded(ctx: RunCtx, run: GoalRun): void {
     this.host.sendInput(ctx.makerSessionId, buildFinalizePrompt(run.spec))
     this.store.appendTurn({
       runId: run.id,
@@ -269,14 +374,24 @@ export class GoalRunController {
       role: 'maker',
       diffSummary: ctx.lastDiff,
       outputTail: 'Verification passed; finalize instruction sent.',
-      costUsd: ctx.costUsd,
+      costUsd: totalCost(ctx),
     })
     this.store.patchRun(run.id, { status: 'succeeded', completedAt: new Date().toISOString() })
     this.teardown(ctx)
   }
 
+  /** Stop the checker session and unregister its listener (idempotent). */
+  private disposeChecker(ctx: RunCtx): void {
+    if (!ctx.checkerSessionId) return
+    this.host.stopClaude(ctx.checkerSessionId)
+    ctx.checkerDispose()
+    ctx.checkerDispose = () => {}
+    ctx.checkerSessionId = null
+    this.store.patchRun(ctx.runId, { checkerSessionId: null })
+  }
+
   private budgetExhausted(ctx: RunCtx, spec: GoalRunSpec): boolean {
-    return ctx.turnCount >= spec.maxTurns || ctx.costUsd >= spec.maxCostUsd
+    return ctx.turnCount >= spec.maxTurns || totalCost(ctx) >= spec.maxCostUsd
   }
 
   private finalizeFailed(ctx: RunCtx, reason: string): void {
@@ -294,6 +409,7 @@ export class GoalRunController {
   }
 
   private teardown(ctx: RunCtx): void {
+    this.disposeChecker(ctx)
     ctx.dispose()
     this.active.delete(ctx.runId)
   }
@@ -312,9 +428,14 @@ function readCumulativeCost(history: HistoryMsg[]): number {
   return 0
 }
 
+/** Run total cost = maker + checker session cumulative cost. */
+function totalCost(ctx: RunCtx): number {
+  return ctx.costUsd + ctx.checkerCostUsd
+}
+
 function budgetReason(ctx: RunCtx, spec: GoalRunSpec): string {
   if (ctx.turnCount >= spec.maxTurns) return `turn budget exhausted (${ctx.turnCount}/${spec.maxTurns})`
-  return `cost budget exhausted ($${ctx.costUsd.toFixed(2)}/$${spec.maxCostUsd.toFixed(2)})`
+  return `cost budget exhausted ($${totalCost(ctx).toFixed(2)}/$${spec.maxCostUsd.toFixed(2)})`
 }
 
 export function buildMakerPrompt(run: GoalRun): string {
@@ -367,4 +488,75 @@ export function buildFinalizePrompt(spec: GoalRunSpec): string {
     return 'Verification passed. Commit your changes and push the branch to the remote. Do not open a pull request.'
   }
   return 'Verification passed. Commit your changes locally. Do not push or open a pull request.'
+}
+
+/** Concatenate the assistant's text output from a session's history. */
+function extractAssistantText(history: HistoryMsg[]): string {
+  let out = ''
+  for (const m of history) {
+    if (m.type === 'output' && typeof m.data === 'string') out += m.data
+  }
+  return out
+}
+
+export interface ParsedVerdict {
+  verdict: CheckerVerdict
+  reason?: string
+}
+
+/**
+ * Parse a checker's free-text reply into a structured verdict. The checker has
+ * no structured verdict event, so it is contracted (via the prompt) to end with
+ * a `VERDICT: <approve|request_changes|escalate>` line. The LAST occurrence wins
+ * so a model that restates the instructions before deciding still resolves to
+ * its final choice. Returns null when no verdict marker is present — the caller
+ * treats that as an escalation rather than a silent pass.
+ */
+export function parseCheckerVerdict(text: string): ParsedVerdict | null {
+  const matches = [...text.matchAll(/VERDICT:\s*(approve|request_changes|escalate)/gi)]
+  if (!matches.length) return null
+  const last = matches[matches.length - 1]
+  const verdict = last[1].toLowerCase() as CheckerVerdict
+  const after = text.slice(last.index + last[0].length)
+  const reasonMatch = after.match(/REASON:\s*(.+)/i)
+  return reasonMatch ? { verdict, reason: reasonMatch[1].trim() } : { verdict }
+}
+
+export function buildCheckerPrompt(run: GoalRun, diff: string): string {
+  const body = diff.length > MAX_CHECKER_DIFF_CHARS ? `${diff.slice(0, MAX_CHECKER_DIFF_CHARS)}\n... [diff truncated]` : diff
+  return [
+    `# Goal Run Review: ${run.kind}`,
+    '',
+    `## Goal`,
+    run.goal,
+    '',
+    `## Deterministic verification`,
+    'These commands already PASSED on this change:',
+    ...run.spec.verify.map((c) => `- \`${c}\``),
+    '',
+    `## Your job`,
+    'Review the diff below as an independent checker. Confirm it genuinely achieves the goal and does NOT:',
+    '- weaken, skip, or delete tests to make verification pass',
+    '- introduce unsafe, incorrect, or out-of-scope changes',
+    'You are reviewing only — do not modify any files.',
+    '',
+    `## Diff`,
+    '```diff',
+    body,
+    '```',
+    '',
+    `## Required response`,
+    'End your reply with exactly one verdict line:',
+    '- `VERDICT: approve` — correct and ready to land',
+    '- `VERDICT: request_changes` then a `REASON:` line stating what must change',
+    '- `VERDICT: escalate` then a `REASON:` line when a human must decide',
+  ].join('\n')
+}
+
+export function buildCheckerFeedback(reason: string | undefined): string {
+  return [
+    'A reviewer assessed your change and requested changes before it can land.',
+    reason ? `Reviewer feedback: ${reason}` : 'The reviewer did not approve the change.',
+    'Address the feedback and continue. Do not weaken tests to satisfy verification.',
+  ].join('\n')
 }

--- a/server/goal-run-finalizer.test.ts
+++ b/server/goal-run-finalizer.test.ts
@@ -1,0 +1,112 @@
+/** Tests for the GoalRun finalizer — stubs the git/gh runners and asserts the
+ * deterministic commit/push/PR sequence per completion policy, plus graceful
+ * failure handling (verification already passed, so finalization never throws). */
+import { describe, it, expect, afterEach } from 'vitest'
+import { defaultFinalizer, _setFinalizerRunners, _resetFinalizerRunners, type FinalizeOptions } from './goal-run-finalizer.js'
+
+afterEach(() => {
+  _resetFinalizerRunners()
+})
+
+type Call = { args: string[]; cwd: string }
+
+/** Wire stub runners, recording every git/gh invocation. */
+function wire(opts: {
+  status?: string
+  git?: (args: string[]) => Promise<string>
+  gh?: (args: string[]) => Promise<string>
+}): { git: Call[]; gh: Call[] } {
+  const git: Call[] = []
+  const gh: Call[] = []
+  _setFinalizerRunners(
+    (args, cwd) => {
+      git.push({ args, cwd })
+      if (opts.git) return opts.git(args)
+      if (args[0] === 'status') return Promise.resolve(opts.status ?? '')
+      return Promise.resolve('')
+    },
+    (args, cwd) => {
+      gh.push({ args, cwd })
+      if (opts.gh) return opts.gh(args)
+      return Promise.resolve('https://github.com/acme/repo/pull/42\n')
+    },
+  )
+  return { git, gh }
+}
+
+const base: FinalizeOptions = { cwd: '/wt/feat', branch: 'fix/ci', policy: 'pr', title: 'fix ci', body: 'body' }
+
+describe('defaultFinalizer', () => {
+  it('commits a dirty tree, pushes, opens a PR and captures the url (policy=pr)', async () => {
+    const rec = wire({ status: ' M src/a.ts\n' })
+    const res = await defaultFinalizer.finalize(base)
+
+    expect(res.prUrl).toBe('https://github.com/acme/repo/pull/42')
+    expect(res.note).toContain('opened PR')
+    expect(rec.git.map((c) => c.args)).toEqual([
+      ['status', '--porcelain'],
+      ['add', '-A'],
+      ['commit', '-m', 'fix ci'],
+      ['push', '-u', 'origin', 'fix/ci'],
+    ])
+    expect(rec.gh[0].args).toEqual(['pr', 'create', '--head', 'fix/ci', '--title', 'fix ci', '--body', 'body'])
+    expect(rec.gh[0].cwd).toBe('/wt/feat')
+  })
+
+  it('skips the commit when the tree is clean', async () => {
+    const rec = wire({ status: '   \n' })
+    await defaultFinalizer.finalize(base)
+    expect(rec.git.map((c) => c.args[0])).toEqual(['status', 'push'])
+  })
+
+  it('commits locally without pushing for policy=commit-only', async () => {
+    const rec = wire({ status: ' M src/a.ts\n' })
+    const res = await defaultFinalizer.finalize({ ...base, policy: 'commit-only' })
+    expect(res.prUrl).toBeNull()
+    expect(res.note).toContain('committed locally')
+    expect(rec.git.map((c) => c.args[0])).toEqual(['status', 'add', 'commit'])
+    expect(rec.gh).toHaveLength(0)
+  })
+
+  it('pushes without opening a PR for policy=merge', async () => {
+    const rec = wire({ status: ' M src/a.ts\n' })
+    const res = await defaultFinalizer.finalize({ ...base, policy: 'merge' })
+    expect(res.prUrl).toBeNull()
+    expect(res.note).toContain('pushed branch fix/ci')
+    expect(rec.gh).toHaveLength(0)
+  })
+
+  it('records a failure note (and never throws) when the push fails', async () => {
+    const rec = wire({
+      status: ' M src/a.ts\n',
+      git: (args) => (args[0] === 'push' ? Promise.reject(new Error('no upstream')) : Promise.resolve('')),
+    })
+    const res = await defaultFinalizer.finalize(base)
+    expect(res.prUrl).toBeNull()
+    expect(res.note).toContain('push failed')
+    expect(rec.gh).toHaveLength(0)
+  })
+
+  it('recovers an already-open PR url when create reports it exists', async () => {
+    wire({
+      status: ' M src/a.ts\n',
+      gh: (args) =>
+        args[1] === 'create'
+          ? Promise.reject(new Error('a pull request already exists'))
+          : Promise.resolve('https://github.com/acme/repo/pull/7\n'),
+    })
+    const res = await defaultFinalizer.finalize(base)
+    expect(res.prUrl).toBe('https://github.com/acme/repo/pull/7')
+    expect(res.note).toContain('already open')
+  })
+
+  it('reports PR creation failure when no existing PR can be recovered', async () => {
+    wire({
+      status: ' M src/a.ts\n',
+      gh: () => Promise.reject(new Error('gh not authenticated')),
+    })
+    const res = await defaultFinalizer.finalize(base)
+    expect(res.prUrl).toBeNull()
+    expect(res.note).toContain('PR creation failed')
+  })
+})

--- a/server/goal-run-finalizer.ts
+++ b/server/goal-run-finalizer.ts
@@ -1,0 +1,141 @@
+/**
+ * Deterministic finalization for a verified GoalRun.
+ *
+ * When the deterministic verifier passes, Codekin — not the maker agent — lands
+ * the verified tree. We commit any uncommitted changes (so what passed
+ * verification is exactly what ships), then, per the completion policy, push the
+ * branch and open a pull request, capturing the PR URL.
+ *
+ * Push / PR failures are *reported* in the returned note but never thrown:
+ * verification already passed, so the run still succeeds — the branch is sitting
+ * locally and a human can push it by hand. The controller surfaces the note in
+ * the evidence ledger and leaves `prUrl` null so "succeeded but no PR" is visible
+ * rather than silently mistaken for "merged-ready".
+ *
+ * All git/gh shell-outs run as fixed argv arrays (no shell interpolation) and are
+ * injectable for tests.
+ */
+
+import { execFile } from 'child_process'
+import { promisify } from 'util'
+import { execGit } from './diff-manager.js'
+import type { CompletionPolicy } from './goal-run-store.js'
+
+const execFileAsync = promisify(execFile)
+const GH_TIMEOUT_MS = 30_000
+
+export interface FinalizeOptions {
+  /** Worktree path the run executed in. */
+  cwd: string
+  /** Branch the maker worked on (the PR head). */
+  branch: string
+  policy: CompletionPolicy
+  /** PR / commit title. */
+  title: string
+  /** PR body (ignored for non-'pr' policies). */
+  body: string
+}
+
+export interface FinalizeResult {
+  /** The opened PR URL, or null when no PR was opened (policy or failure). */
+  prUrl: string | null
+  /** Human-readable outcome recorded in the evidence ledger. */
+  note: string
+}
+
+export interface FinalizerApi {
+  finalize(opts: FinalizeOptions): Promise<FinalizeResult>
+}
+
+type CmdRunner = (args: string[], cwd: string) => Promise<string>
+
+const realGit: CmdRunner = (args, cwd) => execGit(args, cwd)
+const realGh: CmdRunner = async (args, cwd) => {
+  const { stdout } = await execFileAsync('gh', args, { cwd, timeout: GH_TIMEOUT_MS })
+  return stdout
+}
+
+let gitRunner: CmdRunner = realGit
+let ghRunner: CmdRunner = realGh
+
+/** @internal Test-only: override the git/gh runners. */
+export function _setFinalizerRunners(git: CmdRunner, gh: CmdRunner): void {
+  gitRunner = git
+  ghRunner = gh
+}
+
+/** @internal Test-only: restore the real git/gh runners. */
+export function _resetFinalizerRunners(): void {
+  gitRunner = realGit
+  ghRunner = realGh
+}
+
+export const defaultFinalizer: FinalizerApi = {
+  async finalize(opts: FinalizeOptions): Promise<FinalizeResult> {
+    const { cwd, branch, policy, title, body } = opts
+
+    try {
+      await commitIfDirty(cwd, title)
+    } catch (err) {
+      return { prUrl: null, note: `Verification passed; commit failed: ${errMsg(err)}` }
+    }
+
+    if (policy === 'commit-only') {
+      return { prUrl: null, note: 'Verification passed; changes committed locally (no push).' }
+    }
+
+    try {
+      await gitRunner(['push', '-u', 'origin', branch], cwd)
+    } catch (err) {
+      return { prUrl: null, note: `Verification passed; committed but push failed: ${errMsg(err)}` }
+    }
+
+    if (policy === 'merge') {
+      return { prUrl: null, note: `Verification passed; pushed branch ${branch} (no PR).` }
+    }
+
+    // policy === 'pr'
+    try {
+      const out = await ghRunner(['pr', 'create', '--head', branch, '--title', title, '--body', body], cwd)
+      const prUrl = extractPrUrl(out)
+      return prUrl
+        ? { prUrl, note: `Verification passed; opened PR: ${prUrl}` }
+        : { prUrl: null, note: `Verification passed; pushed branch ${branch} (PR URL not parsed).` }
+    } catch (err) {
+      // A PR may already exist for this branch (e.g. a re-run on the same branch);
+      // recover its URL rather than reporting a failure.
+      const existing = await existingPrUrl(branch, cwd)
+      if (existing) return { prUrl: existing, note: `Verification passed; PR already open: ${existing}` }
+      return { prUrl: null, note: `Verification passed; branch pushed but PR creation failed: ${errMsg(err)}` }
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function commitIfDirty(cwd: string, title: string): Promise<void> {
+  const status = await gitRunner(['status', '--porcelain'], cwd)
+  if (!status.trim()) return
+  await gitRunner(['add', '-A'], cwd)
+  await gitRunner(['commit', '-m', title], cwd)
+}
+
+async function existingPrUrl(branch: string, cwd: string): Promise<string | null> {
+  try {
+    const out = await ghRunner(['pr', 'view', branch, '--json', 'url', '-q', '.url'], cwd)
+    return extractPrUrl(out)
+  } catch {
+    return null
+  }
+}
+
+function extractPrUrl(output: string): string | null {
+  const match = output.match(/https?:\/\/\S+\/pull\/\d+/)
+  return match ? match[0] : null
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/server/goal-run-routes.ts
+++ b/server/goal-run-routes.ts
@@ -1,0 +1,135 @@
+/**
+ * REST API routes for Goal Runs (loop runs).
+ *
+ * Mounted at /api/goal-runs/ on the Express app. Exposes the loop templates,
+ * the runs list, a per-run evidence ledger, and start/abort controls. All routes
+ * require the master Bearer token, mirroring the workflow router.
+ *
+ * Endpoints:
+ *   GET  /templates            — list loop templates (built-ins + repo overrides)
+ *   GET  /runs                 — list runs (optional kind/status/limit filters)
+ *   GET  /runs/:id             — a run plus its turn-by-turn evidence ledger
+ *   POST /runs                 — start a run from a template { kind, repo, branch, goal? }
+ *   POST /runs/:id/abort       — abort an in-flight run
+ */
+
+import { Router } from 'express'
+import type { Request, Response } from 'express'
+import { resolveRepoPathInRoot } from './config.js'
+import type { GoalRunKind, GoalRunStatus } from './goal-run-store.js'
+import { GoalRunStore } from './goal-run-store.js'
+import { GoalRunController } from './goal-run-controller.js'
+import { listLoopTemplates, loadLoopTemplate, buildGoalRunInput } from './loop-loader.js'
+
+type VerifyFn = (token: string | undefined) => boolean
+type ExtractFn = (req: Request) => string | undefined
+
+const KINDS: readonly GoalRunKind[] = ['ci-autorepair', 'coverage-increase', 'dependency-upgrade']
+const STATUSES: readonly GoalRunStatus[] = [
+  'queued',
+  'running',
+  'verifying',
+  'checking',
+  'awaiting_human',
+  'succeeded',
+  'failed',
+  'aborted',
+]
+
+interface StartRunBody {
+  kind?: string
+  repo?: string
+  branch?: string
+  goal?: string
+}
+
+export function createGoalRunRouter(
+  verifyToken: VerifyFn,
+  extractToken: ExtractFn,
+  store: GoalRunStore,
+  controller: GoalRunController,
+): Router {
+  const router = Router()
+
+  router.use((req: Request, res: Response, next: () => void) => {
+    if (!verifyToken(extractToken(req))) {
+      res.status(401).json({ error: 'Unauthorized' })
+      return
+    }
+    next()
+  })
+
+  // -------------------------------------------------------------------------
+  // Templates
+  // -------------------------------------------------------------------------
+
+  router.get('/templates', (req, res) => {
+    const repoPath = req.query.repoPath as string | undefined
+    const resolved = repoPath ? resolveRepoPathInRoot(repoPath) : undefined
+    if (repoPath && !resolved) {
+      return res.status(400).json({ error: 'Invalid repoPath: must be an existing directory under the configured repos root' })
+    }
+    res.json({ templates: listLoopTemplates(resolved || undefined) })
+  })
+
+  // -------------------------------------------------------------------------
+  // Runs
+  // -------------------------------------------------------------------------
+
+  router.get('/runs', (req, res) => {
+    const kind = typeof req.query.kind === 'string' ? req.query.kind : undefined
+    const status = typeof req.query.status === 'string' ? req.query.status : undefined
+    const limit = typeof req.query.limit === 'string' ? req.query.limit : undefined
+    if (kind && !KINDS.includes(kind as GoalRunKind)) {
+      return res.status(400).json({ error: `Invalid kind: ${kind}` })
+    }
+    if (status && !STATUSES.includes(status as GoalRunStatus)) {
+      return res.status(400).json({ error: `Invalid status: ${status}` })
+    }
+    const runs = store.listRuns({
+      kind: kind as GoalRunKind | undefined,
+      status: status as GoalRunStatus | undefined,
+      limit: limit ? Math.min(Math.max(parseInt(limit, 10) || 50, 1), 500) : 50,
+    })
+    res.json({ runs })
+  })
+
+  router.get('/runs/:id', (req, res) => {
+    const run = store.getRun(req.params.id)
+    if (!run) return res.status(404).json({ error: 'Run not found' })
+    res.json({ run: { ...run, turns: store.listTurns(run.id) } })
+  })
+
+  router.post('/runs', async (req: Request<Record<string, string>, unknown, StartRunBody>, res) => {
+    const { kind, repo, branch, goal } = req.body
+    if (!kind || !KINDS.includes(kind as GoalRunKind)) {
+      return res.status(400).json({ error: `Missing or invalid kind (expected one of ${KINDS.join(', ')})` })
+    }
+    if (!repo || !branch) {
+      return res.status(400).json({ error: 'Missing required fields: repo, branch' })
+    }
+    const resolvedRepo = resolveRepoPathInRoot(repo)
+    if (!resolvedRepo) {
+      return res.status(400).json({ error: 'Invalid repo: must be an existing directory under the configured repos root' })
+    }
+
+    const template = loadLoopTemplate(kind as GoalRunKind, resolvedRepo)
+    if (!template) return res.status(404).json({ error: `No loop template found for kind: ${kind}` })
+
+    try {
+      const input = buildGoalRunInput(template, { repo: resolvedRepo, branch, goal })
+      const run = await controller.startRun(input)
+      res.json({ run })
+    } catch (err) {
+      res.status(400).json({ error: err instanceof Error ? err.message : 'Failed to start run' })
+    }
+  })
+
+  router.post('/runs/:id/abort', (req, res) => {
+    const aborted = controller.abortRun(req.params.id)
+    if (!aborted) return res.status(404).json({ error: 'Run not found or already finished' })
+    res.json({ success: true })
+  })
+
+  return router
+}

--- a/server/goal-run-store.test.ts
+++ b/server/goal-run-store.test.ts
@@ -1,0 +1,157 @@
+/** Tests for GoalRunStore — verifies run CRUD, spec (de)serialization, patching, and the turn evidence ledger against a real in-memory SQLite DB. */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { GoalRunStore, type CreateGoalRunInput, type GoalRunSpec } from './goal-run-store.js'
+
+const baseSpec: GoalRunSpec = {
+  maker: { provider: 'claude', model: 'sonnet' },
+  checker: { provider: 'opencode' },
+  verify: ['npm test', 'npm run lint'],
+  readonly: ['.github/workflows/**', 'tests/security/**'],
+  maxTurns: 12,
+  maxCostUsd: 5,
+  completionPolicy: 'pr',
+}
+
+function makeInput(overrides: Partial<CreateGoalRunInput> = {}): CreateGoalRunInput {
+  return {
+    kind: 'ci-autorepair',
+    goal: 'All failing checks pass without weakening tests',
+    spec: baseSpec,
+    repo: '/srv/repos/example',
+    branch: 'fix/ci',
+    ...overrides,
+  }
+}
+
+describe('GoalRunStore', () => {
+  let store: GoalRunStore
+
+  beforeEach(() => {
+    store = new GoalRunStore(':memory:')
+  })
+
+  afterEach(() => {
+    store.close()
+  })
+
+  describe('createRun / getRun', () => {
+    it('round-trips a run including the parsed spec', () => {
+      const created = store.createRun(makeInput())
+      expect(created.id).toBeTruthy()
+      expect(created.status).toBe('queued')
+      expect(created.turnCount).toBe(0)
+      expect(created.costUsd).toBe(0)
+      expect(created.makerSessionId).toBeNull()
+      expect(created.completedAt).toBeNull()
+
+      const fetched = store.getRun(created.id)
+      expect(fetched).not.toBeNull()
+      expect(fetched?.spec).toEqual(baseSpec)
+      expect(fetched?.spec.maker.provider).toBe('claude')
+      expect(fetched?.spec.checker?.provider).toBe('opencode')
+      expect(fetched?.goal).toBe('All failing checks pass without weakening tests')
+    })
+
+    it('honours a caller-supplied id', () => {
+      const created = store.createRun(makeInput({ id: 'fixed-id' }))
+      expect(created.id).toBe('fixed-id')
+    })
+
+    it('returns null for an unknown id', () => {
+      expect(store.getRun('nope')).toBeNull()
+    })
+
+    it('supports a single-provider spec with no checker', () => {
+      const spec: GoalRunSpec = { ...baseSpec, checker: null }
+      const created = store.createRun(makeInput({ spec }))
+      expect(store.getRun(created.id)?.spec.checker).toBeNull()
+    })
+  })
+
+  describe('listRuns', () => {
+    it('returns newest first and filters by status and kind', () => {
+      const a = store.createRun(makeInput({ branch: 'a' }))
+      const b = store.createRun(makeInput({ kind: 'coverage-increase', branch: 'b' }))
+      store.patchRun(b.id, { status: 'running' })
+
+      const all = store.listRuns()
+      expect(all.map((r) => r.id)).toEqual([b.id, a.id]) // newest first
+
+      const running = store.listRuns({ status: 'running' })
+      expect(running.map((r) => r.id)).toEqual([b.id])
+
+      const coverage = store.listRuns({ kind: 'coverage-increase' })
+      expect(coverage.map((r) => r.id)).toEqual([b.id])
+
+      expect(store.listRuns({ limit: 1 })).toHaveLength(1)
+    })
+  })
+
+  describe('patchRun', () => {
+    it('updates whitelisted fields and ignores an empty patch', () => {
+      const run = store.createRun(makeInput())
+      store.patchRun(run.id, {
+        status: 'running',
+        makerSessionId: 'sess-1',
+        turnCount: 3,
+        costUsd: 1.25,
+        verdict: '{"verdict":"request_changes"}',
+      })
+      const updated = store.getRun(run.id)
+      expect(updated?.status).toBe('running')
+      expect(updated?.makerSessionId).toBe('sess-1')
+      expect(updated?.turnCount).toBe(3)
+      expect(updated?.costUsd).toBe(1.25)
+      expect(updated?.verdict).toBe('{"verdict":"request_changes"}')
+
+      // empty patch is a no-op, not an error
+      expect(() => store.patchRun(run.id, {})).not.toThrow()
+      expect(store.getRun(run.id)?.status).toBe('running')
+    })
+
+    it('can null out a session id and set completion', () => {
+      const run = store.createRun(makeInput())
+      store.patchRun(run.id, { makerSessionId: 'sess-1' })
+      store.patchRun(run.id, { makerSessionId: null, status: 'succeeded', completedAt: '2026-06-14T00:00:00Z' })
+      const updated = store.getRun(run.id)
+      expect(updated?.makerSessionId).toBeNull()
+      expect(updated?.status).toBe('succeeded')
+      expect(updated?.completedAt).toBe('2026-06-14T00:00:00Z')
+    })
+  })
+
+  describe('appendTurn / listTurns', () => {
+    it('records the evidence ledger ordered by turn index', () => {
+      const run = store.createRun(makeInput())
+      store.appendTurn({ runId: run.id, turnIndex: 1, role: 'maker', diffSummary: ' src/a.ts | 2 +-' })
+      store.appendTurn({
+        runId: run.id,
+        turnIndex: 2,
+        role: 'verifier',
+        verifyCmd: 'npm test',
+        exitCode: 1,
+        outputTail: 'FAIL src/a.test.ts',
+      })
+      store.appendTurn({ runId: run.id, turnIndex: 3, role: 'checker', verdict: 'request_changes', costUsd: 0.4 })
+
+      const turns = store.listTurns(run.id)
+      expect(turns.map((t) => t.turnIndex)).toEqual([1, 2, 3])
+      expect(turns[1].role).toBe('verifier')
+      expect(turns[1].exitCode).toBe(1)
+      expect(turns[1].verifyCmd).toBe('npm test')
+      expect(turns[2].verdict).toBe('request_changes')
+      expect(turns[2].costUsd).toBe(0.4)
+      // unset optional columns come back as null
+      expect(turns[0].verifyCmd).toBeNull()
+      expect(turns[0].verdict).toBeNull()
+    })
+
+    it('isolates turns by run', () => {
+      const a = store.createRun(makeInput())
+      const b = store.createRun(makeInput({ branch: 'b' }))
+      store.appendTurn({ runId: a.id, turnIndex: 1, role: 'maker' })
+      expect(store.listTurns(b.id)).toHaveLength(0)
+      expect(store.listTurns(a.id)).toHaveLength(1)
+    })
+  })
+})

--- a/server/goal-run-store.test.ts
+++ b/server/goal-run-store.test.ts
@@ -118,6 +118,15 @@ describe('GoalRunStore', () => {
       expect(updated?.status).toBe('succeeded')
       expect(updated?.completedAt).toBe('2026-06-14T00:00:00Z')
     })
+
+    it('round-trips the finalization pr url (defaults null)', () => {
+      const run = store.createRun(makeInput())
+      expect(run.prUrl).toBeNull()
+      store.patchRun(run.id, { status: 'succeeded', prUrl: 'https://github.com/acme/repo/pull/9' })
+      expect(store.getRun(run.id)?.prUrl).toBe('https://github.com/acme/repo/pull/9')
+      store.patchRun(run.id, { prUrl: null })
+      expect(store.getRun(run.id)?.prUrl).toBeNull()
+    })
   })
 
   describe('appendTurn / listTurns', () => {

--- a/server/goal-run-store.ts
+++ b/server/goal-run-store.ts
@@ -1,0 +1,393 @@
+/**
+ * Persistence for Goal Runs — durable, auditable loops attached to a repo.
+ *
+ * A Goal Run wraps a coding session in an act → verify → continue/stop loop with
+ * explicit turn/cost budgets, file constraints, and (in maker–checker mode) a
+ * second-provider review pass. This store owns two tables:
+ *
+ *   goal_runs       — one row per loop execution (goal, spec, budgets, status).
+ *   goal_run_turns  — the evidence ledger: one row per maker/checker/verifier
+ *                     action, capturing the diff, the verify command + exit code,
+ *                     the output tail, and any checker verdict. This is what makes
+ *                     a run replayable and auditable.
+ *
+ * Mirrors the WorkflowEngine storage conventions (better-sqlite3, WAL journal,
+ * 0o600 perms, JSON-as-TEXT for structured columns, ':memory:' for tests).
+ */
+
+import Database from 'better-sqlite3'
+import { existsSync, mkdirSync, chmodSync } from 'fs'
+import { homedir } from 'os'
+import { join } from 'path'
+import { randomUUID } from 'crypto'
+import { jsonParse } from './json-parse.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type GoalRunKind = 'ci-autorepair' | 'coverage-increase' | 'dependency-upgrade'
+
+/**
+ * Lifecycle status of a goal run.
+ * - `queued`         — created, maker session not yet started
+ * - `running`        — maker is working a turn
+ * - `verifying`      — deterministic verify commands are executing
+ * - `checking`       — second-provider checker is reviewing the diff
+ * - `awaiting_human` — escalated to a human checkpoint (budget, constraint, or escalate verdict)
+ * - `succeeded`      — verified green, constraints satisfied, completion policy met
+ * - `failed`         — budget exhausted or unrecoverable error
+ * - `aborted`        — cancelled by the user
+ */
+export type GoalRunStatus =
+  | 'queued'
+  | 'running'
+  | 'verifying'
+  | 'checking'
+  | 'awaiting_human'
+  | 'succeeded'
+  | 'failed'
+  | 'aborted'
+
+export type CompletionPolicy = 'pr' | 'merge' | 'commit-only'
+
+export type TurnRole = 'maker' | 'checker' | 'verifier'
+
+export type CheckerVerdict = 'approve' | 'request_changes' | 'escalate'
+
+export type LoopProvider = 'claude' | 'opencode' | 'codex'
+
+export interface ProviderRole {
+  provider: LoopProvider
+  model?: string
+}
+
+/**
+ * The parsed loop recipe (from a `.codekin/loops/*.md` template or an API call).
+ * Stored as JSON text in goal_runs.spec.
+ */
+export interface GoalRunSpec {
+  /** Provider that writes code. */
+  maker: ProviderRole
+  /** Provider that reviews the diff. Omit/null for single-provider (Cut 1) loops. */
+  checker?: ProviderRole | null
+  /** Shell commands run in the worktree as the deterministic gate, in order. */
+  verify: string[]
+  /** Globs that must NOT be modified; a violation re-prompts the maker or escalates. */
+  readonly?: string[]
+  /** Hard cap on maker turns before the run fails. */
+  maxTurns: number
+  /** Hard cap on cumulative USD cost before the run fails. */
+  maxCostUsd: number
+  /** How a successful run lands its changes. Defaults to 'pr' (never auto-merge). */
+  completionPolicy: CompletionPolicy
+}
+
+export interface GoalRun {
+  id: string
+  kind: GoalRunKind
+  status: GoalRunStatus
+  goal: string
+  spec: GoalRunSpec
+  repo: string
+  branch: string
+  makerSessionId: string | null
+  checkerSessionId: string | null
+  turnCount: number
+  costUsd: number
+  /** Last checker verdict (raw JSON string), if any. */
+  verdict: string | null
+  createdAt: string
+  completedAt: string | null
+}
+
+export interface CreateGoalRunInput {
+  kind: GoalRunKind
+  goal: string
+  spec: GoalRunSpec
+  repo: string
+  branch: string
+  id?: string
+}
+
+/** Fields the controller may patch as a run progresses. */
+export interface GoalRunPatch {
+  status?: GoalRunStatus
+  makerSessionId?: string | null
+  checkerSessionId?: string | null
+  turnCount?: number
+  costUsd?: number
+  verdict?: string | null
+  completedAt?: string | null
+}
+
+export interface GoalRunTurn {
+  id: string
+  runId: string
+  turnIndex: number
+  role: TurnRole
+  /** `git diff --stat` snapshot for this turn. */
+  diffSummary: string | null
+  /** The verify command that produced exitCode/outputTail (verifier rows). */
+  verifyCmd: string | null
+  exitCode: number | null
+  /** Last N lines of combined output. */
+  outputTail: string | null
+  /** Checker verdict (checker rows). */
+  verdict: CheckerVerdict | null
+  costUsd: number | null
+  createdAt: string
+}
+
+export interface AppendTurnInput {
+  runId: string
+  turnIndex: number
+  role: TurnRole
+  diffSummary?: string | null
+  verifyCmd?: string | null
+  exitCode?: number | null
+  outputTail?: string | null
+  verdict?: CheckerVerdict | null
+  costUsd?: number | null
+}
+
+export interface ListRunsOptions {
+  status?: GoalRunStatus
+  kind?: GoalRunKind
+  limit?: number
+}
+
+// ---------------------------------------------------------------------------
+// Row shapes (as stored)
+// ---------------------------------------------------------------------------
+
+interface GoalRunRow {
+  id: string
+  kind: string
+  status: string
+  goal: string
+  spec: string
+  repo: string
+  branch: string
+  maker_session_id: string | null
+  checker_session_id: string | null
+  turn_count: number
+  cost_usd: number
+  verdict: string | null
+  created_at: string
+  completed_at: string | null
+}
+
+interface GoalRunTurnRow {
+  id: string
+  run_id: string
+  turn_index: number
+  role: string
+  diff_summary: string | null
+  verify_cmd: string | null
+  exit_code: number | null
+  output_tail: string | null
+  verdict: string | null
+  cost_usd: number | null
+  created_at: string
+}
+
+// Whitelist of patchable columns — guards the dynamic UPDATE against injection.
+const PATCH_COLUMNS: Record<keyof GoalRunPatch, string> = {
+  status: 'status',
+  makerSessionId: 'maker_session_id',
+  checkerSessionId: 'checker_session_id',
+  turnCount: 'turn_count',
+  costUsd: 'cost_usd',
+  verdict: 'verdict',
+  completedAt: 'completed_at',
+}
+
+// ---------------------------------------------------------------------------
+// GoalRunStore
+// ---------------------------------------------------------------------------
+
+export class GoalRunStore {
+  private db: Database.Database
+
+  constructor(dbPath?: string) {
+    const dir = join(homedir(), '.codekin')
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true })
+    const resolvedPath = dbPath ?? join(dir, 'goal-runs.db')
+    this.db = new Database(resolvedPath, { fileMustExist: false })
+    if (resolvedPath !== ':memory:' && existsSync(resolvedPath)) chmodSync(resolvedPath, 0o600)
+    this.db.pragma('journal_mode = WAL')
+    this.createTables()
+  }
+
+  private createTables() {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS goal_runs (
+        id                 TEXT PRIMARY KEY,
+        kind               TEXT NOT NULL,
+        status             TEXT NOT NULL DEFAULT 'queued',
+        goal               TEXT NOT NULL,
+        spec               TEXT NOT NULL DEFAULT '{}',
+        repo               TEXT NOT NULL,
+        branch             TEXT NOT NULL,
+        maker_session_id   TEXT,
+        checker_session_id TEXT,
+        turn_count         INTEGER NOT NULL DEFAULT 0,
+        cost_usd           REAL NOT NULL DEFAULT 0,
+        verdict            TEXT,
+        created_at         TEXT NOT NULL,
+        completed_at       TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS goal_run_turns (
+        id           TEXT PRIMARY KEY,
+        run_id       TEXT NOT NULL REFERENCES goal_runs(id),
+        turn_index   INTEGER NOT NULL,
+        role         TEXT NOT NULL,
+        diff_summary TEXT,
+        verify_cmd   TEXT,
+        exit_code    INTEGER,
+        output_tail  TEXT,
+        verdict      TEXT,
+        cost_usd     REAL,
+        created_at   TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_goal_runs_status ON goal_runs(status);
+      CREATE INDEX IF NOT EXISTS idx_goal_runs_kind ON goal_runs(kind);
+      CREATE INDEX IF NOT EXISTS idx_goal_run_turns_run_id ON goal_run_turns(run_id);
+    `)
+  }
+
+  createRun(input: CreateGoalRunInput): GoalRun {
+    const id = input.id ?? randomUUID()
+    const createdAt = new Date().toISOString()
+    this.db
+      .prepare(
+        `INSERT INTO goal_runs (id, kind, status, goal, spec, repo, branch, created_at)
+         VALUES (?, ?, 'queued', ?, ?, ?, ?, ?)`,
+      )
+      .run(id, input.kind, input.goal, JSON.stringify(input.spec), input.repo, input.branch, createdAt)
+    const run = this.getRun(id)
+    if (!run) throw new Error(`goal run ${id} vanished immediately after insert`)
+    return run
+  }
+
+  getRun(id: string): GoalRun | null {
+    const row = this.db.prepare(`SELECT * FROM goal_runs WHERE id = ?`).get(id) as GoalRunRow | undefined
+    return row ? mapRun(row) : null
+  }
+
+  listRuns(opts: ListRunsOptions = {}): GoalRun[] {
+    const clauses: string[] = []
+    const params: unknown[] = []
+    if (opts.status) {
+      clauses.push('status = ?')
+      params.push(opts.status)
+    }
+    if (opts.kind) {
+      clauses.push('kind = ?')
+      params.push(opts.kind)
+    }
+    let sql = `SELECT * FROM goal_runs`
+    if (clauses.length) sql += ` WHERE ${clauses.join(' AND ')}`
+    // rowid breaks ties when two runs share a created_at millisecond, so
+    // insertion order is the stable secondary key (newest inserted first).
+    sql += ` ORDER BY created_at DESC, rowid DESC`
+    if (opts.limit) {
+      sql += ` LIMIT ?`
+      params.push(opts.limit)
+    }
+    return (this.db.prepare(sql).all(...params) as GoalRunRow[]).map(mapRun)
+  }
+
+  /** Apply a partial update. Only whitelisted columns are written. No-op for an empty patch. */
+  patchRun(id: string, patch: GoalRunPatch): void {
+    const sets: string[] = []
+    const params: unknown[] = []
+    for (const key of Object.keys(patch) as (keyof GoalRunPatch)[]) {
+      const value = patch[key]
+      if (value === undefined) continue
+      sets.push(`${PATCH_COLUMNS[key]} = ?`)
+      params.push(value)
+    }
+    if (!sets.length) return
+    params.push(id)
+    this.db.prepare(`UPDATE goal_runs SET ${sets.join(', ')} WHERE id = ?`).run(...params)
+  }
+
+  appendTurn(input: AppendTurnInput): GoalRunTurn {
+    const id = randomUUID()
+    const createdAt = new Date().toISOString()
+    this.db
+      .prepare(
+        `INSERT INTO goal_run_turns
+         (id, run_id, turn_index, role, diff_summary, verify_cmd, exit_code, output_tail, verdict, cost_usd, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        input.runId,
+        input.turnIndex,
+        input.role,
+        input.diffSummary ?? null,
+        input.verifyCmd ?? null,
+        input.exitCode ?? null,
+        input.outputTail ?? null,
+        input.verdict ?? null,
+        input.costUsd ?? null,
+        createdAt,
+      )
+    const row = this.db.prepare(`SELECT * FROM goal_run_turns WHERE id = ?`).get(id) as GoalRunTurnRow
+    return mapTurn(row)
+  }
+
+  listTurns(runId: string): GoalRunTurn[] {
+    return (
+      this.db.prepare(`SELECT * FROM goal_run_turns WHERE run_id = ? ORDER BY turn_index ASC, created_at ASC`).all(runId) as GoalRunTurnRow[]
+    ).map(mapTurn)
+  }
+
+  close(): void {
+    this.db.close()
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row mapping
+// ---------------------------------------------------------------------------
+
+function mapRun(row: GoalRunRow): GoalRun {
+  return {
+    id: row.id,
+    kind: row.kind as GoalRunKind,
+    status: row.status as GoalRunStatus,
+    goal: row.goal,
+    spec: jsonParse(row.spec) as GoalRunSpec,
+    repo: row.repo,
+    branch: row.branch,
+    makerSessionId: row.maker_session_id,
+    checkerSessionId: row.checker_session_id,
+    turnCount: row.turn_count,
+    costUsd: row.cost_usd,
+    verdict: row.verdict,
+    createdAt: row.created_at,
+    completedAt: row.completed_at,
+  }
+}
+
+function mapTurn(row: GoalRunTurnRow): GoalRunTurn {
+  return {
+    id: row.id,
+    runId: row.run_id,
+    turnIndex: row.turn_index,
+    role: row.role as TurnRole,
+    diffSummary: row.diff_summary,
+    verifyCmd: row.verify_cmd,
+    exitCode: row.exit_code,
+    outputTail: row.output_tail,
+    verdict: row.verdict as CheckerVerdict | null,
+    costUsd: row.cost_usd,
+    createdAt: row.created_at,
+  }
+}

--- a/server/goal-run-store.ts
+++ b/server/goal-run-store.ts
@@ -97,6 +97,8 @@ export interface GoalRun {
   costUsd: number
   /** Last checker verdict (raw JSON string), if any. */
   verdict: string | null
+  /** URL of the pull request opened at finalization (completionPolicy 'pr'), if any. */
+  prUrl: string | null
   createdAt: string
   completedAt: string | null
 }
@@ -118,6 +120,7 @@ export interface GoalRunPatch {
   turnCount?: number
   costUsd?: number
   verdict?: string | null
+  prUrl?: string | null
   completedAt?: string | null
 }
 
@@ -174,6 +177,7 @@ interface GoalRunRow {
   turn_count: number
   cost_usd: number
   verdict: string | null
+  pr_url: string | null
   created_at: string
   completed_at: string | null
 }
@@ -200,6 +204,7 @@ const PATCH_COLUMNS: Record<keyof GoalRunPatch, string> = {
   turnCount: 'turn_count',
   costUsd: 'cost_usd',
   verdict: 'verdict',
+  prUrl: 'pr_url',
   completedAt: 'completed_at',
 }
 
@@ -218,6 +223,15 @@ export class GoalRunStore {
     if (resolvedPath !== ':memory:' && existsSync(resolvedPath)) chmodSync(resolvedPath, 0o600)
     this.db.pragma('journal_mode = WAL')
     this.createTables()
+    this.migrateSchema()
+  }
+
+  /** Additive, idempotent column migrations for databases created before a column existed. */
+  private migrateSchema() {
+    const columns = (this.db.prepare(`PRAGMA table_info(goal_runs)`).all() as { name: string }[]).map((c) => c.name)
+    if (!columns.includes('pr_url')) {
+      this.db.exec(`ALTER TABLE goal_runs ADD COLUMN pr_url TEXT`)
+    }
   }
 
   private createTables() {
@@ -235,6 +249,7 @@ export class GoalRunStore {
         turn_count         INTEGER NOT NULL DEFAULT 0,
         cost_usd           REAL NOT NULL DEFAULT 0,
         verdict            TEXT,
+        pr_url             TEXT,
         created_at         TEXT NOT NULL,
         completed_at       TEXT
       );
@@ -371,6 +386,7 @@ function mapRun(row: GoalRunRow): GoalRun {
     turnCount: row.turn_count,
     costUsd: row.cost_usd,
     verdict: row.verdict,
+    prUrl: row.pr_url,
     createdAt: row.created_at,
     completedAt: row.completed_at,
   }

--- a/server/loop-loader.test.ts
+++ b/server/loop-loader.test.ts
@@ -1,0 +1,180 @@
+/** Tests for the loop template loader — parsing, validation, built-ins, repo overrides. */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import {
+  parseLoopTemplate,
+  loadBuiltinLoops,
+  loadLoopTemplate,
+  listLoopTemplates,
+  discoverRepoLoops,
+  buildGoalRunInput,
+} from './loop-loader.js'
+
+const VALID = `---
+kind: ci-autorepair
+name: CI Autorepair
+maker:
+  provider: claude
+checker:
+  provider: opencode
+  model: gpt-x
+verify:
+  - npm test
+  - npm run lint
+readonly:
+  - .github/workflows/**
+maxTurns: 12
+maxCostUsd: 5
+completionPolicy: pr
+---
+Fix the failing CI checks.`
+
+describe('parseLoopTemplate', () => {
+  it('parses a full template into a validated spec', () => {
+    const t = parseLoopTemplate(VALID, 'x.md', 'builtin')
+    expect(t.kind).toBe('ci-autorepair')
+    expect(t.name).toBe('CI Autorepair')
+    expect(t.goal).toBe('Fix the failing CI checks.')
+    expect(t.source).toBe('builtin')
+    expect(t.spec.maker).toEqual({ provider: 'claude' })
+    expect(t.spec.checker).toEqual({ provider: 'opencode', model: 'gpt-x' })
+    expect(t.spec.verify).toEqual(['npm test', 'npm run lint'])
+    expect(t.spec.readonly).toEqual(['.github/workflows/**'])
+    expect(t.spec.maxTurns).toBe(12)
+    expect(t.spec.completionPolicy).toBe('pr')
+  })
+
+  it('treats an omitted checker as a single-provider loop', () => {
+    const md = `---
+kind: coverage-increase
+name: Coverage
+maker:
+  provider: claude
+verify:
+  - npm test
+maxTurns: 8
+maxCostUsd: 3
+---
+Add tests.`
+    const t = parseLoopTemplate(md, 'x.md', 'repo')
+    expect(t.spec.checker).toBeNull()
+    expect(t.spec.completionPolicy).toBe('pr') // defaulted
+  })
+
+  it('rejects an unknown kind', () => {
+    const md = VALID.replace('kind: ci-autorepair', 'kind: world-domination')
+    expect(() => parseLoopTemplate(md, 'x.md', 'builtin')).toThrow(/kind must be one of/)
+  })
+
+  it('rejects an unknown provider', () => {
+    const md = VALID.replace('provider: claude', 'provider: skynet')
+    expect(() => parseLoopTemplate(md, 'x.md', 'builtin')).toThrow(/maker.provider must be one of/)
+  })
+
+  it('rejects an empty verify list', () => {
+    const md = VALID.replace('verify:\n  - npm test\n  - npm run lint', 'verify: []')
+    expect(() => parseLoopTemplate(md, 'x.md', 'builtin')).toThrow(/at least one command/)
+  })
+
+  it('rejects a non-positive budget', () => {
+    const md = VALID.replace('maxTurns: 12', 'maxTurns: 0')
+    expect(() => parseLoopTemplate(md, 'x.md', 'builtin')).toThrow(/maxTurns must be a positive number/)
+  })
+
+  it('rejects an invalid completion policy', () => {
+    const md = VALID.replace('completionPolicy: pr', 'completionPolicy: yolo')
+    expect(() => parseLoopTemplate(md, 'x.md', 'builtin')).toThrow(/completionPolicy must be one of/)
+  })
+
+  it('rejects a file with no frontmatter', () => {
+    expect(() => parseLoopTemplate('just a body', 'x.md', 'builtin')).toThrow(/no YAML frontmatter/)
+  })
+
+  it('rejects an empty goal body', () => {
+    const md = VALID.replace('Fix the failing CI checks.', '   ')
+    expect(() => parseLoopTemplate(md, 'x.md', 'builtin')).toThrow(/body \(goal text\) is empty/)
+  })
+})
+
+describe('built-in templates', () => {
+  it('ships and parses all three built-in loops', () => {
+    const loops = loadBuiltinLoops(true)
+    const kinds = loops.map((l) => l.kind).sort()
+    expect(kinds).toEqual(['ci-autorepair', 'coverage-increase', 'dependency-upgrade'])
+    for (const l of loops) {
+      expect(l.spec.verify.length).toBeGreaterThan(0)
+      expect(l.goal.length).toBeGreaterThan(0)
+      expect(l.source).toBe('builtin')
+    }
+  })
+
+  it('listLoopTemplates returns the built-in kinds', () => {
+    const infos = listLoopTemplates()
+    expect(infos.map((i) => i.kind).sort()).toEqual(['ci-autorepair', 'coverage-increase', 'dependency-upgrade'])
+    expect(infos.every((i) => i.source === 'builtin')).toBe(true)
+  })
+
+  it('loadLoopTemplate resolves a built-in by kind', () => {
+    const t = loadLoopTemplate('dependency-upgrade')
+    expect(t?.kind).toBe('dependency-upgrade')
+    expect(t?.spec.verify).toContain('npm run build')
+  })
+})
+
+describe('repo overrides', () => {
+  let repo: string
+
+  beforeEach(() => {
+    repo = mkdtempSync(join(tmpdir(), 'loop-repo-'))
+    mkdirSync(join(repo, '.codekin', 'loops'), { recursive: true })
+  })
+
+  afterEach(() => {
+    rmSync(repo, { recursive: true, force: true })
+  })
+
+  it('a repo template overrides the built-in of the same kind', () => {
+    const override = VALID.replace('maxTurns: 12', 'maxTurns: 99')
+    writeFileSync(join(repo, '.codekin', 'loops', 'ci-autorepair.md'), override)
+
+    const repoLoops = discoverRepoLoops(repo)
+    expect(repoLoops).toHaveLength(1)
+    expect(repoLoops[0].source).toBe('repo')
+
+    const resolved = loadLoopTemplate('ci-autorepair', repo)
+    expect(resolved?.source).toBe('repo')
+    expect(resolved?.spec.maxTurns).toBe(99)
+  })
+
+  it('falls back to the built-in when no repo override exists', () => {
+    const resolved = loadLoopTemplate('ci-autorepair', repo)
+    expect(resolved?.source).toBe('builtin')
+  })
+})
+
+describe('buildGoalRunInput', () => {
+  const template = parseLoopTemplate(VALID, 'x.md', 'builtin')
+
+  it('maps a template into a CreateGoalRunInput with runtime repo/branch', () => {
+    const input = buildGoalRunInput(template, { repo: '/repo', branch: 'fix/ci' })
+    expect(input).toEqual({
+      kind: 'ci-autorepair',
+      goal: 'Fix the failing CI checks.',
+      spec: template.spec,
+      repo: '/repo',
+      branch: 'fix/ci',
+    })
+  })
+
+  it('uses an explicit goal override when provided', () => {
+    const input = buildGoalRunInput(template, { repo: '/repo', branch: 'fix/ci', goal: 'job `build` failed: tsc error' })
+    expect(input.goal).toBe('job `build` failed: tsc error')
+  })
+
+  it('falls back to the template goal when the override is blank', () => {
+    const input = buildGoalRunInput(template, { repo: '/repo', branch: 'fix/ci', goal: '   ' })
+    expect(input.goal).toBe('Fix the failing CI checks.')
+  })
+})

--- a/server/loop-loader.ts
+++ b/server/loop-loader.ts
@@ -1,0 +1,260 @@
+/**
+ * Loop template loader.
+ *
+ * A loop template is the authorable recipe for a Goal Run: a markdown file with
+ * YAML frontmatter describing the `GoalRunSpec` (maker/checker providers, verify
+ * commands, readonly constraints, budgets, completion policy) followed by a body
+ * that becomes the default goal text.
+ *
+ * Templates are read from two places, mirroring the workflow loader:
+ *   - built-ins shipped with the package in server/loops/*.md
+ *   - per-repo overrides in {repoPath}/.codekin/loops/*.md (same `kind` wins)
+ *
+ * MD file format:
+ *
+ *   ---
+ *   kind: ci-autorepair
+ *   name: CI Autorepair
+ *   maker:
+ *     provider: claude
+ *   checker:           # optional — omit for a single-provider loop
+ *     provider: opencode
+ *   verify:
+ *     - npm test
+ *     - npm run lint
+ *   readonly:          # optional
+ *     - .github/workflows/**
+ *   maxTurns: 12
+ *   maxCostUsd: 5
+ *   completionPolicy: pr
+ *   ---
+ *   The CI checks are failing on this branch. Diagnose and fix the root cause...
+ *
+ * The frontmatter is structured (nested objects, arrays) so it is parsed with the
+ * `yaml` library rather than the line-based key:value scan the workflow loader uses.
+ */
+
+import { existsSync, readdirSync, readFileSync } from 'fs'
+import { dirname, join } from 'path'
+import { fileURLToPath } from 'url'
+import { parse as parseYaml } from 'yaml'
+import type {
+  CompletionPolicy,
+  CreateGoalRunInput,
+  GoalRunKind,
+  GoalRunSpec,
+  LoopProvider,
+  ProviderRole,
+} from './goal-run-store.js'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface LoopTemplate {
+  kind: GoalRunKind
+  name: string
+  spec: GoalRunSpec
+  /** Default goal text from the MD body. */
+  goal: string
+  source: 'builtin' | 'repo'
+}
+
+export interface LoopTemplateInfo {
+  kind: GoalRunKind
+  name: string
+  source: 'builtin' | 'repo'
+}
+
+const KINDS: readonly GoalRunKind[] = ['ci-autorepair', 'coverage-increase', 'dependency-upgrade']
+const PROVIDERS: readonly LoopProvider[] = ['claude', 'opencode', 'codex']
+const POLICIES: readonly CompletionPolicy[] = ['pr', 'merge', 'commit-only']
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function fail(sourcePath: string, msg: string): never {
+  throw new Error(`Invalid loop template ${sourcePath}: ${msg}`)
+}
+
+function asRecord(value: unknown, sourcePath: string): Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    fail(sourcePath, 'frontmatter must be a YAML mapping')
+  }
+  return value as Record<string, unknown>
+}
+
+function parseProviderRole(value: unknown, field: string, sourcePath: string): ProviderRole {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    fail(sourcePath, `${field} must be a mapping with a provider`)
+  }
+  const obj = value as Record<string, unknown>
+  const provider = obj.provider
+  if (typeof provider !== 'string' || !PROVIDERS.includes(provider as LoopProvider)) {
+    fail(sourcePath, `${field}.provider must be one of ${PROVIDERS.join(', ')}`)
+  }
+  const role: ProviderRole = { provider: provider as LoopProvider }
+  if (obj.model !== undefined) {
+    if (typeof obj.model !== 'string') fail(sourcePath, `${field}.model must be a string`)
+    role.model = obj.model
+  }
+  return role
+}
+
+function parseStringArray(value: unknown, field: string, sourcePath: string): string[] {
+  if (!Array.isArray(value) || value.some((v) => typeof v !== 'string')) {
+    fail(sourcePath, `${field} must be a list of strings`)
+  }
+  return value as string[]
+}
+
+function parsePositiveNumber(value: unknown, field: string, sourcePath: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    fail(sourcePath, `${field} must be a positive number`)
+  }
+  return value
+}
+
+/** Build a validated GoalRunSpec + kind/name from parsed frontmatter. */
+function specFromFrontmatter(fm: Record<string, unknown>, sourcePath: string): { kind: GoalRunKind; name: string; spec: GoalRunSpec } {
+  const kind = fm.kind
+  if (typeof kind !== 'string' || !KINDS.includes(kind as GoalRunKind)) {
+    fail(sourcePath, `kind must be one of ${KINDS.join(', ')}`)
+  }
+  const name = fm.name
+  if (typeof name !== 'string' || !name.trim()) fail(sourcePath, 'name is required')
+
+  if (fm.maker === undefined) fail(sourcePath, 'maker is required')
+  const maker = parseProviderRole(fm.maker, 'maker', sourcePath)
+  const checker = fm.checker == null ? null : parseProviderRole(fm.checker, 'checker', sourcePath)
+
+  const verify = parseStringArray(fm.verify, 'verify', sourcePath)
+  if (verify.length === 0) fail(sourcePath, 'verify must list at least one command')
+
+  const readonly = fm.readonly === undefined ? undefined : parseStringArray(fm.readonly, 'readonly', sourcePath)
+
+  const policy = fm.completionPolicy ?? 'pr'
+  if (typeof policy !== 'string' || !POLICIES.includes(policy as CompletionPolicy)) {
+    fail(sourcePath, `completionPolicy must be one of ${POLICIES.join(', ')}`)
+  }
+
+  const spec: GoalRunSpec = {
+    maker,
+    checker,
+    verify,
+    readonly,
+    maxTurns: parsePositiveNumber(fm.maxTurns, 'maxTurns', sourcePath),
+    maxCostUsd: parsePositiveNumber(fm.maxCostUsd, 'maxCostUsd', sourcePath),
+    completionPolicy: policy as CompletionPolicy,
+  }
+  return { kind: kind as GoalRunKind, name, spec }
+}
+
+/** Parse a loop MD file into a LoopTemplate. Throws on malformed/unsafe input. */
+export function parseLoopTemplate(content: string, sourcePath: string, source: 'builtin' | 'repo'): LoopTemplate {
+  const fmMatch = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/)
+  if (!fmMatch) fail(sourcePath, 'no YAML frontmatter found')
+
+  let parsed: unknown
+  try {
+    parsed = parseYaml(fmMatch[1])
+  } catch (err) {
+    fail(sourcePath, `frontmatter is not valid YAML: ${err instanceof Error ? err.message : String(err)}`)
+  }
+  const fm = asRecord(parsed, sourcePath)
+  const goal = fmMatch[2].trim()
+  if (!goal) fail(sourcePath, 'body (goal text) is empty')
+
+  const { kind, name, spec } = specFromFrontmatter(fm, sourcePath)
+  return { kind, name, spec, goal, source }
+}
+
+// ---------------------------------------------------------------------------
+// File discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the built-in loops directory. When running from server/dist/ the MD
+ * files live one level up in server/loops/; from source they sit alongside.
+ */
+const __ownDir = dirname(fileURLToPath(import.meta.url))
+const LOOPS_DIR = existsSync(join(__ownDir, 'loops')) ? join(__ownDir, 'loops') : join(__ownDir, '..', 'loops')
+
+function loadFromDir(dir: string, source: 'builtin' | 'repo', strict: boolean): LoopTemplate[] {
+  if (!existsSync(dir)) return []
+  const out: LoopTemplate[] = []
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.md')) continue
+    const filePath = join(dir, file)
+    try {
+      out.push(parseLoopTemplate(readFileSync(filePath, 'utf-8'), filePath, source))
+    } catch (err) {
+      if (strict) throw err
+      console.error(`[loop-loader] Failed to parse ${filePath}:`, err)
+    }
+  }
+  return out
+}
+
+/** Load the built-in loop templates shipped with the package. */
+export function loadBuiltinLoops(strict = false): LoopTemplate[] {
+  if (!existsSync(LOOPS_DIR)) {
+    console.warn(`[loop-loader] Built-in loops dir not found: ${LOOPS_DIR}`)
+    return []
+  }
+  return loadFromDir(LOOPS_DIR, 'builtin', strict)
+}
+
+/** Scan {repoPath}/.codekin/loops/ for per-repo loop templates. */
+export function discoverRepoLoops(repoPath: string): LoopTemplate[] {
+  return loadFromDir(join(repoPath, '.codekin', 'loops'), 'repo', false)
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a loop template by kind. A per-repo template overrides the built-in of
+ * the same kind, mirroring the workflow loader's override semantics.
+ */
+export function loadLoopTemplate(kind: GoalRunKind, repoPath?: string): LoopTemplate | null {
+  if (repoPath) {
+    const override = discoverRepoLoops(repoPath).find((t) => t.kind === kind)
+    if (override) return override
+  }
+  return loadBuiltinLoops().find((t) => t.kind === kind) ?? null
+}
+
+/** List available loop kinds: built-ins plus any repo templates with a new kind. */
+export function listLoopTemplates(repoPath?: string): LoopTemplateInfo[] {
+  const builtins = loadBuiltinLoops()
+  const infos: LoopTemplateInfo[] = builtins.map((t) => ({ kind: t.kind, name: t.name, source: 'builtin' }))
+  if (repoPath) {
+    const builtinKinds = new Set(builtins.map((t) => t.kind))
+    for (const t of discoverRepoLoops(repoPath)) {
+      if (builtinKinds.has(t.kind)) continue
+      infos.push({ kind: t.kind, name: t.name, source: 'repo' })
+    }
+  }
+  return infos
+}
+
+/**
+ * Turn a template into a CreateGoalRunInput for the controller. `repo` and
+ * `branch` are runtime values; `goal` overrides the template's default goal text
+ * (e.g. a CI-autorepair run injects the actual failing job).
+ */
+export function buildGoalRunInput(
+  template: LoopTemplate,
+  opts: { repo: string; branch: string; goal?: string },
+): CreateGoalRunInput {
+  return {
+    kind: template.kind,
+    goal: opts.goal?.trim() ? opts.goal.trim() : template.goal,
+    spec: template.spec,
+    repo: opts.repo,
+    branch: opts.branch,
+  }
+}

--- a/server/loops/ci-autorepair.md
+++ b/server/loops/ci-autorepair.md
@@ -1,0 +1,24 @@
+---
+kind: ci-autorepair
+name: CI Autorepair
+maker:
+  provider: claude
+checker:
+  provider: opencode
+verify:
+  - npm test
+  - npm run lint
+readonly:
+  - .github/workflows/**
+maxTurns: 12
+maxCostUsd: 5
+completionPolicy: pr
+---
+The continuous integration checks are failing on this branch. Diagnose the failures
+and fix the underlying cause so that every verification command passes.
+
+- Make the smallest change that fixes the root cause; do not refactor unrelated code.
+- Do NOT weaken, skip, delete, or relax tests to make verification pass.
+- Do NOT modify CI workflow configuration to sidestep the failure.
+- If the failure is environmental or genuinely cannot be fixed in code, stop and
+  explain why rather than forcing a green result.

--- a/server/loops/coverage-increase.md
+++ b/server/loops/coverage-increase.md
@@ -1,0 +1,23 @@
+---
+kind: coverage-increase
+name: Coverage Increase
+maker:
+  provider: claude
+checker:
+  provider: opencode
+verify:
+  - npm test
+maxTurns: 15
+maxCostUsd: 6
+completionPolicy: pr
+---
+Increase meaningful test coverage for this codebase by adding tests that exercise
+real behavior and edge cases.
+
+- Add tests only; do NOT change production code to make coverage easier unless you
+  are fixing a genuine bug the new test reveals (call that out explicitly).
+- Tests must assert real behavior — no trivially-true assertions, no tests that
+  only execute code without checking outcomes.
+- Keep each test focused and readable; prefer covering untested branches and error
+  paths over padding already-covered lines.
+- Every verification command must pass before you finish.

--- a/server/loops/dependency-upgrade.md
+++ b/server/loops/dependency-upgrade.md
@@ -1,0 +1,26 @@
+---
+kind: dependency-upgrade
+name: Dependency Upgrade
+maker:
+  provider: claude
+checker:
+  provider: opencode
+verify:
+  - npm install
+  - npm run build
+  - npm test
+readonly:
+  - .github/workflows/**
+maxTurns: 12
+maxCostUsd: 6
+completionPolicy: pr
+---
+Upgrade the project's dependencies and adapt the code to any breaking changes so
+that the build and the full test suite pass on the new versions.
+
+- Update package.json and the lockfile together; keep the dependency tree consistent.
+- Make the minimal source changes required to accommodate breaking API changes.
+- Do NOT weaken or delete tests to absorb a breaking change — fix the calling code.
+- Do NOT pin to an older version to avoid the work unless an upgrade is genuinely
+  incompatible; if so, stop and explain which dependency blocked the upgrade.
+- Every verification command must pass before you finish.

--- a/server/verifier-runner.test.ts
+++ b/server/verifier-runner.test.ts
@@ -1,0 +1,81 @@
+/** Tests for the verifier runner — exercises verify-command exit-code capture and the git diff helpers against a real temp repo. */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, rmSync, writeFileSync, appendFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { runVerifier, getDiffSummary, getChangedFiles } from './verifier-runner.js'
+import { execGit } from './diff-manager.js'
+
+describe('runVerifier', () => {
+  let dir: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'verifier-'))
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('passes when every command exits 0', async () => {
+    const result = await runVerifier({ cwd: dir, commands: ['exit 0', 'echo ok'] })
+    expect(result.passed).toBe(true)
+    expect(result.results).toHaveLength(2)
+    expect(result.results.every((r) => r.exitCode === 0)).toBe(true)
+  })
+
+  it('fails and short-circuits on the first non-zero command', async () => {
+    const result = await runVerifier({ cwd: dir, commands: ['exit 3', 'echo should-not-run'] })
+    expect(result.passed).toBe(false)
+    // short-circuit: the second command is never executed
+    expect(result.results).toHaveLength(1)
+    expect(result.results[0].exitCode).toBe(3)
+    expect(result.results[0].timedOut).toBe(false)
+  })
+
+  it('captures a tail of command output', async () => {
+    const result = await runVerifier({ cwd: dir, commands: ['echo first-line; echo second-line'] })
+    expect(result.results[0].outputTail).toContain('first-line')
+    expect(result.results[0].outputTail).toContain('second-line')
+  })
+
+  it('trims output to the requested number of tail lines', async () => {
+    const result = await runVerifier({
+      cwd: dir,
+      commands: ['for i in 1 2 3 4 5; do echo line-$i; done'],
+      tailLines: 2,
+    })
+    const lines = result.results[0].outputTail.split('\n')
+    expect(lines).toHaveLength(2)
+    expect(lines).toEqual(['line-4', 'line-5'])
+  })
+})
+
+describe('git helpers', () => {
+  let dir: string
+
+  beforeEach(async () => {
+    dir = mkdtempSync(join(tmpdir(), 'verifier-git-'))
+    await execGit(['init', '-q'], dir)
+    await execGit(['config', 'user.email', 'test@example.com'], dir)
+    await execGit(['config', 'user.name', 'Test'], dir)
+    writeFileSync(join(dir, 'a.txt'), 'hello\n')
+    await execGit(['add', 'a.txt'], dir)
+    await execGit(['commit', '-q', '-m', 'init'], dir)
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('reports a clean tree as empty', async () => {
+    expect(await getChangedFiles(dir)).toEqual([])
+    expect(await getDiffSummary(dir)).toBe('')
+  })
+
+  it('detects a modified tracked file', async () => {
+    appendFileSync(join(dir, 'a.txt'), 'world\n')
+    expect(await getChangedFiles(dir)).toEqual(['a.txt'])
+    expect(await getDiffSummary(dir)).toContain('a.txt')
+  })
+})

--- a/server/verifier-runner.ts
+++ b/server/verifier-runner.ts
@@ -1,0 +1,140 @@
+/**
+ * Deterministic verifier for Goal Runs.
+ *
+ * This is the cheap, objective gate that runs BEFORE any model-based checker:
+ * run the loop's verify commands (e.g. `npm test`, `npm run lint`) in the run's
+ * worktree, capture each command's exit code and a tail of its output, and report
+ * pass/fail. The controller uses this to decide whether to feed a failure back to
+ * the maker, invoke the checker, or finalize.
+ *
+ * It also exposes two git helpers the controller needs:
+ *   - getDiffSummary  → `git diff --stat` (debounce signal + evidence ledger entry)
+ *   - getChangedFiles → `git diff --name-only` (readonly-glob constraint enforcement)
+ *
+ * Verify commands are authored by the repo owner (loop template / API), exactly
+ * like package.json scripts or a CI config — they are trusted and run through a
+ * shell. Git commands run argv-only (no shell) via the diff-manager helper.
+ */
+
+import { exec } from 'child_process'
+import { execGit } from './diff-manager.js'
+
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes per command
+const DEFAULT_TAIL_LINES = 50
+const MAX_BUFFER = 16 * 1024 * 1024 // 16 MB
+
+export interface VerifyCommandResult {
+  command: string
+  exitCode: number
+  /** Combined stdout+stderr, trimmed to the last `tailLines` lines. */
+  outputTail: string
+  durationMs: number
+  timedOut: boolean
+}
+
+export interface VerifyResult {
+  /** True only if every command exited 0. */
+  passed: boolean
+  results: VerifyCommandResult[]
+}
+
+export interface VerifierOptions {
+  /** Worktree directory the commands run in. */
+  cwd: string
+  /** Shell commands, executed in order. */
+  commands: string[]
+  /** Per-command timeout. Defaults to 10 minutes. */
+  timeoutMs?: number
+  /** Lines of output to retain per command. Defaults to 50. */
+  tailLines?: number
+  /** Extra environment for the commands (merged over process.env). */
+  env?: NodeJS.ProcessEnv
+}
+
+interface ExecFailure {
+  code?: number | null
+  killed?: boolean
+  signal?: NodeJS.Signals | null
+  stdout?: string
+  stderr?: string
+}
+
+function isExecFailure(err: unknown): err is ExecFailure {
+  return typeof err === 'object' && err !== null
+}
+
+function tail(text: string, lines: number): string {
+  // Trim trailing newlines first: otherwise a final '\n' yields an empty last
+  // element that would displace a real line out of the tail window.
+  const trimmed = text.trimEnd()
+  const split = trimmed.split('\n')
+  if (split.length <= lines) return trimmed
+  return split.slice(split.length - lines).join('\n')
+}
+
+/** Run a single shell command, capturing exit code + output regardless of success. */
+function runCommand(
+  command: string,
+  cwd: string,
+  timeoutMs: number,
+  tailLines: number,
+  env: NodeJS.ProcessEnv,
+): Promise<VerifyCommandResult> {
+  const startedAt = Date.now()
+  return new Promise((resolve) => {
+    exec(command, { cwd, timeout: timeoutMs, maxBuffer: MAX_BUFFER, env }, (err, stdout, stderr) => {
+      const durationMs = Date.now() - startedAt
+      const combined = `${stdout}${stderr}`
+      if (!err) {
+        resolve({ command, exitCode: 0, outputTail: tail(combined, tailLines), durationMs, timedOut: false })
+        return
+      }
+      const failure: ExecFailure = isExecFailure(err) ? err : {}
+      const timedOut = failure.killed === true && failure.signal === 'SIGTERM'
+      // exec surfaces the real exit code on `.code`; fall back to 1 when the
+      // process was killed (timeout) or no code is available.
+      const exitCode = typeof failure.code === 'number' ? failure.code : 1
+      const out = `${failure.stdout ?? stdout}${failure.stderr ?? stderr}`
+      resolve({ command, exitCode, outputTail: tail(out, tailLines), durationMs, timedOut })
+    })
+  })
+}
+
+/**
+ * Run the verify commands in order, short-circuiting on the first failure.
+ * Short-circuit keeps cost down: there is no point linting code whose tests
+ * already failed, and the first failure is what the maker needs to see next.
+ */
+export async function runVerifier(opts: VerifierOptions): Promise<VerifyResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const tailLines = opts.tailLines ?? DEFAULT_TAIL_LINES
+  const env = { ...process.env, ...(opts.env ?? {}) }
+  const results: VerifyCommandResult[] = []
+  for (const command of opts.commands) {
+    const result = await runCommand(command, opts.cwd, timeoutMs, tailLines, env)
+    results.push(result)
+    if (result.exitCode !== 0) {
+      return { passed: false, results }
+    }
+  }
+  return { passed: true, results }
+}
+
+/**
+ * `git diff --stat` of the working tree against HEAD. Doubles as the debounce
+ * signal (unchanged stat since last verify ⇒ skip re-running) and the diff
+ * summary recorded in the evidence ledger.
+ */
+export async function getDiffSummary(cwd: string): Promise<string> {
+  const out = await execGit(['diff', '--stat', 'HEAD'], cwd)
+  return out.trimEnd()
+}
+
+/** Files changed in the working tree vs HEAD — input to readonly-glob enforcement. */
+export async function getChangedFiles(cwd: string): Promise<string[]> {
+  const out = await execGit(['diff', '--name-only', 'HEAD'], cwd)
+  return out
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+}

--- a/server/verifier-runner.ts
+++ b/server/verifier-runner.ts
@@ -130,6 +130,17 @@ export async function getDiffSummary(cwd: string): Promise<string> {
   return out.trimEnd()
 }
 
+/**
+ * Full `git diff HEAD` patch of the working tree. Fed to a maker–checker review
+ * pass so the checker can assess the actual change (the maker's edits are
+ * uncommitted, so a sibling worktree can't see them — the patch travels in the
+ * prompt instead).
+ */
+export async function getDiff(cwd: string): Promise<string> {
+  const out = await execGit(['diff', 'HEAD'], cwd)
+  return out.trimEnd()
+}
+
 /** Files changed in the working tree vs HEAD — input to readonly-glob enforcement. */
 export async function getChangedFiles(cwd: string): Promise<string[]> {
   const out = await execGit(['diff', '--name-only', 'HEAD'], cwd)

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -32,6 +32,9 @@ import { initWorkflowEngine, shutdownWorkflowEngine, type WorkflowEvent } from '
 import { generate404Page, generate500Page } from './error-page.js'
 import { loadMdWorkflows } from './workflow-loader.js'
 import { createWorkflowRouter, syncSchedules } from './workflow-routes.js'
+import { GoalRunStore } from './goal-run-store.js'
+import { GoalRunController } from './goal-run-controller.js'
+import { createGoalRunRouter } from './goal-run-routes.js'
 import { CommitEventHandler } from './commit-event-handler.js'
 import { jsonParse } from './json-parse.js'
 import { createMessageRateLimiter } from './ws-rate-limit.js'
@@ -368,6 +371,10 @@ app.use('/api/workflows', createWorkflowRouter(verifyToken, extractToken, sessio
 // Orchestrator router — monitorRef is populated after workflow engine init
 const orchestratorMonitorRef: { current: OrchestratorMonitor | null } = { current: null }
 app.use(createOrchestratorRouter(verifyToken, extractToken, sessions, orchestratorMonitorRef, verifyTokenOrSessionToken))
+// Goal Run (loop) router — durable act→verify→continue loops with an evidence ledger.
+const goalRunStore = new GoalRunStore()
+const goalRunController = new GoalRunController(sessions, goalRunStore)
+app.use('/api/goal-runs', createGoalRunRouter(verifyToken, extractToken, goalRunStore, goalRunController))
 
 // --- SPA fallback: serve index.html for non-API routes (client-side routing) ---
 if (FRONTEND_DIST && existsSync(FRONTEND_DIST)) {
@@ -688,6 +695,7 @@ server.listen(port, '0.0.0.0', () => {
 async function gracefulShutdown(signal: string): Promise<void> {
   console.log(`${signal} received, shutting down...`)
   shutdownWorkflowEngine()
+  goalRunStore.close()
   commitEventState.handler?.shutdown()
   webhookHandler.shutdown()
   stepflowHandler.shutdown()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { Settings } from './components/Settings'
 import { LeftSidebar } from './components/LeftSidebar'
 import { MobileTopBar } from './components/MobileTopBar'
 import { WorkflowsView } from './components/WorkflowsView'
+import { LoopRunsView } from './components/LoopRunsView'
 import { CommandPalette } from './components/CommandPalette'
 import type { InputBarHandle } from './components/InputBar'
 import { RepoSelector } from './components/RepoSelector'
@@ -608,6 +609,7 @@ export default function App() {
         onSendModule={handleSendModule}
         agentName={agentName}
         onNavigateToWorkflows={() => navigate('/workflows')}
+        onNavigateToLoops={() => navigate('/loops')}
         onNavigateToOrchestrator={() => handleNavigateToOrchestrator()}
         onBrowseDocs={handleBrowseDocs}
         docsPicker={{
@@ -685,6 +687,16 @@ export default function App() {
           />
         ) : view === 'workflows' ? (
           <WorkflowsView
+            token={settings.token}
+            onNavigateToSession={(sessionId) => {
+              clearMessages()
+              leaveSession()
+              joinSession(sessionId)
+              navigate(`/s/${sessionId}`)
+            }}
+          />
+        ) : view === 'loops' ? (
+          <LoopRunsView
             token={settings.token}
             onNavigateToSession={(sessionId) => {
               clearMessages()

--- a/src/components/LeftSidebar.tsx
+++ b/src/components/LeftSidebar.tsx
@@ -12,6 +12,7 @@ import {
   IconBook, IconSettings as IconSettingsGear,
   IconLogout, IconSun, IconMoon,
   IconChevronRight, IconChevronLeft, IconSparkles, IconX, IconRobotFace,
+  IconRefresh,
 } from '@tabler/icons-react'
 import type { Session, Module, Repo, DocsPickerProps, MobileProps, ConnectionState } from '../types'
 import type { RepoGroup } from '../hooks/useRepos'
@@ -139,6 +140,8 @@ interface Props {
   onSendModule: (mod: Module) => void
   /** Navigate to the workflows view. */
   onNavigateToWorkflows: () => void
+  /** Navigate to the loop runs view. */
+  onNavigateToLoops: () => void
   /** Navigate to the orchestrator view. */
   onNavigateToOrchestrator: () => void
   /** Open the docs browser for a repo's documentation files. */
@@ -190,6 +193,7 @@ export function LeftSidebar({
   onSendModule,
   agentName = 'Joe',
   onNavigateToWorkflows,
+  onNavigateToLoops,
   onNavigateToOrchestrator,
   onBrowseDocs,
   docsPicker = {},
@@ -389,6 +393,17 @@ export function LeftSidebar({
           >
             <IconSparkles size={16} stroke={2} className="flex-shrink-0" />
             <span className="flex-1 text-left">AI Workflows</span>
+          </button>
+          <button
+            onClick={() => { onNavigateToLoops(); if (isMobile) onMobileClose?.() }}
+            className={`w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-[15px] transition-colors ${
+              view === 'loops'
+                ? 'bg-accent-9/30 text-accent-2'
+                : 'text-neutral-3 hover:text-neutral-1 hover:bg-neutral-6'
+            }`}
+          >
+            <IconRefresh size={16} stroke={2} className="flex-shrink-0" />
+            <span className="flex-1 text-left">Loop Runs</span>
           </button>
           <button
             onClick={() => { onNavigateToOrchestrator(); if (isMobile) onMobileClose?.() }}

--- a/src/components/LoopRunsView.tsx
+++ b/src/components/LoopRunsView.tsx
@@ -1,0 +1,472 @@
+/**
+ * Loop Runs page — the UI for Goal Runs (durable act→verify→continue loops).
+ *
+ * Left: a list of runs with status. Right: the selected run's detail plus its
+ * evidence ledger (one row per maker/verifier/checker turn). A "Start Loop"
+ * form launches a new run from a loop template against a repo + branch.
+ */
+
+import { useState, useEffect, useCallback } from 'react'
+import { IconPlayerPlay, IconRefresh, IconX } from '@tabler/icons-react'
+import {
+  listGoalRuns,
+  getGoalRun,
+  listLoopTemplates,
+  startGoalRun,
+  abortGoalRun,
+  type GoalRun,
+  type GoalRunStatus,
+  type GoalRunWithTurns,
+  type GoalRunTurn,
+  type LoopTemplateInfo,
+} from '../lib/goalRunApi'
+import { formatTime } from '../lib/workflowHelpers'
+
+const TERMINAL: ReadonlySet<GoalRunStatus> = new Set(['succeeded', 'failed', 'aborted', 'awaiting_human'])
+
+function isActive(status: GoalRunStatus): boolean {
+  return !TERMINAL.has(status)
+}
+
+/** Tailwind classes for a goal-run status badge. */
+function statusBadge(status: GoalRunStatus): string {
+  switch (status) {
+    case 'succeeded': return 'bg-success-7 text-success-2'
+    case 'failed': return 'bg-error-8 text-error-2'
+    case 'aborted': return 'bg-warning-8 text-warning-2'
+    case 'awaiting_human': return 'bg-warning-7 text-warning-1'
+    case 'running': return 'bg-accent-8 text-accent-2 animate-pulse'
+    case 'verifying': return 'bg-accent-8 text-accent-2 animate-pulse'
+    case 'checking': return 'bg-primary-8 text-primary-2 animate-pulse'
+    case 'queued': return 'bg-neutral-8 text-neutral-3'
+    default: return 'bg-neutral-8 text-neutral-3'
+  }
+}
+
+function roleBadge(role: GoalRunTurn['role']): string {
+  switch (role) {
+    case 'maker': return 'bg-accent-9/40 text-accent-2'
+    case 'checker': return 'bg-primary-9/40 text-primary-2'
+    case 'verifier': return 'bg-neutral-8 text-neutral-3'
+    default: return 'bg-neutral-8 text-neutral-3'
+  }
+}
+
+interface Props {
+  /** Auth token for REST API calls. */
+  token: string
+  /** Navigate the main app to a session (e.g. the run's maker session). */
+  onNavigateToSession?: (sessionId: string) => void
+}
+
+/** Loop Runs management page — list of goal runs, per-run evidence ledger, and a start form. */
+export function LoopRunsView({ token, onNavigateToSession }: Props) {
+  const [runs, setRuns] = useState<GoalRun[]>([])
+  const [templates, setTemplates] = useState<LoopTemplateInfo[]>([])
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null)
+  const [detail, setDetail] = useState<GoalRunWithTurns | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [showForm, setShowForm] = useState(false)
+
+  const refreshRuns = useCallback(async () => {
+    try {
+      setRuns(await listGoalRuns(token, { limit: 100 }))
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load runs')
+    }
+  }, [token])
+
+  // Initial load: runs + templates.
+  useEffect(() => {
+    let cancelled = false
+    listGoalRuns(token, { limit: 100 })
+      .then((r) => { if (!cancelled) setRuns(r) })
+      .catch((err: unknown) => { if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load runs') })
+    listLoopTemplates(token)
+      .then((t) => { if (!cancelled) setTemplates(t) })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [token])
+
+  // Poll the runs list while any run is still active.
+  useEffect(() => {
+    if (!runs.some((r) => isActive(r.status))) return
+    const id = setInterval(() => { void refreshRuns() }, 4000)
+    return () => { clearInterval(id) }
+  }, [runs, refreshRuns])
+
+  // Fetch detail on selection (a stale detail is hidden by the id guard at render).
+  useEffect(() => {
+    if (!selectedRunId) return
+    let cancelled = false
+    getGoalRun(token, selectedRunId)
+      .then((d) => { if (!cancelled) setDetail(d) })
+      .catch(() => { if (!cancelled) setDetail(null) })
+    return () => { cancelled = true }
+  }, [selectedRunId, token])
+
+  // Poll detail while the selected run is active.
+  useEffect(() => {
+    if (!selectedRunId || !detail || !isActive(detail.status)) return
+    const id = setInterval(() => {
+      getGoalRun(token, selectedRunId).then(setDetail).catch(() => {})
+    }, 3000)
+    return () => { clearInterval(id) }
+  }, [selectedRunId, detail, token])
+
+  const handleAbort = useCallback(async (runId: string) => {
+    try {
+      await abortGoalRun(token, runId)
+      await refreshRuns()
+      if (selectedRunId === runId) {
+        getGoalRun(token, runId).then(setDetail).catch(() => {})
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to abort run')
+    }
+  }, [token, refreshRuns, selectedRunId])
+
+  const handleStarted = useCallback((run: GoalRun) => {
+    setShowForm(false)
+    setSelectedRunId(run.id)
+    void refreshRuns()
+  }, [refreshRuns])
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between border-b border-neutral-8/50 px-5 py-3">
+        <h1 className="text-[18px] font-medium text-neutral-1">Loop Runs</h1>
+        <div className="flex items-center gap-1.5">
+          <button
+            onClick={() => { void refreshRuns() }}
+            className="flex items-center gap-1.5 rounded-md px-2 py-1.5 text-[15px] text-neutral-3 hover:text-neutral-1 hover:bg-neutral-6 transition-colors"
+            title="Refresh"
+          >
+            <IconRefresh size={14} stroke={2} />
+          </button>
+          <button
+            onClick={() => { setShowForm(true) }}
+            className="flex items-center gap-1.5 rounded-md bg-primary-8 px-3 py-1.5 text-[15px] font-medium text-on-primary hover:bg-primary-7 transition-colors"
+          >
+            <IconPlayerPlay size={14} stroke={2} />
+            Start Loop
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="border-b border-error-9/50 bg-error-10/40 px-4 py-2 text-[15px] text-error-4">
+          {error}
+        </div>
+      )}
+
+      <div className="flex flex-1 overflow-hidden">
+        {/* Runs list */}
+        <div className="w-80 flex-shrink-0 overflow-y-auto border-r border-neutral-8/50">
+          {runs.length === 0 ? (
+            <div className="px-4 py-10 text-center text-[15px] text-neutral-5">
+              No loop runs yet.
+            </div>
+          ) : (
+            <ul className="divide-y divide-neutral-9/40">
+              {runs.map((run) => (
+                <li key={run.id}>
+                  <button
+                    onClick={() => { setSelectedRunId((p) => (p === run.id ? null : run.id)) }}
+                    className={`w-full px-4 py-2.5 text-left transition-colors ${
+                      selectedRunId === run.id ? 'bg-neutral-9/60' : 'hover:bg-neutral-9/30'
+                    }`}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="truncate text-[15px] font-medium text-neutral-2">{run.kind}</span>
+                      <span className={`inline-flex flex-shrink-0 items-center rounded px-1.5 py-0.5 text-[12px] font-medium ${statusBadge(run.status)}`}>
+                        {run.status}
+                      </span>
+                    </div>
+                    <div className="mt-0.5 flex items-center justify-between gap-2 text-[13px] text-neutral-5">
+                      <span className="truncate">{run.branch}</span>
+                      <span className="flex-shrink-0">{formatTime(run.createdAt)}</span>
+                    </div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Detail */}
+        <div className="flex-1 overflow-y-auto">
+          {!selectedRunId ? (
+            <div className="flex h-full items-center justify-center text-[15px] text-neutral-5">
+              Select a run to see its evidence ledger.
+            </div>
+          ) : !detail || detail.id !== selectedRunId ? (
+            <div className="px-5 py-6 text-[15px] text-neutral-5">Loading…</div>
+          ) : (
+            <RunDetail
+              run={detail}
+              onAbort={(id) => { void handleAbort(id) }}
+              onNavigateToSession={onNavigateToSession}
+            />
+          )}
+        </div>
+      </div>
+
+      {showForm && (
+        <StartLoopModal
+          token={token}
+          templates={templates}
+          onClose={() => { setShowForm(false) }}
+          onStarted={handleStarted}
+        />
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Run detail + evidence ledger
+// ---------------------------------------------------------------------------
+
+function RunDetail({
+  run,
+  onAbort,
+  onNavigateToSession,
+}: {
+  run: GoalRunWithTurns
+  onAbort: (runId: string) => void
+  onNavigateToSession?: (sessionId: string) => void
+}) {
+  const { makerSessionId } = run
+  return (
+    <div className="p-5">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className="text-[17px] font-medium text-neutral-1">{run.kind}</h2>
+            <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[12px] font-medium ${statusBadge(run.status)}`}>
+              {run.status}
+            </span>
+          </div>
+          <p className="mt-1 text-[14px] text-neutral-4">{run.goal}</p>
+        </div>
+        {isActive(run.status) && (
+          <button
+            onClick={() => { onAbort(run.id) }}
+            className="flex flex-shrink-0 items-center gap-1.5 rounded-md border border-error-8/50 px-2.5 py-1 text-[14px] text-error-3 hover:bg-error-10/40 transition-colors"
+          >
+            <IconX size={13} stroke={2} />
+            Abort
+          </button>
+        )}
+      </div>
+
+      {/* Meta */}
+      <div className="mt-3 grid grid-cols-2 gap-x-6 gap-y-1 text-[14px] sm:grid-cols-3">
+        <Meta label="Branch" value={run.branch} />
+        <Meta label="Turns" value={`${run.turnCount} / ${run.spec.maxTurns}`} />
+        <Meta label="Cost" value={`$${run.costUsd.toFixed(2)} / $${run.spec.maxCostUsd.toFixed(2)}`} />
+        <Meta label="Maker" value={run.spec.maker.provider} />
+        <Meta label="Checker" value={run.spec.checker?.provider ?? 'none'} />
+        <Meta label="Policy" value={run.spec.completionPolicy} />
+      </div>
+
+      {makerSessionId && onNavigateToSession && (
+        <button
+          onClick={() => { onNavigateToSession(makerSessionId) }}
+          className="mt-3 text-[14px] text-accent-3 hover:text-accent-2 hover:underline"
+        >
+          Open maker session →
+        </button>
+      )}
+
+      {/* Evidence ledger */}
+      <h3 className="mt-5 mb-2 text-[14px] font-medium uppercase tracking-wide text-neutral-5">Evidence Ledger</h3>
+      {run.turns.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-neutral-8 px-4 py-6 text-center text-[14px] text-neutral-5">
+          No turns recorded yet.
+        </div>
+      ) : (
+        <ol className="space-y-2">
+          {run.turns.map((turn) => (
+            <TurnRow key={turn.id} turn={turn} />
+          ))}
+        </ol>
+      )}
+    </div>
+  )
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-1.5">
+      <span className="text-neutral-5">{label}:</span>
+      <span className="truncate text-neutral-2">{value}</span>
+    </div>
+  )
+}
+
+function TurnRow({ turn }: { turn: GoalRunTurn }) {
+  return (
+    <li className="rounded-lg border border-neutral-9/60 bg-neutral-10/30 px-3 py-2">
+      <div className="flex items-center gap-2">
+        <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[12px] font-medium ${roleBadge(turn.role)}`}>
+          {turn.role}
+        </span>
+        <span className="text-[13px] text-neutral-5">turn {turn.turnIndex}</span>
+        {turn.verdict && (
+          <span className="text-[13px] text-neutral-3">verdict: {turn.verdict}</span>
+        )}
+        {turn.exitCode !== null && (
+          <span className={`text-[13px] ${turn.exitCode === 0 ? 'text-success-3' : 'text-error-3'}`}>
+            exit {turn.exitCode}
+          </span>
+        )}
+        <span className="ml-auto text-[12px] text-neutral-6">{formatTime(turn.createdAt)}</span>
+      </div>
+      {turn.verifyCmd && (
+        <div className="mt-1 font-mono text-[13px] text-neutral-3">$ {turn.verifyCmd}</div>
+      )}
+      {turn.diffSummary && (
+        <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-words font-mono text-[12px] text-neutral-4">{turn.diffSummary}</pre>
+      )}
+      {turn.outputTail && (
+        <pre className="mt-1 overflow-x-auto whitespace-pre-wrap break-words font-mono text-[12px] text-neutral-5">{turn.outputTail}</pre>
+      )}
+    </li>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Start Loop modal
+// ---------------------------------------------------------------------------
+
+function StartLoopModal({
+  token,
+  templates,
+  onClose,
+  onStarted,
+}: {
+  token: string
+  templates: LoopTemplateInfo[]
+  onClose: () => void
+  onStarted: (run: GoalRun) => void
+}) {
+  const initialKind: string = templates[0]?.kind ?? ''
+  const [kind, setKind] = useState(initialKind)
+  const [repo, setRepo] = useState('')
+  const [branch, setBranch] = useState('')
+  const [goal, setGoal] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState<string | null>(null)
+
+  const submit = async () => {
+    setFormError(null)
+    if (!kind || !repo.trim() || !branch.trim()) {
+      setFormError('Template, repo, and branch are required.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const run = await startGoalRun(token, {
+        kind: kind as GoalRun['kind'],
+        repo: repo.trim(),
+        branch: branch.trim(),
+        goal: goal.trim() || undefined,
+      })
+      onStarted(run)
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to start loop')
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" onClick={onClose}>
+      <div className="w-full max-w-lg rounded-xl border border-neutral-8 bg-neutral-12 p-5 shadow-xl" onClick={(e) => { e.stopPropagation() }}>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-[17px] font-medium text-neutral-1">Start Loop Run</h2>
+          <button onClick={onClose} className="rounded p-1 text-neutral-4 hover:text-neutral-2 hover:bg-neutral-9">
+            <IconX size={18} stroke={2} />
+          </button>
+        </div>
+
+        <div className="space-y-3">
+          <Field label="Template">
+            <select
+              value={kind}
+              onChange={(e) => { setKind(e.target.value) }}
+              className="w-full rounded-md border border-neutral-8 bg-neutral-11 px-2.5 py-1.5 text-[15px] text-neutral-2 focus:border-primary-7 focus:outline-none"
+            >
+              {templates.length === 0 && <option value="">No templates available</option>}
+              {templates.map((t) => (
+                <option key={t.kind} value={t.kind}>{t.name} ({t.source})</option>
+              ))}
+            </select>
+          </Field>
+
+          <Field label="Repo path">
+            <input
+              value={repo}
+              onChange={(e) => { setRepo(e.target.value) }}
+              placeholder="/path/to/repo"
+              className="w-full rounded-md border border-neutral-8 bg-neutral-11 px-2.5 py-1.5 text-[15px] text-neutral-2 focus:border-primary-7 focus:outline-none"
+            />
+          </Field>
+
+          <Field label="Branch">
+            <input
+              value={branch}
+              onChange={(e) => { setBranch(e.target.value) }}
+              placeholder="fix/ci"
+              className="w-full rounded-md border border-neutral-8 bg-neutral-11 px-2.5 py-1.5 text-[15px] text-neutral-2 focus:border-primary-7 focus:outline-none"
+            />
+          </Field>
+
+          <Field label="Goal override (optional)">
+            <textarea
+              value={goal}
+              onChange={(e) => { setGoal(e.target.value) }}
+              rows={3}
+              placeholder="Leave blank to use the template's default goal."
+              className="w-full resize-y rounded-md border border-neutral-8 bg-neutral-11 px-2.5 py-1.5 text-[15px] text-neutral-2 focus:border-primary-7 focus:outline-none"
+            />
+          </Field>
+        </div>
+
+        {formError && (
+          <div className="mt-3 rounded-md border border-error-8/50 bg-error-10/40 px-3 py-2 text-[14px] text-error-4">
+            {formError}
+          </div>
+        )}
+
+        <div className="mt-4 flex justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded-md px-3 py-1.5 text-[15px] text-neutral-3 hover:text-neutral-1 hover:bg-neutral-9 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => { void submit() }}
+            disabled={submitting}
+            className="flex items-center gap-1.5 rounded-md bg-primary-8 px-3 py-1.5 text-[15px] font-medium text-on-primary hover:bg-primary-7 disabled:opacity-50 transition-colors"
+          >
+            <IconPlayerPlay size={14} stroke={2} />
+            {submitting ? 'Starting…' : 'Start'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-[14px] text-neutral-4">{label}</span>
+      {children}
+    </label>
+  )
+}

--- a/src/components/LoopRunsView.tsx
+++ b/src/components/LoopRunsView.tsx
@@ -281,6 +281,23 @@ function RunDetail({
         </button>
       )}
 
+      {run.prUrl ? (
+        <div className="mt-3">
+          <a
+            href={run.prUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="text-[14px] text-accent-3 hover:text-accent-2 hover:underline"
+          >
+            View pull request →
+          </a>
+        </div>
+      ) : run.status === 'succeeded' && (
+        <div className="mt-3 text-[14px] text-warning-3">
+          Finalization failed — branch is committed locally but no PR was opened. See the evidence ledger.
+        </div>
+      )}
+
       {/* Evidence ledger */}
       <h3 className="mt-5 mb-2 text-[14px] font-medium uppercase tracking-wide text-neutral-5">Evidence Ledger</h3>
       {run.turns.length === 0 ? (

--- a/src/hooks/useRouter.ts
+++ b/src/hooks/useRouter.ts
@@ -11,7 +11,7 @@ import { useState, useCallback, useEffect } from 'react'
 interface RouteState {
   path: string
   sessionId: string | null
-  view: 'chat' | 'workflows' | 'orchestrator'
+  view: 'chat' | 'workflows' | 'orchestrator' | 'loops'
 }
 
 export function parsePath(pathname: string): RouteState {
@@ -20,6 +20,9 @@ export function parsePath(pathname: string): RouteState {
   }
   if (pathname === '/workflows' || pathname === '/workflows/') {
     return { path: pathname, sessionId: null, view: 'workflows' }
+  }
+  if (pathname === '/loops' || pathname === '/loops/') {
+    return { path: pathname, sessionId: null, view: 'loops' }
   }
   const match = pathname.match(/^\/s\/([a-f0-9-]+)\/?$/)
   return {

--- a/src/lib/goalRunApi.ts
+++ b/src/lib/goalRunApi.ts
@@ -1,0 +1,166 @@
+/**
+ * HTTP client for the Goal Run (loop) REST API.
+ *
+ * All calls go through /cc/api/goal-runs/ with Bearer token auth. Mirrors the
+ * shapes returned by server/goal-run-routes.ts and server/goal-run-store.ts.
+ */
+
+const BASE = '/cc/api/goal-runs'
+
+async function fetchJson<T>(res: Response): Promise<T> {
+  return res.json() as Promise<T>
+}
+
+function headers(token: string): HeadersInit {
+  return {
+    'Content-Type': 'application/json',
+    Authorization: `Bearer ${token}`,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Types (mirroring server/goal-run-store.ts)
+// ---------------------------------------------------------------------------
+
+export type GoalRunKind = 'ci-autorepair' | 'coverage-increase' | 'dependency-upgrade'
+
+export type GoalRunStatus =
+  | 'queued'
+  | 'running'
+  | 'verifying'
+  | 'checking'
+  | 'awaiting_human'
+  | 'succeeded'
+  | 'failed'
+  | 'aborted'
+
+export type TurnRole = 'maker' | 'checker' | 'verifier'
+export type CheckerVerdict = 'approve' | 'request_changes' | 'escalate'
+export type LoopProvider = 'claude' | 'opencode' | 'codex'
+export type CompletionPolicy = 'pr' | 'merge' | 'commit-only'
+
+export interface ProviderRole {
+  provider: LoopProvider
+  model?: string
+}
+
+export interface GoalRunSpec {
+  maker: ProviderRole
+  checker?: ProviderRole | null
+  verify: string[]
+  readonly?: string[]
+  maxTurns: number
+  maxCostUsd: number
+  completionPolicy: CompletionPolicy
+}
+
+export interface GoalRun {
+  id: string
+  kind: GoalRunKind
+  status: GoalRunStatus
+  goal: string
+  spec: GoalRunSpec
+  repo: string
+  branch: string
+  makerSessionId: string | null
+  checkerSessionId: string | null
+  turnCount: number
+  costUsd: number
+  verdict: string | null
+  createdAt: string
+  completedAt: string | null
+}
+
+export interface GoalRunTurn {
+  id: string
+  runId: string
+  turnIndex: number
+  role: TurnRole
+  diffSummary: string | null
+  verifyCmd: string | null
+  exitCode: number | null
+  outputTail: string | null
+  verdict: CheckerVerdict | null
+  costUsd: number | null
+  createdAt: string
+}
+
+export interface GoalRunWithTurns extends GoalRun {
+  turns: GoalRunTurn[]
+}
+
+export interface LoopTemplateInfo {
+  kind: GoalRunKind
+  name: string
+  source: 'builtin' | 'repo'
+}
+
+// ---------------------------------------------------------------------------
+// Templates
+// ---------------------------------------------------------------------------
+
+/** List available loop templates, optionally including a repo's overrides. */
+export async function listLoopTemplates(token: string, repoPath?: string): Promise<LoopTemplateInfo[]> {
+  const params = new URLSearchParams()
+  if (repoPath) params.set('repoPath', repoPath)
+  const qs = params.toString()
+  const res = await fetch(`${BASE}/templates${qs ? `?${qs}` : ''}`, { headers: headers(token) })
+  if (!res.ok) throw new Error(`Failed to list loop templates: ${res.status}`)
+  const data = await fetchJson<{ templates: LoopTemplateInfo[] }>(res)
+  return data.templates
+}
+
+// ---------------------------------------------------------------------------
+// Runs
+// ---------------------------------------------------------------------------
+
+/** Fetch goal runs, optionally filtered by kind/status. */
+export async function listGoalRuns(
+  token: string,
+  opts?: { kind?: GoalRunKind; status?: GoalRunStatus; limit?: number },
+): Promise<GoalRun[]> {
+  const params = new URLSearchParams()
+  if (opts?.kind) params.set('kind', opts.kind)
+  if (opts?.status) params.set('status', opts.status)
+  if (opts?.limit) params.set('limit', String(opts.limit))
+  const qs = params.toString()
+  const res = await fetch(`${BASE}/runs${qs ? `?${qs}` : ''}`, { headers: headers(token) })
+  if (!res.ok) throw new Error(`Failed to list goal runs: ${res.status}`)
+  const data = await fetchJson<{ runs: GoalRun[] }>(res)
+  return data.runs
+}
+
+/** Fetch a single run with its evidence ledger (turns). */
+export async function getGoalRun(token: string, runId: string): Promise<GoalRunWithTurns> {
+  const res = await fetch(`${BASE}/runs/${runId}`, { headers: headers(token) })
+  if (!res.ok) throw new Error(`Failed to get goal run: ${res.status}`)
+  const data = await fetchJson<{ run: GoalRunWithTurns }>(res)
+  return data.run
+}
+
+/** Start a goal run from a template. `goal` overrides the template's default goal text. */
+export async function startGoalRun(
+  token: string,
+  input: { kind: GoalRunKind; repo: string; branch: string; goal?: string },
+): Promise<GoalRun> {
+  const res = await fetch(`${BASE}/runs`, {
+    method: 'POST',
+    headers: headers(token),
+    body: JSON.stringify(input),
+  })
+  if (!res.ok) {
+    const data = await fetchJson<{ error?: string }>(res).catch(() => ({ error: undefined }))
+    throw new Error(data.error || `Failed to start goal run: ${res.status}`)
+  }
+  const data = await fetchJson<{ run: GoalRun }>(res)
+  return data.run
+}
+
+/** Abort an in-flight goal run. */
+export async function abortGoalRun(token: string, runId: string): Promise<void> {
+  const res = await fetch(`${BASE}/runs/${runId}/abort`, {
+    method: 'POST',
+    headers: headers(token),
+  })
+  if (!res.ok) throw new Error(`Failed to abort goal run: ${res.status}`)
+}

--- a/src/lib/goalRunApi.ts
+++ b/src/lib/goalRunApi.ts
@@ -67,6 +67,7 @@ export interface GoalRun {
   turnCount: number
   costUsd: number
   verdict: string | null
+  prUrl: string | null
   createdAt: string
   completedAt: string | null
 }


### PR DESCRIPTION
## Summary

Introduces the **GoalRun** primitive: a durable, auditable act→verify→continue loop around a coding agent, delivered across five incremental cuts on this branch.

- **Cut 1 — Loop primitive**: `goal_runs`/`goal_run_turns` SQLite store, deterministic verifier (run cmds → exit code → pass/fail), and the controller state machine with turn/cost **budget enforcement** and **readonly-glob constraint** enforcement.
- **Cut 2 — Maker–checker**: an optional second-provider review pass. Maker writes → deterministic gate → a *different* provider checker judges scope-creep / test-gaming / goal-met with a strict parseable verdict {approve | request_changes | escalate}.
- **Cut 3 — Loop templates**: `ci-autorepair`, `coverage-increase`, `dependency-upgrade` (`.codekin/loops/*.md`, YAML frontmatter + markdown goal).
- **Cut 4 — API + UI**: `/api/goal-runs` router (templates, runs list, per-run evidence ledger, start, abort) behind the master token; a **Loop Runs** panel (runs list + evidence ledger + start-loop form) with sidebar nav.
- **Cut 5 — Deterministic finalization / PR write-back**: on success Codekin (not the agent) commits the verified tree, pushes, and opens a PR via `gh`, capturing the URL. Push/PR failures keep the run `succeeded` (verification passed) with the reason in the evidence ledger, surfaced in the UI.

Default `completionPolicy` is `pr` — **never auto-merges to main**.

## Test plan

- [x] `tsc -b` + `vite build` clean
- [x] Full suite green (2431 passing, 98 files)
- [x] New unit coverage: finalizer (commit/push/PR per policy + graceful failure + already-open-PR recovery), controller finalize (deterministic + prUrl capture + failure-still-succeeds), store `pr_url` round-trip
- [x] eslint clean on new/changed files
- [ ] Manual smoke: start a `ci-autorepair` run from the Loop Runs panel against a repo, confirm evidence ledger + PR link populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)